### PR TITLE
Implement MAX_DAILY_PHOTOS option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,9 @@ ORIGIN=https://einvault.yourdomain.com
 # If you raise this above 50, raise BODY_SIZE_LIMIT to match.
 # UPLOAD_MAX_MB=10
 
+# Maximum number of journal photos per companion per day (default: 5).
+# MAX_DAILY_PHOTOS=5
+
 # SvelteKit's internal request body cap (default: 50M).
 # Must be >= UPLOAD_MAX_MB. SvelteKit enforces this before the upload handler runs,
 # so it needs to be high enough to let requests through. Accepts K, M, G suffixes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ ENV HOST=0.0.0.0
 ENV PORT=3000
 ENV DATABASE_URL=/data/einvault.db
 ENV UPLOAD_MAX_MB=10
+ENV MAX_DAILY_PHOTOS=5
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD wget -qO- http://127.0.0.1:3000/api/health || exit 1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ EinVault is a private, self-hosted companion health and care tracker built for h
 ## Features
 
 - **Companion profiles:** breed, bio, vet info, emergency contacts, and avatar photo
-- **Daily journal:** per-companion entries with mood tracking and up to 5 photos per day
+- **Daily journal:** per-companion entries with mood tracking and configurable daily photo limit (default 5)
 - **Health tracking:** vet visits, vaccinations, medications, procedures, and weight history
 - **Activity logging:** walks, meals, bathroom trips, treats, play sessions, and grooming
 - **Reminders:** recurring and one-time reminders for medications, vaccinations, grooming, and more
@@ -145,13 +145,14 @@ einvault.yourdomain.com {
 
 Everything else in the compose file can be edited directly:
 
-|                 | Default             | Description                                                                                                                     |
-| --------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `TZ`            | `UTC`               | Container timezone. Set to your local timezone (e.g. `America/New_York`, `Europe/London`) so dates and times display correctly. |
-| `UPLOAD_MAX_MB` | `10`                | Maximum upload size in MB. SvelteKit's internal `BODY_SIZE_LIMIT` is derived from this automatically at container start.        |
-| `user`          | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                       |
-| `./data` volume | `./data`            | Where the database and uploads are stored on the host.                                                                          |
-| `DATABASE_URL`  | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                  |
+|                    | Default             | Description                                                                                                                     |
+| ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `TZ`               | `UTC`               | Container timezone. Set to your local timezone (e.g. `America/New_York`, `Europe/London`) so dates and times display correctly. |
+| `UPLOAD_MAX_MB`    | `10`                | Maximum upload size in MB. SvelteKit's internal `BODY_SIZE_LIMIT` is derived from this automatically at container start.        |
+| `MAX_DAILY_PHOTOS` | `5`                 | Maximum number of journal photos per companion per day.                                                                         |
+| `user`             | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                       |
+| `./data` volume    | `./data`            | Where the database and uploads are stored on the host.                                                                          |
+| `DATABASE_URL`     | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                  |
 
 ### Data and backup
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,6 +31,8 @@ services:
       DATABASE_URL: /data/einvault.db
       # Maximum upload size in MB. BODY_SIZE_LIMIT is derived automatically.
       UPLOAD_MAX_MB: ${UPLOAD_MAX_MB:-10}
+      # Maximum journal photos per companion per day.
+      MAX_DAILY_PHOTOS: ${MAX_DAILY_PHOTOS:-5}
 
       # Set to your local timezone so dates and times display correctly.
       # Defaults to UTC if omitted. Example: America/New_York, Europe/London

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,8 @@ services:
       DATABASE_URL: /data/einvault.db
       # Maximum upload size in MB. BODY_SIZE_LIMIT is derived automatically.
       UPLOAD_MAX_MB: 10
+      # Maximum journal photos per companion per day.
+      MAX_DAILY_PHOTOS: 5
 
       # Set to your local timezone so dates and times display correctly.
       # Defaults to UTC if omitted. Example: America/New_York, Europe/London

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -1,0 +1,13 @@
+import { env } from '$env/dynamic/private';
+
+/**
+ * Parse an env var as a positive integer. Falls back to `defaultValue`
+ * when the value is missing, non-numeric, or not > 0.
+ */
+function envInt(value: string | undefined, defaultValue: number): number {
+	const n = Number(value);
+	return Number.isInteger(n) && n > 0 ? n : defaultValue;
+}
+
+export const UPLOAD_MAX_MB = envInt(env.UPLOAD_MAX_MB, 10);
+export const MAX_DAILY_PHOTOS = envInt(env.MAX_DAILY_PHOTOS, 5);

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
@@ -65,7 +65,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		date,
 		today,
 		isToday: date === today,
-		uploadMaxMb: env.UPLOAD_MAX_MB ?? '10'
+		uploadMaxMb: env.UPLOAD_MAX_MB ?? '10',
+		maxDailyPhotos: Math.max(1, parseInt(env.MAX_DAILY_PHOTOS ?? '5') || 5)
 	};
 };
 

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
@@ -7,7 +7,7 @@ import { generateId } from '$lib/server/utils';
 import { parseMood, parseDailyEventType, isValidDate } from '$lib/server/validation';
 import { localDateISO } from '$lib/date';
 import { upsertJournalEntry } from '$lib/server/journal';
