### PR TITLE
Add attribution to all models and display within UI

### DIFF
--- a/drizzle/0002_reflective_iron_fist.sql
+++ b/drizzle/0002_reflective_iron_fist.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `health_events` ADD `logged_by` text REFERENCES users(id);--> statement-breakpoint
+ALTER TABLE `reminders` ADD `logged_by` text REFERENCES users(id);--> statement-breakpoint
+ALTER TABLE `weight_entries` ADD `logged_by` text REFERENCES users(id);

--- a/drizzle/0003_fix_logged_by_fk.sql
+++ b/drizzle/0003_fix_logged_by_fk.sql
@@ -1,0 +1,65 @@
+-- Fix logged_by foreign keys to include ON DELETE SET NULL.
+-- SQLite ALTER TABLE ADD COLUMN cannot express ON DELETE clauses,
+-- so we recreate the three affected tables with the correct constraint.
+
+-- health_events
+CREATE TABLE `health_events_new` (
+	`id` text PRIMARY KEY NOT NULL,
+	`companion_id` text NOT NULL,
+	`type` text NOT NULL,
+	`title` text NOT NULL,
+	`notes` text,
+	`occurred_at` integer NOT NULL,
+	`next_due_at` integer,
+	`vet_name` text,
+	`vet_clinic` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`logged_by` text,
+	FOREIGN KEY (`companion_id`) REFERENCES `companions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`logged_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+INSERT INTO `health_events_new` SELECT * FROM `health_events`;--> statement-breakpoint
+DROP TABLE `health_events`;--> statement-breakpoint
+ALTER TABLE `health_events_new` RENAME TO `health_events`;--> statement-breakpoint
+CREATE INDEX `health_companion_idx` ON `health_events` (`companion_id`);--> statement-breakpoint
+CREATE INDEX `health_type_idx` ON `health_events` (`type`);--> statement-breakpoint
+
+-- weight_entries
+CREATE TABLE `weight_entries_new` (
+	`id` text PRIMARY KEY NOT NULL,
+	`companion_id` text NOT NULL,
+	`weight` real NOT NULL,
+	`unit` text NOT NULL,
+	`recorded_at` integer NOT NULL,
+	`notes` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`logged_by` text,
+	FOREIGN KEY (`companion_id`) REFERENCES `companions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`logged_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+INSERT INTO `weight_entries_new` SELECT * FROM `weight_entries`;--> statement-breakpoint
+DROP TABLE `weight_entries`;--> statement-breakpoint
+ALTER TABLE `weight_entries_new` RENAME TO `weight_entries`;--> statement-breakpoint
+CREATE INDEX `weight_companion_idx` ON `weight_entries` (`companion_id`);--> statement-breakpoint
+
+-- reminders
+CREATE TABLE `reminders_new` (
+	`id` text PRIMARY KEY NOT NULL,
+	`companion_id` text NOT NULL,
+	`title` text NOT NULL,
+	`description` text,
+	`type` text NOT NULL,
+	`due_at` integer NOT NULL,
+	`is_recurring` integer DEFAULT false NOT NULL,
+	`recurring_days` integer,
+	`is_dismissed` integer DEFAULT false NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`logged_by` text,
+	FOREIGN KEY (`companion_id`) REFERENCES `companions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`logged_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+INSERT INTO `reminders_new` SELECT * FROM `reminders`;--> statement-breakpoint
+DROP TABLE `reminders`;--> statement-breakpoint
+ALTER TABLE `reminders_new` RENAME TO `reminders`;--> statement-breakpoint
+CREATE INDEX `reminder_companion_idx` ON `reminders` (`companion_id`);--> statement-breakpoint
+CREATE INDEX `reminder_due_idx` ON `reminders` (`due_at`);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1163 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0765792d-578d-4e2b-9e0a-7393b3bfa070",
+  "prevId": "3e86626e-5472-4adf-8376-5df108777c29",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_due_at": {
+          "name": "next_due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurring_days": {
+          "name": "recurring_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_dismissed": {
+          "name": "is_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1163 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a1b2c3d4-fix0-fk01-null-logged0by0fix",
+  "prevId": "0765792d-578d-4e2b-9e0a-7393b3bfa070",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_due_at": {
+          "name": "next_due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurring_days": {
+          "name": "recurring_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_dismissed": {
+          "name": "is_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775737577881,
       "tag": "0002_reflective_iron_fist",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1775738400000,
+      "tag": "0003_fix_logged_by_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775390240699,
       "tag": "0001_faithful_power_man",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1775737577881,
+      "tag": "0002_reflective_iron_fist",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/LoggedBy.svelte
+++ b/src/lib/components/LoggedBy.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import { t, getLocale } from '$lib/i18n';
-
-	type Logger = { displayName: string } | null | undefined;
+	import type { Logger } from '$lib/types';
 
 	let {
 		logger,
 		variant = 'block',
 		class: className = ''
-	}: { logger: Logger; variant?: 'inline' | 'block'; class?: string } = $props();
+	}: { logger: Logger | undefined; variant?: 'inline' | 'block'; class?: string } = $props();
 	const locale = getLocale();
 </script>
 

--- a/src/lib/components/LoggedBy.svelte
+++ b/src/lib/components/LoggedBy.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { t, getLocale } from '$lib/i18n';
+
+	type Logger = { displayName: string } | null | undefined;
+
+	let {
+		logger,
+		variant = 'block',
+		class: className = ''
+	}: { logger: Logger; variant?: 'inline' | 'block'; class?: string } = $props();
+	const locale = getLocale();
+</script>
+
+{#if logger}
+	{#if variant === 'inline'}
+		<span class="text-muted-foreground text-xs ml-1 {className}"
+			>{t(locale, 'common.loggedBy', { name: logger.displayName })}</span
+		>
+	{:else}
+		<p class="text-xs text-muted-foreground opacity-60 {className}">
+			{t(locale, 'common.loggedBy', { name: logger.displayName })}
+		</p>
+	{/if}
+{/if}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -19,6 +19,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.no': 'Nein',
 	'common.or': 'oder',
 	'common.optional': 'optional',
+	'common.loggedBy': 'von {name}',
 
 	// Enum: Moods
 	'enum.mood.great': 'Super',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -17,6 +17,7 @@ const messages = {
 	'common.no': 'No',
 	'common.or': 'or',
 	'common.optional': 'optional',
+	'common.loggedBy': 'by {name}',
 
 	// Enum: Moods
 	'enum.mood.great': 'Great',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -19,6 +19,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.no': 'No',
 	'common.or': 'o',
 	'common.optional': 'opcional',
+	'common.loggedBy': 'por {name}',
 
 	// Enum: Moods
 	'enum.mood.great': 'Genial',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -19,6 +19,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.no': 'Non',
 	'common.or': 'ou',
 	'common.optional': 'facultatif',
+	'common.loggedBy': 'par {name}',
 
 	// Enum: Moods
 	'enum.mood.great': 'Super',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -19,6 +19,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.no': 'No',
 	'common.or': 'o',
 	'common.optional': 'facoltativo',
+	'common.loggedBy': 'di {name}',
 
 	// Enum: Moods
 	'enum.mood.great': 'Ottimo',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -19,7 +19,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.no': 'No',
 	'common.or': 'o',
 	'common.optional': 'facoltativo',
-	'common.loggedBy': 'di {name}',
+	'common.loggedBy': 'da {name}',
 
 	// Enum: Moods
 	'enum.mood.great': 'Ottimo',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -19,6 +19,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.no': 'Não',
 	'common.or': 'ou',
 	'common.optional': 'opcional',
+	'common.loggedBy': 'por {name}',
 
 	// Enum: Moods
 	'enum.mood.great': 'Ótimo',

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -298,7 +298,12 @@ export const sessionsRelations = relations(sessions, ({ one }) => ({
 export const usersRelations = relations(users, ({ many }) => ({
 	sessions: many(sessions),
 	companionCaretakers: many(companionCaretakers),
-	shifts: many(caretakerShifts)
+	shifts: many(caretakerShifts),
+	loggedJournalEntries: many(journalEntries),
+	loggedDailyEvents: many(dailyEvents),
+	loggedHealthEvents: many(healthEvents),
+	loggedWeightEntries: many(weightEntries),
+	loggedReminders: many(reminders)
 }));
 
 export const companionCaretakersRelations = relations(companionCaretakers, ({ one }) => ({

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -152,7 +152,8 @@ export const healthEvents = sqliteTable(
 		vetClinic: text('vet_clinic'),
 		createdAt: integer('created_at', { mode: 'timestamp' })
 			.notNull()
-			.default(sql`(unixepoch())`)
+			.default(sql`(unixepoch())`),
+		loggedBy: text('logged_by').references(() => users.id, { onDelete: 'set null' })
 	},
 	(t) => ({
 		companionIdx: index('health_companion_idx').on(t.companionId),
@@ -173,7 +174,8 @@ export const weightEntries = sqliteTable(
 		notes: text('notes'),
 		createdAt: integer('created_at', { mode: 'timestamp' })
 			.notNull()
-			.default(sql`(unixepoch())`)
+			.default(sql`(unixepoch())`),
+		loggedBy: text('logged_by').references(() => users.id, { onDelete: 'set null' })
 	},
 	(t) => ({
 		companionIdx: index('weight_companion_idx').on(t.companionId)
@@ -226,7 +228,8 @@ export const reminders = sqliteTable(
 		isDismissed: integer('is_dismissed', { mode: 'boolean' }).notNull().default(false),
 		createdAt: integer('created_at', { mode: 'timestamp' })
 			.notNull()
-			.default(sql`(unixepoch())`)
+			.default(sql`(unixepoch())`),
+		loggedBy: text('logged_by').references(() => users.id, { onDelete: 'set null' })
 	},
 	(t) => ({
 		companionIdx: index('reminder_companion_idx').on(t.companionId),
@@ -308,4 +311,24 @@ export const companionCaretakersRelations = relations(companionCaretakers, ({ on
 
 export const caretakerShiftsRelations = relations(caretakerShifts, ({ one }) => ({
 	user: one(users, { fields: [caretakerShifts.userId], references: [users.id] })
+}));
+
+export const journalEntriesRelations = relations(journalEntries, ({ one }) => ({
+	logger: one(users, { fields: [journalEntries.loggedBy], references: [users.id] })
+}));
+
+export const dailyEventsRelations = relations(dailyEvents, ({ one }) => ({
+	logger: one(users, { fields: [dailyEvents.loggedBy], references: [users.id] })
+}));
+
+export const healthEventsRelations = relations(healthEvents, ({ one }) => ({
+	logger: one(users, { fields: [healthEvents.loggedBy], references: [users.id] })
+}));
+
+export const weightEntriesRelations = relations(weightEntries, ({ one }) => ({
+	logger: one(users, { fields: [weightEntries.loggedBy], references: [users.id] })
+}));
+
+export const remindersRelations = relations(reminders, ({ one }) => ({
+	logger: one(users, { fields: [reminders.loggedBy], references: [users.id] })
 }));

--- a/src/lib/server/journal.ts
+++ b/src/lib/server/journal.ts
@@ -19,14 +19,18 @@ export async function getEnrichedJournalEntries(
 			before ? lt(schema.journalEntries.date, before) : undefined
 		),
 		orderBy: (j, { desc }) => [desc(j.date)],
-		limit: pageSize + 1
+		limit: pageSize + 1,
+		with: { logger: { columns: { displayName: true } } }
 	});
 
 	const hasMore = entries.length > pageSize;
 	const pageEntries = entries.slice(0, pageSize);
 
+	type EventWithLogger = typeof schema.dailyEvents.$inferSelect & {
+		logger: { displayName: string } | null;
+	};
 	let photosByEntry = new Map<string, (typeof schema.journalPhotos.$inferSelect)[]>();
-	let eventsByDate = new Map<string, (typeof schema.dailyEvents.$inferSelect)[]>();
+	let eventsByDate = new Map<string, EventWithLogger[]>();
 
 	if (pageEntries.length > 0) {
 		const entryIds = pageEntries.map((e) => e.id);
@@ -48,7 +52,8 @@ export async function getEnrichedJournalEntries(
 					gte(schema.dailyEvents.loggedAt, rangeStart),
 					lt(schema.dailyEvents.loggedAt, rangeEnd)
 				),
-				orderBy: (d, { asc }) => [asc(d.loggedAt)]
+				orderBy: (d, { asc }) => [asc(d.loggedAt)],
+				with: { logger: { columns: { displayName: true } } }
 			})
 		]);
 

--- a/src/lib/server/journal.ts
+++ b/src/lib/server/journal.ts
@@ -3,6 +3,7 @@ import { eq, lt, gte, and, inArray } from 'drizzle-orm';
 import { localDateISO } from '$lib/date';
 import { generateId } from '$lib/server/utils';
 import type { Mood } from '$lib/server/validation';
+import type { Logger } from '$lib/types';
 
 const PAGE_SIZE = 20;
 
@@ -27,7 +28,7 @@ export async function getEnrichedJournalEntries(
 	const pageEntries = entries.slice(0, pageSize);
 
 	type EventWithLogger = typeof schema.dailyEvents.$inferSelect & {
-		logger: { displayName: string } | null;
+		logger: Logger;
 	};
 	let photosByEntry = new Map<string, (typeof schema.journalPhotos.$inferSelect)[]>();
 	let eventsByDate = new Map<string, EventWithLogger[]>();

--- a/src/lib/server/reminders.ts
+++ b/src/lib/server/reminders.ts
@@ -21,7 +21,8 @@ export async function dismissReminder(
 			type: reminder.type,
 			dueAt: nextDueAt,
 			isRecurring: true,
-			recurringDays: reminder.recurringDays
+			recurringDays: reminder.recurringDays,
+			loggedBy: reminder.loggedBy
 		});
 	}
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,2 @@
+/** Lightweight author info attached to loggable entities via Drizzle's `with: { logger }` relation. */
+export type Logger = { displayName: string } | null;

--- a/src/routes/(app)/(companion)/[companionId]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/+page.server.ts
@@ -21,12 +21,14 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		db.query.healthEvents.findMany({
 			where: eq(schema.healthEvents.companionId, params.companionId),
 			orderBy: (h, { desc }) => [desc(h.occurredAt)],
-			limit: 5
+			limit: 5,
+			with: { logger: { columns: { displayName: true } } }
 		}),
 		db.query.dailyEvents.findMany({
 			where: eq(schema.dailyEvents.companionId, params.companionId),
 			orderBy: (d, { desc }) => [desc(d.loggedAt)],
-			limit: 10
+			limit: 10,
+			with: { logger: { columns: { displayName: true } } }
 		}),
 		db.query.reminders.findMany({
 			where: and(
@@ -34,18 +36,21 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 				eq(schema.reminders.isDismissed, false)
 			),
 			orderBy: (r, { asc }) => [asc(r.dueAt)],
-			limit: 5
+			limit: 5,
+			with: { logger: { columns: { displayName: true } } }
 		}),
 		db.query.weightEntries.findMany({
 			where: eq(schema.weightEntries.companionId, params.companionId),
 			orderBy: (w, { desc }) => [desc(w.recordedAt)],
-			limit: 10
+			limit: 10,
+			with: { logger: { columns: { displayName: true } } }
 		}),
 		db.query.journalEntries.findFirst({
 			where: and(
 				eq(schema.journalEntries.companionId, params.companionId),
 				eq(schema.journalEntries.date, localDateISO(now))
-			)
+			),
+			with: { logger: { columns: { displayName: true } } }
 		}),
 		db
 			.select({

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -689,7 +689,12 @@
 									</span>
 								{/if}
 							</div>
-							<LoggedBy logger={event.logger} class="pl-[7.5rem]" />
+							{#if event.logger}
+								<div class="flex items-center gap-3 text-sm">
+									<span class="w-24 shrink-0"></span>
+									<LoggedBy logger={event.logger} />
+								</div>
+							{/if}
 						</button>
 					{/each}
 				</div>
@@ -736,7 +741,12 @@
 								<Badge variant="bark" class="capitalize">{event.type.replace('_', ' ')}</Badge>
 								<span class="truncate text-foreground">{event.title}</span>
 							</div>
-							<LoggedBy logger={event.logger} class="pl-[7.5rem]" />
+							{#if event.logger}
+								<div class="flex items-center gap-3 text-sm">
+									<span class="w-24 shrink-0"></span>
+									<LoggedBy logger={event.logger} />
+								</div>
+							{/if}
 						</button>
 					{/each}
 				</div>

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -246,6 +246,11 @@
 							</div>
 						</div>
 					{/if}
+					{#if r.logger}
+						<p class="text-xs text-muted-foreground opacity-60 mt-2">
+							{t(locale, 'common.loggedBy', { name: r.logger.displayName })}
+						</p>
+					{/if}
 				{:else if selected.kind === 'weight'}
 					{@const w = selected.item}
 					<div class="flex items-center gap-3">
@@ -261,7 +266,12 @@
 						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
 							>{t(locale, 'page.dashboard.modalLabelRecorded')}</span
 						>
-						<span class="text-foreground"><LocalTime date={w.recordedAt} format="datetime" /></span>
+						<span class="text-foreground"
+							><LocalTime date={w.recordedAt} format="datetime" />{#if w.logger}<span
+									class="text-muted-foreground text-xs ml-1"
+									>{t(locale, 'common.loggedBy', { name: w.logger.displayName })}</span
+								>{/if}</span
+						>
 					</div>
 					{#if w.notes}
 						<div class="pt-1">
@@ -285,7 +295,12 @@
 						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
 							>{t(locale, 'page.dashboard.modalLabelLogged')}</span
 						>
-						<span class="text-foreground"><LocalTime date={e.loggedAt} format="datetime" /></span>
+						<span class="text-foreground"
+							><LocalTime date={e.loggedAt} format="datetime" />{#if e.logger}<span
+									class="text-muted-foreground text-xs ml-1"
+									>{t(locale, 'common.loggedBy', { name: e.logger.displayName })}</span
+								>{/if}</span
+						>
 					</div>
 					{#if e.durationMinutes}
 						<div class="flex items-center gap-3">
@@ -317,7 +332,12 @@
 						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
 							>{t(locale, 'page.dashboard.modalLabelDate')}</span
 						>
-						<span class="text-foreground"><LocalTime date={h.occurredAt} format="datetime" /></span>
+						<span class="text-foreground"
+							><LocalTime date={h.occurredAt} format="datetime" />{#if h.logger}<span
+									class="text-muted-foreground text-xs ml-1"
+									>{t(locale, 'common.loggedBy', { name: h.logger.displayName })}</span
+								>{/if}</span
+						>
 					</div>
 					{#if h.nextDueAt}
 						<div class="flex items-center gap-3">
@@ -657,18 +677,25 @@
 						<button
 							type="button"
 							onclick={() => openDetail({ kind: 'activity', item: event })}
-							class="w-full flex items-center gap-3 text-sm rounded-md px-2 py-1.5 -mx-2
+							class="w-full rounded-md px-2 py-1.5 -mx-2
 								hover:bg-accent transition-colors text-left"
 						>
-							<span class="w-24 shrink-0 text-xs text-muted-foreground whitespace-nowrap">
-								<LocalTime date={event.loggedAt} format="date" />
-							</span>
-							<span class="text-base shrink-0">{ACTIVITY_ICON[event.type] ?? '📝'}</span>
-							<Badge variant="secondary" class="capitalize">{event.type}</Badge>
-							{#if event.notes}
-								<span class="truncate text-muted-foreground">
-									{event.notes.replace(/[#*_`~>[\]]/g, '').trim()}
+							<div class="flex items-center gap-3 text-sm">
+								<span class="w-24 shrink-0 text-xs text-muted-foreground whitespace-nowrap">
+									<LocalTime date={event.loggedAt} format="date" />
 								</span>
+								<span class="text-base shrink-0">{ACTIVITY_ICON[event.type] ?? '📝'}</span>
+								<Badge variant="secondary" class="capitalize">{event.type}</Badge>
+								{#if event.notes}
+									<span class="truncate text-muted-foreground">
+										{event.notes.replace(/[#*_`~>[\]]/g, '').trim()}
+									</span>
+								{/if}
+							</div>
+							{#if event.logger}
+								<p class="text-xs text-muted-foreground opacity-60 pl-[7.5rem]">
+									{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
+								</p>
 							{/if}
 						</button>
 					{/each}
@@ -706,14 +733,21 @@
 						<button
 							type="button"
 							onclick={() => openDetail({ kind: 'health', item: event })}
-							class="w-full flex items-center gap-3 text-sm rounded-md px-2 py-1.5 -mx-2
+							class="w-full rounded-md px-2 py-1.5 -mx-2
 								hover:bg-accent transition-colors text-left"
 						>
-							<span class="w-24 shrink-0 text-xs text-muted-foreground whitespace-nowrap">
-								<LocalTime date={event.occurredAt} />
-							</span>
-							<Badge variant="bark" class="capitalize">{event.type.replace('_', ' ')}</Badge>
-							<span class="truncate text-foreground">{event.title}</span>
+							<div class="flex items-center gap-3 text-sm">
+								<span class="w-24 shrink-0 text-xs text-muted-foreground whitespace-nowrap">
+									<LocalTime date={event.occurredAt} />
+								</span>
+								<Badge variant="bark" class="capitalize">{event.type.replace('_', ' ')}</Badge>
+								<span class="truncate text-foreground">{event.title}</span>
+							</div>
+							{#if event.logger}
+								<p class="text-xs text-muted-foreground opacity-60 pl-[7.5rem]">
+									{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
+								</p>
+							{/if}
 						</button>
 					{/each}
 				</div>

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData } from './$types';
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
+	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import { localDateISO } from '$lib/date';
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -246,11 +247,7 @@
 							</div>
 						</div>
 					{/if}
-					{#if r.logger}
-						<p class="text-xs text-muted-foreground opacity-60 mt-2">
-							{t(locale, 'common.loggedBy', { name: r.logger.displayName })}
-						</p>
-					{/if}
+					<LoggedBy logger={r.logger} />
 				{:else if selected.kind === 'weight'}
 					{@const w = selected.item}
 					<div class="flex items-center gap-3">
@@ -267,10 +264,10 @@
 							>{t(locale, 'page.dashboard.modalLabelRecorded')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={w.recordedAt} format="datetime" />{#if w.logger}<span
-									class="text-muted-foreground text-xs ml-1"
-									>{t(locale, 'common.loggedBy', { name: w.logger.displayName })}</span
-								>{/if}</span
+							><LocalTime date={w.recordedAt} format="datetime" /><LoggedBy
+								logger={w.logger}
+								variant="inline"
+							/></span
 						>
 					</div>
 					{#if w.notes}
@@ -296,10 +293,10 @@
 							>{t(locale, 'page.dashboard.modalLabelLogged')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={e.loggedAt} format="datetime" />{#if e.logger}<span
-									class="text-muted-foreground text-xs ml-1"
-									>{t(locale, 'common.loggedBy', { name: e.logger.displayName })}</span
-								>{/if}</span
+							><LocalTime date={e.loggedAt} format="datetime" /><LoggedBy
+								logger={e.logger}
+								variant="inline"
+							/></span
 						>
 					</div>
 					{#if e.durationMinutes}
@@ -333,10 +330,10 @@
 							>{t(locale, 'page.dashboard.modalLabelDate')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={h.occurredAt} format="datetime" />{#if h.logger}<span
-									class="text-muted-foreground text-xs ml-1"
-									>{t(locale, 'common.loggedBy', { name: h.logger.displayName })}</span
-								>{/if}</span
+							><LocalTime date={h.occurredAt} format="datetime" /><LoggedBy
+								logger={h.logger}
+								variant="inline"
+							/></span
 						>
 					</div>
 					{#if h.nextDueAt}
@@ -692,11 +689,7 @@
 									</span>
 								{/if}
 							</div>
-							{#if event.logger}
-								<p class="text-xs text-muted-foreground opacity-60 pl-[7.5rem]">
-									{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
-								</p>
-							{/if}
+							<LoggedBy logger={event.logger} class="pl-[7.5rem]" />
 						</button>
 					{/each}
 				</div>
@@ -743,11 +736,7 @@
 								<Badge variant="bark" class="capitalize">{event.type.replace('_', ' ')}</Badge>
 								<span class="truncate text-foreground">{event.title}</span>
 							</div>
-							{#if event.logger}
-								<p class="text-xs text-muted-foreground opacity-60 pl-[7.5rem]">
-									{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
-								</p>
-							{/if}
+							<LoggedBy logger={event.logger} class="pl-[7.5rem]" />
 						</button>
 					{/each}
 				</div>

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.server.ts
@@ -13,11 +13,13 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	const [healthEvents, weightEntries] = await Promise.all([
 		db.query.healthEvents.findMany({
 			where: eq(schema.healthEvents.companionId, params.companionId),
-			orderBy: (h, { desc }) => [desc(h.occurredAt)]
+			orderBy: (h, { desc }) => [desc(h.occurredAt)],
+			with: { logger: { columns: { displayName: true } } }
 		}),
 		db.query.weightEntries.findMany({
 			where: eq(schema.weightEntries.companionId, params.companionId),
-			orderBy: (w, { desc }) => [desc(w.recordedAt)]
+			orderBy: (w, { desc }) => [desc(w.recordedAt)],
+			with: { logger: { columns: { displayName: true } } }
 		})
 	]);
 
@@ -51,7 +53,8 @@ export const actions: Actions = {
 			occurredAt,
 			nextDueAt,
 			vetName,
-			vetClinic
+			vetClinic,
+			loggedBy: locals.user.id
 		});
 
 		return { healthSuccess: true };
@@ -76,7 +79,8 @@ export const actions: Actions = {
 			weight,
 			unit,
 			notes,
-			recordedAt
+			recordedAt,
+			loggedBy: locals.user.id
 		});
 
 		return { weightSuccess: true };

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -3,6 +3,7 @@
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import { enhance } from '$app/forms';
 	import LocalTime from '$lib/components/LocalTime.svelte';
+	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -175,10 +176,10 @@
 							>{t(locale, 'page.health.detailRecorded')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={w.recordedAt} format="datetime" />{#if w.logger}<span
-									class="text-muted-foreground text-xs ml-1"
-									>{t(locale, 'common.loggedBy', { name: w.logger.displayName })}</span
-								>{/if}</span
+							><LocalTime date={w.recordedAt} format="datetime" /><LoggedBy
+								logger={w.logger}
+								variant="inline"
+							/></span
 						>
 					</div>
 					{#if w.notes}
@@ -204,10 +205,10 @@
 							>{t(locale, 'page.health.detailDate')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={h.occurredAt} format="datetime" />{#if h.logger}<span
-									class="text-muted-foreground text-xs ml-1"
-									>{t(locale, 'common.loggedBy', { name: h.logger.displayName })}</span
-								>{/if}</span
+							><LocalTime date={h.occurredAt} format="datetime" /><LoggedBy
+								logger={h.logger}
+								variant="inline"
+							/></span
 						>
 					</div>
 					{#if h.nextDueAt}
@@ -631,16 +632,12 @@
 								<span class="w-20 shrink-0 font-semibold text-foreground"
 									>{entry.weight} {entry.unit}</span
 								>
-								<span class="flex-1 min-w-0 text-xs text-muted-foreground">
+								<div class="flex-1 min-w-0 text-xs text-muted-foreground">
 									<span class="truncate block"
 										>{entry.notes ? entry.notes.replace(/[#*_`~>[\]]/g, '').trim() : ''}</span
 									>
-									{#if entry.logger}
-										<span class="block opacity-60"
-											>{t(locale, 'common.loggedBy', { name: entry.logger.displayName })}</span
-										>
-									{/if}
-								</span>
+									<LoggedBy logger={entry.logger} />
+								</div>
 							</button>
 							{#if data.companion.isActive !== false}
 								<div class="flex gap-1 shrink-0">
@@ -837,11 +834,7 @@
 												<LocalTime date={event.nextDueAt} />
 											</p>
 										{/if}
-										{#if event.logger}
-											<p class="text-xs mt-0.5 text-muted-foreground opacity-60">
-												{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
-											</p>
-										{/if}
+										<LoggedBy logger={event.logger} class="mt-0.5" />
 									</div>
 								</button>
 								{#if data.companion.isActive !== false}

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -174,7 +174,12 @@
 						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
 							>{t(locale, 'page.health.detailRecorded')}</span
 						>
-						<span class="text-foreground"><LocalTime date={w.recordedAt} format="datetime" /></span>
+						<span class="text-foreground"
+							><LocalTime date={w.recordedAt} format="datetime" />{#if w.logger}<span
+									class="text-muted-foreground text-xs ml-1"
+									>{t(locale, 'common.loggedBy', { name: w.logger.displayName })}</span
+								>{/if}</span
+						>
 					</div>
 					{#if w.notes}
 						<div class="pt-1">
@@ -198,7 +203,12 @@
 						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
 							>{t(locale, 'page.health.detailDate')}</span
 						>
-						<span class="text-foreground"><LocalTime date={h.occurredAt} format="datetime" /></span>
+						<span class="text-foreground"
+							><LocalTime date={h.occurredAt} format="datetime" />{#if h.logger}<span
+									class="text-muted-foreground text-xs ml-1"
+									>{t(locale, 'common.loggedBy', { name: h.logger.displayName })}</span
+								>{/if}</span
+						>
 					</div>
 					{#if h.nextDueAt}
 						<div class="flex items-center gap-3">
@@ -621,9 +631,16 @@
 								<span class="w-20 shrink-0 font-semibold text-foreground"
 									>{entry.weight} {entry.unit}</span
 								>
-								<span class="flex-1 text-xs truncate text-muted-foreground"
-									>{entry.notes ? entry.notes.replace(/[#*_`~>[\]]/g, '').trim() : ''}</span
-								>
+								<span class="flex-1 min-w-0 text-xs text-muted-foreground">
+									<span class="truncate block"
+										>{entry.notes ? entry.notes.replace(/[#*_`~>[\]]/g, '').trim() : ''}</span
+									>
+									{#if entry.logger}
+										<span class="block opacity-60"
+											>{t(locale, 'common.loggedBy', { name: entry.logger.displayName })}</span
+										>
+									{/if}
+								</span>
 							</button>
 							{#if data.companion.isActive !== false}
 								<div class="flex gap-1 shrink-0">
@@ -818,6 +835,11 @@
 											<p class="text-xs mt-1 text-primary">
 												📅 {t(locale, 'page.health.nextDueLabel')}
 												<LocalTime date={event.nextDueAt} />
+											</p>
+										{/if}
+										{#if event.logger}
+											<p class="text-xs mt-0.5 text-muted-foreground opacity-60">
+												{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
 											</p>
 										{/if}
 									</div>

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -314,7 +314,12 @@
 						>{t(locale, 'page.journal.activityDetailLogged')}</span
 					>
 					<span class="text-foreground"
-						><LocalTime date={detailEvent.loggedAt} format="datetime" /></span
+						><LocalTime
+							date={detailEvent.loggedAt}
+							format="datetime"
+						/>{#if detailEvent.logger}<span class="text-muted-foreground text-xs ml-1"
+								>{t(locale, 'common.loggedBy', { name: detailEvent.logger.displayName })}</span
+							>{/if}</span
 					>
 				</div>
 				{#if detailEvent.durationMinutes}
@@ -426,6 +431,11 @@
 									{#if entry.date === data.today}
 										<span class="text-xs font-medium text-primary"
 											>{t(locale, 'page.journal.today')}</span
+										>
+									{/if}
+									{#if entry.logger}
+										<span class="text-xs text-muted-foreground"
+											>{t(locale, 'common.loggedBy', { name: entry.logger.displayName })}</span
 										>
 									{/if}
 								</div>

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -7,6 +7,7 @@
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { ChevronLeft, ChevronRight, X, Pencil, NotebookPen, ArrowRight } from '@lucide/svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
+	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import { tick } from 'svelte';
 	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { t, getLocale } from '$lib/i18n';
@@ -314,12 +315,10 @@
 						>{t(locale, 'page.journal.activityDetailLogged')}</span
 					>
 					<span class="text-foreground"
-						><LocalTime
-							date={detailEvent.loggedAt}
-							format="datetime"
-						/>{#if detailEvent.logger}<span class="text-muted-foreground text-xs ml-1"
-								>{t(locale, 'common.loggedBy', { name: detailEvent.logger.displayName })}</span
-							>{/if}</span
+						><LocalTime date={detailEvent.loggedAt} format="datetime" /><LoggedBy
+							logger={detailEvent.logger}
+							variant="inline"
+						/></span
 					>
 				</div>
 				{#if detailEvent.durationMinutes}
@@ -433,11 +432,7 @@
 											>{t(locale, 'page.journal.today')}</span
 										>
 									{/if}
-									{#if entry.logger}
-										<span class="text-xs text-muted-foreground"
-											>{t(locale, 'common.loggedBy', { name: entry.logger.displayName })}</span
-										>
-									{/if}
+									<LoggedBy logger={entry.logger} variant="inline" class="ml-0" />
 								</div>
 							</div>
 							{#if companion.isActive !== false}

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
@@ -21,7 +21,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		where: and(
 			eq(schema.journalEntries.companionId, companionId),
 			eq(schema.journalEntries.date, date)
-		)
+		),
+		with: { logger: { columns: { displayName: true } } }
 	});
 
 	// Load photos for this date
@@ -49,7 +50,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 			gte(schema.dailyEvents.loggedAt, dayStart),
 			lt(schema.dailyEvents.loggedAt, dayEnd)
 		),
-		orderBy: (d, { asc }) => [asc(d.loggedAt)]
+		orderBy: (d, { asc }) => [asc(d.loggedAt)],
+		with: { logger: { columns: { displayName: true } } }
 	});
 
 	const today = localDateISO();

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -26,6 +26,7 @@
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import LocalTime from '$lib/components/LocalTime.svelte';
+	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import { SvelteDate } from 'svelte/reactivity';
 	import { localDatetimes } from '$lib/actions/localDatetimes';
 	import { t, getLocale } from '$lib/i18n';
@@ -343,12 +344,10 @@
 						>{t(locale, 'page.journal.day.detailLogged')}</span
 					>
 					<span class="text-foreground"
-						><LocalTime
-							date={detailEvent.loggedAt}
-							format="datetime"
-						/>{#if detailEvent.logger}<span class="text-muted-foreground text-xs ml-1"
-								>{t(locale, 'common.loggedBy', { name: detailEvent.logger.displayName })}</span
-							>{/if}</span
+						><LocalTime date={detailEvent.loggedAt} format="datetime" /><LoggedBy
+							logger={detailEvent.logger}
+							variant="inline"
+						/></span
 					>
 				</div>
 				{#if detailEvent.durationMinutes}
@@ -460,11 +459,7 @@
 				>
 			{/if}
 		</div>
-		{#if data.entry?.logger}
-			<span class="text-xs text-muted-foreground"
-				>{t(locale, 'common.loggedBy', { name: data.entry.logger.displayName })}</span
-			>
-		{/if}
+		<LoggedBy logger={data.entry?.logger} variant="inline" class="ml-0" />
 	</div>
 
 	<!-- Mood -->
@@ -989,11 +984,7 @@
 											...(serverTimezone ? { timeZone: serverTimezone } : {})
 										})}</span
 									>
-									{#if event.logger}
-										<p class="opacity-60">
-											{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
-										</p>
-									{/if}
+									<LoggedBy logger={event.logger} />
 								</div>
 							</button>
 							<button

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -343,7 +343,12 @@
 						>{t(locale, 'page.journal.day.detailLogged')}</span
 					>
 					<span class="text-foreground"
-						><LocalTime date={detailEvent.loggedAt} format="datetime" /></span
+						><LocalTime
+							date={detailEvent.loggedAt}
+							format="datetime"
+						/>{#if detailEvent.logger}<span class="text-muted-foreground text-xs ml-1"
+								>{t(locale, 'common.loggedBy', { name: detailEvent.logger.displayName })}</span
+							>{/if}</span
 					>
 				</div>
 				{#if detailEvent.durationMinutes}
@@ -455,6 +460,11 @@
 				>
 			{/if}
 		</div>
+		{#if data.entry?.logger}
+			<span class="text-xs text-muted-foreground"
+				>{t(locale, 'common.loggedBy', { name: data.entry.logger.displayName })}</span
+			>
+		{/if}
 	</div>
 
 	<!-- Mood -->
@@ -971,13 +981,20 @@
 										</p>
 									{/if}
 								</div>
-								<span class="text-xs shrink-0 text-muted-foreground">
-									{new Date(event.loggedAt).toLocaleTimeString(undefined, {
-										hour: 'numeric',
-										minute: '2-digit',
-										...(serverTimezone ? { timeZone: serverTimezone } : {})
-									})}
-								</span>
+								<div class="text-xs shrink-0 text-muted-foreground text-right">
+									<span
+										>{new Date(event.loggedAt).toLocaleTimeString(undefined, {
+											hour: 'numeric',
+											minute: '2-digit',
+											...(serverTimezone ? { timeZone: serverTimezone } : {})
+										})}</span
+									>
+									{#if event.logger}
+										<p class="opacity-60">
+											{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
+										</p>
+									{/if}
+								</div>
 							</button>
 							<button
 								type="button"

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.server.ts
@@ -13,7 +13,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 
 	const reminders = await db.query.reminders.findMany({
 		where: eq(schema.reminders.companionId, params.companionId),
-		orderBy: (r, { asc }) => [asc(r.dueAt)]
+		orderBy: (r, { asc }) => [asc(r.dueAt)],
+		with: { logger: { columns: { displayName: true } } }
 	});
 
 	return { companion, reminders };
@@ -42,7 +43,8 @@ export const actions: Actions = {
 			type,
 			dueAt,
 			isRecurring,
-			recurringDays: recurringDays && recurringDays > 0 ? recurringDays : null
+			recurringDays: recurringDays && recurringDays > 0 ? recurringDays : null,
+			loggedBy: locals.user.id
 		});
 
 		return { success: true };

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData, ActionData } from './$types';
 	import { enhance } from '$app/forms';
 	import LocalTime from '$lib/components/LocalTime.svelte';
+	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import { renderMarkdown } from '$lib/markdown';
 	import { Card, CardContent } from '$lib/components/ui/card/index.js';
@@ -186,11 +187,7 @@
 						</div>
 					</div>
 				{/if}
-				{#if r.logger}
-					<p class="text-xs text-muted-foreground opacity-60 mt-2">
-						{t(locale, 'common.loggedBy', { name: r.logger.displayName })}
-					</p>
-				{/if}
+				<LoggedBy logger={r.logger} />
 			</div>
 
 			<Separator />
@@ -517,14 +514,10 @@
 										<p
 											class="text-xs mt-1 {overdue ? 'text-destructive' : 'text-muted-foreground'}"
 										>
-											Due <LocalTime
-												date={reminder.dueAt}
-												format="datetime"
-											/>{#if reminder.logger}<span class="text-muted-foreground ml-1">
-													· {t(locale, 'common.loggedBy', {
-														name: reminder.logger.displayName
-													})}</span
-												>{/if}
+											Due <LocalTime date={reminder.dueAt} format="datetime" /><LoggedBy
+												logger={reminder.logger}
+												variant="inline"
+											/>
 										</p>
 									</div>
 								</button>

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -186,6 +186,11 @@
 						</div>
 					</div>
 				{/if}
+				{#if r.logger}
+					<p class="text-xs text-muted-foreground opacity-60 mt-2">
+						{t(locale, 'common.loggedBy', { name: r.logger.displayName })}
+					</p>
+				{/if}
 			</div>
 
 			<Separator />
@@ -512,7 +517,14 @@
 										<p
 											class="text-xs mt-1 {overdue ? 'text-destructive' : 'text-muted-foreground'}"
 										>
-											Due <LocalTime date={reminder.dueAt} format="datetime" />
+											Due <LocalTime
+												date={reminder.dueAt}
+												format="datetime"
+											/>{#if reminder.logger}<span class="text-muted-foreground ml-1">
+													· {t(locale, 'common.loggedBy', {
+														name: reminder.logger.displayName
+													})}</span
+												>{/if}
 										</p>
 									</div>
 								</button>

--- a/src/routes/(caretaker)/care/[companionId]/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/+page.server.ts
@@ -22,7 +22,8 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 			eq(schema.healthEvents.companionId, params.companionId),
 			eq(schema.healthEvents.type, 'medication')
 		),
-		orderBy: (h, { desc }) => [desc(h.occurredAt)]
+		orderBy: (h, { desc }) => [desc(h.occurredAt)],
+		with: { logger: { columns: { displayName: true } } }
 	});
 
 	const todayStart = new Date();
@@ -33,7 +34,8 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 			eq(schema.dailyEvents.companionId, params.companionId),
 			gte(schema.dailyEvents.loggedAt, todayStart)
 		),
-		orderBy: (d, { asc }) => [asc(d.loggedAt)]
+		orderBy: (d, { asc }) => [asc(d.loggedAt)],
+		with: { logger: { columns: { displayName: true } } }
 	});
 
 	const latestWeight = await db.query.weightEntries.findFirst({
@@ -62,7 +64,8 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 				eq(schema.reminders.companionId, params.companionId),
 				eq(schema.reminders.isDismissed, false)
 			),
-			orderBy: (r, { asc }) => [asc(r.dueAt)]
+			orderBy: (r, { asc }) => [asc(r.dueAt)],
+			with: { logger: { columns: { displayName: true } } }
 		}),
 		db.query.caretakerShifts.findMany({
 			where: and(

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData } from './$types';
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
+	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import { Card, CardHeader, CardContent, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Phone, Mail, X, Bell, CheckCheck } from '@lucide/svelte';
@@ -224,10 +225,10 @@
 						>{t(locale, 'page.dashboard.caretaker.modalLabelLogged')}</span
 					>
 					<span class="text-foreground"
-						><LocalTime date={selected.loggedAt} format="datetime" />{#if selected.logger}<span
-								class="text-muted-foreground text-xs ml-1"
-								>{t(locale, 'common.loggedBy', { name: selected.logger.displayName })}</span
-							>{/if}</span
+						><LocalTime date={selected.loggedAt} format="datetime" /><LoggedBy
+							logger={selected.logger}
+							variant="inline"
+						/></span
 					>
 				</div>
 				{#if selected.durationMinutes}
@@ -325,11 +326,7 @@
 						</div>
 					</div>
 				{/if}
-				{#if selectedReminder.logger}
-					<p class="text-xs text-muted-foreground opacity-60 mt-2">
-						{t(locale, 'common.loggedBy', { name: selectedReminder.logger.displayName })}
-					</p>
-				{/if}
+				<LoggedBy logger={selectedReminder.logger} />
 			</div>
 
 			<Separator />
@@ -692,11 +689,7 @@
 									<LocalTime date={event.loggedAt} format="time" />
 								</span>
 							</div>
-							{#if event.logger}
-								<p class="text-xs text-muted-foreground opacity-60 pl-8">
-									{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
-								</p>
-							{/if}
+							<LoggedBy logger={event.logger} class="pl-8" />
 						</button>
 					{/each}
 				</div>

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -224,7 +224,10 @@
 						>{t(locale, 'page.dashboard.caretaker.modalLabelLogged')}</span
 					>
 					<span class="text-foreground"
-						><LocalTime date={selected.loggedAt} format="datetime" /></span
+						><LocalTime date={selected.loggedAt} format="datetime" />{#if selected.logger}<span
+								class="text-muted-foreground text-xs ml-1"
+								>{t(locale, 'common.loggedBy', { name: selected.logger.displayName })}</span
+							>{/if}</span
 					>
 				</div>
 				{#if selected.durationMinutes}
@@ -321,6 +324,11 @@
 							{@html renderMarkdown(selectedReminder.description)}
 						</div>
 					</div>
+				{/if}
+				{#if selectedReminder.logger}
+					<p class="text-xs text-muted-foreground opacity-60 mt-2">
+						{t(locale, 'common.loggedBy', { name: selectedReminder.logger.displayName })}
+					</p>
 				{/if}
 			</div>
 
@@ -665,23 +673,30 @@
 						<button
 							type="button"
 							onclick={() => openDetail(event)}
-							class="w-full flex items-center gap-3 text-sm rounded-lg px-2 py-1.5 hover:bg-accent transition-colors text-left"
+							class="w-full rounded-lg px-2 py-1.5 hover:bg-accent transition-colors text-left"
 						>
-							<span class="text-base shrink-0">{ACTIVITY_ICONS[event.type] ?? '📝'}</span>
-							<Badge variant="secondary" class="capitalize shrink-0">{event.type}</Badge>
-							{#if event.durationMinutes}
-								<span class="text-xs text-muted-foreground shrink-0"
-									>{event.durationMinutes} min</span
-								>
+							<div class="flex items-center gap-3 text-sm">
+								<span class="text-base shrink-0">{ACTIVITY_ICONS[event.type] ?? '📝'}</span>
+								<Badge variant="secondary" class="capitalize shrink-0">{event.type}</Badge>
+								{#if event.durationMinutes}
+									<span class="text-xs text-muted-foreground shrink-0"
+										>{event.durationMinutes} min</span
+									>
+								{/if}
+								{#if event.notes}
+									<span class="truncate text-muted-foreground text-xs"
+										>{event.notes.replace(/[#*_`~>[\]]/g, '').trim()}</span
+									>
+								{/if}
+								<span class="ml-auto text-xs shrink-0 text-muted-foreground">
+									<LocalTime date={event.loggedAt} format="time" />
+								</span>
+							</div>
+							{#if event.logger}
+								<p class="text-xs text-muted-foreground opacity-60 pl-8">
+									{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
+								</p>
 							{/if}
-							{#if event.notes}
-								<span class="truncate text-muted-foreground text-xs"
-									>{event.notes.replace(/[#*_`~>[\]]/g, '').trim()}</span
-								>
-							{/if}
-							<span class="ml-auto text-xs shrink-0 text-muted-foreground">
-								<LocalTime date={event.loggedAt} format="time" />
-							</span>
 						</button>
 					{/each}
 				</div>

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
@@ -29,7 +29,8 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 		where: and(
 			eq(schema.journalEntries.companionId, params.companionId),
 			eq(schema.journalEntries.date, today)
-		)
+		),
+		with: { logger: { columns: { displayName: true } } }
 	});
 
 	const photos = todayEntry

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData } from './$types';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
+	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import { untrack } from 'svelte';
 	import { Card, CardHeader, CardContent } from '$lib/components/ui/card/index.js';
 	import { t, getLocale } from '$lib/i18n';
@@ -197,11 +198,7 @@
 					>
 				{/if}
 			</span>
-			{#if data.todayEntry?.logger}
-				<span class="text-xs text-muted-foreground"
-					>{t(locale, 'common.loggedBy', { name: data.todayEntry.logger.displayName })}</span
-				>
-			{/if}
+			<LoggedBy logger={data.todayEntry?.logger} variant="inline" />
 		</div>
 
 		<!-- Mood -->

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -197,6 +197,11 @@
 					>
 				{/if}
 			</span>
+			{#if data.todayEntry?.logger}
+				<span class="text-xs text-muted-foreground"
+					>{t(locale, 'common.loggedBy', { name: data.todayEntry.logger.displayName })}</span
+				>
+			{/if}
 		</div>
 
 		<!-- Mood -->

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.server.ts
@@ -30,7 +30,8 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 			eq(schema.dailyEvents.companionId, params.companionId),
 			gte(schema.dailyEvents.loggedAt, todayStart)
 		),
-		orderBy: (d, { desc }) => [desc(d.loggedAt)]
+		orderBy: (d, { desc }) => [desc(d.loggedAt)],
+		with: { logger: { columns: { displayName: true } } }
 	});
 
 	return { companion, todayEvents };

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
@@ -218,9 +218,14 @@
 										<p class="text-sm truncate text-muted-foreground mt-0.5">{event.notes}</p>
 									{/if}
 								</div>
-								<span class="text-xs shrink-0 text-muted-foreground"
-									><LocalTime date={event.loggedAt} format="time" /></span
-								>
+								<div class="text-xs shrink-0 text-muted-foreground text-right">
+									<LocalTime date={event.loggedAt} format="time" />
+									{#if event.logger}
+										<p class="opacity-60">
+											{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
+										</p>
+									{/if}
+								</div>
 								{#if event.loggedBy === data.user?.id}
 									<form
 										method="POST"

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData, ActionData } from './$types';
 	import { enhance } from '$app/forms';
 	import LocalTime from '$lib/components/LocalTime.svelte';
+	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import { Card, CardHeader, CardContent } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -220,11 +221,7 @@
 								</div>
 								<div class="text-xs shrink-0 text-muted-foreground text-right">
 									<LocalTime date={event.loggedAt} format="time" />
-									{#if event.logger}
-										<p class="opacity-60">
-											{t(locale, 'common.loggedBy', { name: event.logger.displayName })}
-										</p>
-									{/if}
+									<LoggedBy logger={event.logger} />
 								</div>
 								{#if event.loggedBy === data.user?.id}
 									<form


### PR DESCRIPTION
Closes #11 

  ## Summary
  - Add `loggedBy` column to `healthEvents`, `weightEntries`, and `reminders` tables (migration 0002) to track who created each record; `journalEntries` and `dailyEvents` already had this field
  - Fix FK constraints with migration 0003: recreate tables to add `ON DELETE SET NULL` (SQLite `ALTER TABLE ADD COLUMN` can't express this inline)
  - Add Drizzle ORM relations (`logger`) for all five `loggedBy` foreign keys so queries can eagerly load the author's display name
  - Update all server loaders and form actions across both member and caretaker routes to populate and return attribution data
  - Extract reusable `LoggedBy.svelte` component and use it across all UI surfaces: detail modals, list rows, and dashboard cards
  - Carry forward `loggedBy` when recurring reminders auto-create the next instance
  - Add `common.loggedBy` i18n key in all 6 supported locales (en, de, es, fr, it, pt)