### PR TITLE
Replace datetime-local inputs with UTC ISO strings

### DIFF
--- a/src/lib/actions/localDatetimes.ts
+++ b/src/lib/actions/localDatetimes.ts
@@ -1,0 +1,32 @@
+/**
+ * Svelte action for <form> elements.
+ *
+ * datetime-local inputs send values like "2024-03-24T06:00" with no timezone
+ * info. The browser treats these as local time, but Node.js on a UTC server
+ * parses them as UTC. This causes timestamps to be stored offset by the user's
+ * UTC offset.
+ *
+ * This action listens for the `formdata` event (fired when SvelteKit's enhance
+ * calls `new FormData(form)`) and replaces each datetime-local value with a
+ * proper UTC ISO string before the data reaches the server.
+ * 
+ * Note: I missed this while testing on local hardware.
+ */
+export function localDatetimes(node: HTMLFormElement) {
+	function onFormdata(e: FormDataEvent) {
+		node.querySelectorAll<HTMLInputElement>('input[type="datetime-local"]').forEach((el) => {
+			if (!el.value || !el.name) return;
+			const d = new Date(el.value);
+			if (!isNaN(d.getTime())) {
+				e.formData.set(el.name, d.toISOString());
+			}
+		});
+	}
+
+	node.addEventListener('formdata', onFormdata);
+	return {
+		destroy() {
+			node.removeEventListener('formdata', onFormdata);
+		}
+	};
+}

--- a/src/routes/(app)/(admin)/admin/users/+page.svelte
+++ b/src/routes/(app)/(admin)/admin/users/+page.svelte
@@ -21,6 +21,7 @@
 		KeyRound
 	} from '@lucide/svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import { localDatetimes } from '$lib/actions/localDatetimes';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 
@@ -416,6 +417,7 @@
 										<form
 											method="POST"
 											action="?/updateShift"
+											use:localDatetimes
 											use:enhance={() =>
 												({ update }) => {
 													update();
@@ -518,6 +520,7 @@
 						<form
 							method="POST"
 							action="?/addShift"
+							use:localDatetimes
 							use:enhance
 							class="space-y-3 pt-3 border-t border-border"
 						>

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -16,6 +16,7 @@
 	import { renderMarkdown } from '$lib/markdown';
 	import { tick } from 'svelte';
 	import { page } from '$app/state';
+	import { localDatetimes } from '$lib/actions/localDatetimes';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 	let showHealthForm = $state(false);
@@ -341,6 +342,7 @@
 				<form
 					method="POST"
 					action="?/addHealth"
+					use:localDatetimes
 					use:enhance={() => {
 						submittingHealth = true;
 						return async ({ update }) => {
@@ -441,6 +443,7 @@
 				<form
 					method="POST"
 					action="?/addWeight"
+					use:localDatetimes
 					use:enhance={() => {
 						submittingWeight = true;
 						return async ({ update }) => {
@@ -519,6 +522,7 @@
 							<form
 								method="POST"
 								action="?/updateWeight"
+								use:localDatetimes
 								use:enhance={() =>
 									({ update }) => {
 										update();
@@ -646,6 +650,7 @@
 								<form
 									method="POST"
 									action="?/updateHealth"
+									use:localDatetimes
 									use:enhance={() =>
 										({ update }) => {
 											update();

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -24,6 +24,7 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import { SvelteDate } from 'svelte/reactivity';
+	import { localDatetimes } from '$lib/actions/localDatetimes';
 
 	let { data }: { data: PageData } = $props();
 
@@ -723,6 +724,7 @@
 				<form
 					method="POST"
 					action="?/addActivity"
+					use:localDatetimes
 					use:enhance={() =>
 						({ update }) => {
 							update();
@@ -817,6 +819,7 @@
 							<form
 								method="POST"
 								action="?/updateActivity"
+								use:localDatetimes
 								use:enhance={() =>
 									({ update }) => {
 										update();

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -16,6 +16,7 @@
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import { tick } from 'svelte';
 	import { page } from '$app/state';
+	import { localDatetimes } from '$lib/actions/localDatetimes';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 	let showForm = $state(false);
@@ -267,6 +268,7 @@
 				<form
 					method="POST"
 					action="?/add"
+					use:localDatetimes
 					use:enhance={() => {
 						submitting = true;
 						return async ({ update }) => {
@@ -366,6 +368,7 @@
 							<form
 								method="POST"
 								action="?/update"
+								use:localDatetimes
 								use:enhance={() =>
 									({ update }) => {
 										update();
@@ -546,6 +549,7 @@
 								<form
 									method="POST"
 									action="?/update"
+									use:localDatetimes
 									use:enhance={() =>
 										({ update }) => {
 											update();

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
@@ -9,6 +9,7 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Trash2 } from '@lucide/svelte';
 	import { EVENT_TYPES, ACTIVITY_ICONS } from '$lib/constants/activities';
+	import { localDatetimes } from '$lib/actions/localDatetimes';
 
 	// isOnShift and nextShift come from the caretaker layout data
 
@@ -89,6 +90,7 @@
 				<form
 					method="POST"
 					action="?/add"
+					use:localDatetimes
 					use:enhance={() =>
 						async ({ result, update }) => {
 							await update({ reset: false });


### PR DESCRIPTION
I missed this during development as I was working on local hardware. Once deployed to a server using UTC-based timezones, the timestamps were shown incorrectly.