-import { env } from '$env/dynamic/private';
+import { MAX_DAILY_PHOTOS, UPLOAD_MAX_MB } from '$lib/server/env';
 
 export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -65,8 +65,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		date,
 		today,
 		isToday: date === today,
-		uploadMaxMb: env.UPLOAD_MAX_MB ?? '10',
-		maxDailyPhotos: Math.max(1, parseInt(env.MAX_DAILY_PHOTOS ?? '5') || 5)
+		uploadMaxMb: UPLOAD_MAX_MB,
+		maxDailyPhotos: MAX_DAILY_PHOTOS
 	};
 };
 

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -113,8 +113,8 @@
 	}
 
 	async function uploadPhoto(file: File) {
-		if (photos.length >= 5) {
-			setUploadError('Maximum 5 photos per day');
+		if (photos.length >= data.maxDailyPhotos) {
+			setUploadError(t(locale, 'error.maxPhotosExceeded', { max: String(data.maxDailyPhotos) }));
 			return;
 		}
 		uploadError = '';
@@ -190,7 +190,7 @@
 		const files = (e.target as HTMLInputElement).files;
 		if (!files?.length) return;
 		for (const file of Array.from(files)) {
-			if (photos.length < 5) uploadPhoto(file);
+			if (photos.length < data.maxDailyPhotos) uploadPhoto(file);
 		}
 		if (fileInputEl) fileInputEl.value = '';
 	}
@@ -601,9 +601,11 @@
 			<h2 class="font-semibold flex items-center gap-2 text-foreground">
 				<Camera class="h-4 w-4" />
 				{t(locale, 'page.journal.day.photosTitle')}
-				<span class="text-xs font-normal text-muted-foreground">{photos.length}/5</span>
+				<span class="text-xs font-normal text-muted-foreground"
+					>{photos.length}/{data.maxDailyPhotos}</span
+				>
 			</h2>
-			{#if photos.length < 5}
+			{#if photos.length < data.maxDailyPhotos}
 				<label
 					class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent cursor-pointer"
 				>

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -114,7 +114,7 @@
 
 	async function uploadPhoto(file: File) {
 		if (photos.length >= data.maxDailyPhotos) {
-			setUploadError(t(locale, 'error.maxPhotosExceeded', { max: String(data.maxDailyPhotos) }));
+			setUploadError(t(locale, 'error.maxPhotosExceeded', { max: data.maxDailyPhotos }));
 			return;
 		}
 		uploadError = '';

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
@@ -7,7 +7,7 @@ import { parseMood } from '$lib/server/validation';
 import { getShiftStatus } from '$lib/server/shifts';
 import { localDateISO } from '$lib/date';
 import { upsertJournalEntry } from '$lib/server/journal';
-import { env } from '$env/dynamic/private';
+import { MAX_DAILY_PHOTOS } from '$lib/server/env';
 
 export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	const { companions, isOnShift } = await parent();
@@ -21,10 +21,9 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	if (!companion) error(404, t(locals.locale, 'error.companionNotFound'));
 
 	const today = localDateISO();
-	const maxDailyPhotos = Math.max(1, parseInt(env.MAX_DAILY_PHOTOS ?? '5') || 5);
 
 	if (!isOnShift) {
-		return { companion, todayEntry: null, photos: [], today, maxDailyPhotos };
+		return { companion, todayEntry: null, photos: [], today, maxDailyPhotos: MAX_DAILY_PHOTOS };
 	}
 
 	const todayEntry = await db.query.journalEntries.findFirst({
@@ -47,7 +46,7 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 		todayEntry: todayEntry ?? null,
 		photos,
 		today,
-		maxDailyPhotos
+		maxDailyPhotos: MAX_DAILY_PHOTOS
 	};
 };
 

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
@@ -7,6 +7,7 @@ import { parseMood } from '$lib/server/validation';
 import { getShiftStatus } from '$lib/server/shifts';
 import { localDateISO } from '$lib/date';
 import { upsertJournalEntry } from '$lib/server/journal';
+import { env } from '$env/dynamic/private';
 
 export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	const { companions, isOnShift } = await parent();
@@ -20,9 +21,10 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	if (!companion) error(404, t(locals.locale, 'error.companionNotFound'));
 
 	const today = localDateISO();
+	const maxDailyPhotos = Math.max(1, parseInt(env.MAX_DAILY_PHOTOS ?? '5') || 5);
 
 	if (!isOnShift) {
-		return { companion, todayEntry: null, photos: [], today };
+		return { companion, todayEntry: null, photos: [], today, maxDailyPhotos };
 	}
 
 	const todayEntry = await db.query.journalEntries.findFirst({
@@ -44,7 +46,8 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 		companion,
 		todayEntry: todayEntry ?? null,
 		photos,
-		today
+		today,
+		maxDailyPhotos
 	};
 };
 

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -63,8 +63,8 @@
 	}
 
 	async function uploadPhoto(file: File) {
-		if (photos.length >= 5) {
-			setUploadError('Maximum 5 photos per day');
+		if (photos.length >= data.maxDailyPhotos) {
+			setUploadError(t(locale, 'error.maxPhotosExceeded', { max: String(data.maxDailyPhotos) }));
 			return;
 		}
 		uploadError = '';
@@ -137,7 +137,7 @@
 		const files = (e.target as HTMLInputElement).files;
 		if (!files?.length) return;
 		for (const file of Array.from(files)) {
-			if (photos.length < 5) uploadPhoto(file);
+			if (photos.length < data.maxDailyPhotos) uploadPhoto(file);
 		}
 		fileInputEl.value = '';
 	}
@@ -262,9 +262,11 @@
 				<h2 class="font-semibold flex items-center gap-2">
 					<span>📷</span>
 					{t(locale, 'page.journal.caretaker.photos')}
-					<span class="text-xs font-normal text-muted-foreground">{photos.length}/5</span>
+					<span class="text-xs font-normal text-muted-foreground"
+						>{photos.length}/{data.maxDailyPhotos}</span
+					>
 				</h2>
-				{#if photos.length < 5}
+				{#if photos.length < data.maxDailyPhotos}
 					<label
 						class="inline-flex items-center justify-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent hover:text-accent-foreground cursor-pointer transition-colors"
 					>
@@ -377,7 +379,7 @@
 								</div>
 							</div>
 						{/each}
-						{#if photos.length < 5}
+						{#if photos.length < data.maxDailyPhotos}
 							<label
 								class="aspect-square w-24 rounded-lg border-2 border-dashed flex flex-col items-center
 							justify-center cursor-pointer hover:opacity-80 transition-colors"

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -64,7 +64,7 @@
 
 	async function uploadPhoto(file: File) {
 		if (photos.length >= data.maxDailyPhotos) {
-			setUploadError(t(locale, 'error.maxPhotosExceeded', { max: String(data.maxDailyPhotos) }));
+			setUploadError(t(locale, 'error.maxPhotosExceeded', { max: data.maxDailyPhotos }));
 			return;
 		}
 		uploadError = '';

--- a/src/routes/api/companions/[companionId]/avatar/+server.ts
+++ b/src/routes/api/companions/[companionId]/avatar/+server.ts
@@ -6,11 +6,11 @@ import { eq, and } from 'drizzle-orm';
 import { writeFile, mkdir, unlink } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
-import { env } from '$env/dynamic/private';
 import sharp from 'sharp';
 import { DATA_DIR } from '$lib/server/paths';
+import { UPLOAD_MAX_MB } from '$lib/server/env';
 
-const MAX_SIZE = parseInt(env.UPLOAD_MAX_MB ?? '10') * 1024 * 1024;
+const MAX_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 async function assertCanEditAvatar(
@@ -42,7 +42,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	if (!file || file.size === 0) error(400, t(locals.locale, 'error.noFileProvided'));
 	if (file.size > MAX_SIZE)
-		error(400, t(locals.locale, 'error.fileTooLarge', { max: env.UPLOAD_MAX_MB ?? '10' }));
+		error(400, t(locals.locale, 'error.fileTooLarge', { max: UPLOAD_MAX_MB }));
 	if (!ALLOWED_TYPES.includes(file.type))
 		error(400, t(locals.locale, 'error.invalidFileTypeAvatar'));
 

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -11,7 +11,7 @@ import sharp from 'sharp';
 import { DATA_DIR } from '$lib/server/paths';
 import { isValidDate } from '$lib/server/validation';
 
-const MAX_PHOTOS_PER_DAY = 5;
+const MAX_PHOTOS_PER_DAY = Math.max(1, parseInt(env.MAX_DAILY_PHOTOS ?? '5') || 5);
 const MAX_FILE_SIZE = parseInt(env.UPLOAD_MAX_MB ?? '10') * 1024 * 1024;
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -6,13 +6,12 @@ import { eq, and, count } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 import { writeFile, mkdir } from 'fs/promises';
 import { join } from 'path';
-import { env } from '$env/dynamic/private';
 import sharp from 'sharp';
 import { DATA_DIR } from '$lib/server/paths';
+import { MAX_DAILY_PHOTOS, UPLOAD_MAX_MB } from '$lib/server/env';
 import { isValidDate } from '$lib/server/validation';
 
-const MAX_PHOTOS_PER_DAY = Math.max(1, parseInt(env.MAX_DAILY_PHOTOS ?? '5') || 5);
-const MAX_FILE_SIZE = parseInt(env.UPLOAD_MAX_MB ?? '10') * 1024 * 1024;
+const MAX_FILE_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
@@ -54,8 +53,8 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		.from(schema.journalPhotos)
 		.where(eq(schema.journalPhotos.entryId, entry.id));
 
-	if (photoCount >= MAX_PHOTOS_PER_DAY) {
-		error(400, t(locals.locale, 'error.maxPhotosExceeded', { max: String(MAX_PHOTOS_PER_DAY) }));
+	if (photoCount >= MAX_DAILY_PHOTOS) {
+		error(400, t(locals.locale, 'error.maxPhotosExceeded', { max: MAX_DAILY_PHOTOS }));
 	}
 
 	const formData = await request.formData();
@@ -63,7 +62,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	if (!file || file.size === 0) error(400, t(locals.locale, 'error.noFileProvided'));
 	if (file.size > MAX_FILE_SIZE)
-		error(400, t(locals.locale, 'error.fileTooLarge', { max: env.UPLOAD_MAX_MB ?? '10' }));
+		error(400, t(locals.locale, 'error.fileTooLarge', { max: UPLOAD_MAX_MB }));
 	if (!ALLOWED_TYPES.includes(file.type)) error(400, t(locals.locale, 'error.invalidFileType'));
 
 	const raw = Buffer.from(await file.arrayBuffer());


### PR DESCRIPTION
Closes #21 

## Summary

- Add `MAX_DAILY_PHOTOS` env var (default `5`) to replace the hardcoded daily journal photo cap on both upload endpoint and journal UIs
- Introduce `src/lib/server/env.ts` as a single source for numeric env config, exporting `UPLOAD_MAX_MB` and `MAX_DAILY_PHOTOS` as typed constants
- Route files (`photos`, `avatar`, both journal `+page.server.ts`) drop inline `parseInt`/`env.*` parsing and import the constants

## Implementation notes

- `envInt(value, defaultValue)` uses `Number` + `Number.isInteger(n) && n > 0` instead of `parseInt` + `Math.max`. Rejects non-integers (`"10.5"`), stray chars (`"5abc"`), empty string, and zero/negative values (any of which fall back to the default).
- `t()` already accepts `Record<string, string | number>`, so the client error for exceeded limit uses the existing `error.maxPhotosExceeded` i18n key (fixes a hardcoded English string in the caretaker + companion journal pages along the way).
- Documented in `.env.example`, `Dockerfile`, `docker-compose.dev.yml`, `docker-compose.prod.yml`, and the README env table.