### PR TITLE
Add loggedBy to Journal Photos and allow acceptable users to modify photos

### DIFF
--- a/drizzle/0004_hesitant_fat_cobra.sql
+++ b/drizzle/0004_hesitant_fat_cobra.sql
@@ -1,0 +1,22 @@
+-- Add logged_by FK to journal_photos with ON DELETE SET NULL.
+-- SQLite ALTER TABLE ADD COLUMN cannot express ON DELETE clauses,
+-- so recreate the table with the correct constraint.
+
+CREATE TABLE `journal_photos_new` (
+	`id` text PRIMARY KEY NOT NULL,
+	`entry_id` text NOT NULL,
+	`filename` text NOT NULL,
+	`original_name` text,
+	`mime_type` text NOT NULL,
+	`size_bytes` integer NOT NULL,
+	`notes` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`logged_by` text,
+	FOREIGN KEY (`entry_id`) REFERENCES `journal_entries`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`logged_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+INSERT INTO `journal_photos_new` (`id`, `entry_id`, `filename`, `original_name`, `mime_type`, `size_bytes`, `notes`, `created_at`)
+	SELECT `id`, `entry_id`, `filename`, `original_name`, `mime_type`, `size_bytes`, `notes`, `created_at` FROM `journal_photos`;--> statement-breakpoint
+DROP TABLE `journal_photos`;--> statement-breakpoint
+ALTER TABLE `journal_photos_new` RENAME TO `journal_photos`;--> statement-breakpoint
+CREATE INDEX `photo_entry_idx` ON `journal_photos` (`entry_id`);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1183 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8f65942e-1940-49e5-afaf-0e2601b6a796",
+  "prevId": "a1b2c3d4-fix0-fk01-null-logged0by0fix",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_due_at": {
+          "name": "next_due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurring_days": {
+          "name": "recurring_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_dismissed": {
+          "name": "is_dismissed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1775738400000,
       "tag": "0003_fix_logged_by_fk",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1775908177456,
+      "tag": "0004_hesitant_fat_cobra",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -632,6 +632,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.moreActions': 'Weitere Aktionen',
 	'aria.deleteEntry': 'Eintrag löschen',
 	'aria.deletePhoto': 'Foto löschen',
+	'aria.downloadPhoto': 'Foto herunterladen',
 	'aria.closeDialog': 'Dialog schließen',
 	'aria.close': 'Schließen',
 	'aria.previousPhoto': 'Vorheriges Foto',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -626,6 +626,7 @@ const messages = {
 	'aria.moreActions': 'More actions',
 	'aria.deleteEntry': 'Delete entry',
 	'aria.deletePhoto': 'Delete photo',
+	'aria.downloadPhoto': 'Download photo',
 	'aria.closeDialog': 'Close dialog',
 	'aria.close': 'Close',
 	'aria.previousPhoto': 'Previous photo',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -630,6 +630,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.moreActions': 'Más acciones',
 	'aria.deleteEntry': 'Eliminar entrada',
 	'aria.deletePhoto': 'Eliminar foto',
+	'aria.downloadPhoto': 'Descargar foto',
 	'aria.closeDialog': 'Cerrar diálogo',
 	'aria.close': 'Cerrar',
 	'aria.previousPhoto': 'Foto anterior',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -632,6 +632,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.moreActions': "Plus d'actions",
 	'aria.deleteEntry': "Supprimer l'entrée",
 	'aria.deletePhoto': 'Supprimer la photo',
+	'aria.downloadPhoto': 'Télécharger la photo',
 	'aria.closeDialog': 'Fermer la boîte de dialogue',
 	'aria.close': 'Fermer',
 	'aria.previousPhoto': 'Photo précédente',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -629,6 +629,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.moreActions': 'Altre azioni',
 	'aria.deleteEntry': 'Elimina voce',
 	'aria.deletePhoto': 'Elimina foto',
+	'aria.downloadPhoto': 'Scarica foto',
 	'aria.closeDialog': 'Chiudi finestra',
 	'aria.close': 'Chiudi',
 	'aria.previousPhoto': 'Foto precedente',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -630,6 +630,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.moreActions': 'Mais ações',
 	'aria.deleteEntry': 'Eliminar entrada',
 	'aria.deletePhoto': 'Eliminar foto',
+	'aria.downloadPhoto': 'Baixar foto',
 	'aria.closeDialog': 'Fechar diálogo',
 	'aria.close': 'Fechar',
 	'aria.previousPhoto': 'Foto anterior',

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -6,11 +6,11 @@
 type AuthUser = { id: string; role: 'admin' | 'member' | 'caretaker' } | null | undefined;
 
 /**
- * Admins can delete any journal photo. Other users can delete only photos
- * they uploaded. Photos with a null `loggedBy` (pre-migration legacy rows)
- * are deletable only by admins.
+ * Admins can modify (edit caption, delete) any journal photo. Other users
+ * can modify only photos they uploaded. Photos with a null `loggedBy`
+ * (pre-migration legacy rows) are modifiable only by admins.
  */
-export function canDeletePhoto(user: AuthUser, photo: { loggedBy: string | null }): boolean {
+export function canModifyPhoto(user: AuthUser, photo: { loggedBy: string | null }): boolean {
 	if (!user) return false;
 	return user.role === 'admin' || photo.loggedBy === user.id;
 }

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,16 @@
+/**
+ * Authorization helpers shared by client UI and server route handlers.
+ * Keep logic here so the UI (button visibility) and API (403 check) cannot drift.
+ */
+
+type AuthUser = { id: string; role: 'admin' | 'member' | 'caretaker' } | null | undefined;
+
+/**
+ * Admins can delete any journal photo. Other users can delete only photos
+ * they uploaded. Photos with a null `loggedBy` (pre-migration legacy rows)
+ * are deletable only by admins.
+ */
+export function canDeletePhoto(user: AuthUser, photo: { loggedBy: string | null }): boolean {
+	if (!user) return false;
+	return user.role === 'admin' || photo.loggedBy === user.id;
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -125,7 +125,8 @@ export const journalPhotos = sqliteTable(
 		notes: text('notes'),
 		createdAt: integer('created_at', { mode: 'timestamp' })
 			.notNull()
-			.default(sql`(unixepoch())`)
+			.default(sql`(unixepoch())`),
+		loggedBy: text('logged_by').references(() => users.id, { onDelete: 'set null' })
 	},
 	(t) => ({
 		entryIdx: index('photo_entry_idx').on(t.entryId)
@@ -300,6 +301,7 @@ export const usersRelations = relations(users, ({ many }) => ({
 	companionCaretakers: many(companionCaretakers),
 	shifts: many(caretakerShifts),
 	loggedJournalEntries: many(journalEntries),
+	loggedJournalPhotos: many(journalPhotos),
 	loggedDailyEvents: many(dailyEvents),
 	loggedHealthEvents: many(healthEvents),
 	loggedWeightEntries: many(weightEntries),
@@ -318,8 +320,17 @@ export const caretakerShiftsRelations = relations(caretakerShifts, ({ one }) => 
 	user: one(users, { fields: [caretakerShifts.userId], references: [users.id] })
 }));
 
-export const journalEntriesRelations = relations(journalEntries, ({ one }) => ({
-	logger: one(users, { fields: [journalEntries.loggedBy], references: [users.id] })
+export const journalEntriesRelations = relations(journalEntries, ({ one, many }) => ({
+	logger: one(users, { fields: [journalEntries.loggedBy], references: [users.id] }),
+	photos: many(journalPhotos)
+}));
+
+export const journalPhotosRelations = relations(journalPhotos, ({ one }) => ({
+	entry: one(journalEntries, {
+		fields: [journalPhotos.entryId],
+		references: [journalEntries.id]
+	}),
+	logger: one(users, { fields: [journalPhotos.loggedBy], references: [users.id] })
 }));
 
 export const dailyEventsRelations = relations(dailyEvents, ({ one }) => ({

--- a/src/lib/server/journal.ts
+++ b/src/lib/server/journal.ts
@@ -30,7 +30,10 @@ export async function getEnrichedJournalEntries(
 	type EventWithLogger = typeof schema.dailyEvents.$inferSelect & {
 		logger: Logger;
 	};
-	let photosByEntry = new Map<string, (typeof schema.journalPhotos.$inferSelect)[]>();
+	type PhotoWithLogger = typeof schema.journalPhotos.$inferSelect & {
+		logger: Logger;
+	};
+	let photosByEntry = new Map<string, PhotoWithLogger[]>();
 	let eventsByDate = new Map<string, EventWithLogger[]>();
 
 	if (pageEntries.length > 0) {
@@ -45,7 +48,8 @@ export async function getEnrichedJournalEntries(
 		const [allPhotos, allEvents] = await Promise.all([
 			db.query.journalPhotos.findMany({
 				where: inArray(schema.journalPhotos.entryId, entryIds),
-				orderBy: (p, { asc }) => [asc(p.createdAt)]
+				orderBy: (p, { asc }) => [asc(p.createdAt)],
+				with: { logger: { columns: { displayName: true } } }
 			}),
 			db.query.dailyEvents.findMany({
 				where: and(

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -265,6 +265,11 @@
 					{@html renderMarkdown(lightboxPhoto.notes)}
 				</div>
 			{/if}
+			{#if lightboxPhoto.logger}
+				<div class="mt-2 flex justify-center">
+					<LoggedBy logger={lightboxPhoto.logger} variant="inline" class="!text-white/60 !ml-0" />
+				</div>
+			{/if}
 		</div>
 	</div>
 {/if}

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -5,7 +5,15 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Separator } from '$lib/components/ui/separator/index.js';
-	import { ChevronLeft, ChevronRight, X, Pencil, NotebookPen, ArrowRight } from '@lucide/svelte';
+	import {
+		ChevronLeft,
+		ChevronRight,
+		X,
+		Pencil,
+		NotebookPen,
+		ArrowRight,
+		Download
+	} from '@lucide/svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import { tick } from 'svelte';
@@ -216,14 +224,24 @@
 				{:else}
 					<span></span>
 				{/if}
-				<button
-					type="button"
-					onclick={closeLightbox}
-					class="text-white/70 hover:text-white p-1 rounded"
-					aria-label={t(locale, 'aria.close')}
-				>
-					<X class="h-5 w-5" />
-				</button>
+				<div class="flex items-center gap-1">
+					<a
+						href={photoUrl(lightboxPhoto, lightboxDate)}
+						download={lightboxPhoto.originalName ?? lightboxPhoto.filename}
+						class="text-white/70 hover:text-white p-1 rounded"
+						aria-label={t(locale, 'aria.downloadPhoto')}
+					>
+						<Download class="h-5 w-5" />
+					</a>
+					<button
+						type="button"
+						onclick={closeLightbox}
+						class="text-white/70 hover:text-white p-1 rounded"
+						aria-label={t(locale, 'aria.close')}
+					>
+						<X class="h-5 w-5" />
+					</button>
+				</div>
 			</div>
 
 			<div class="relative">

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
@@ -29,7 +29,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	const photos = entry
 		? await db.query.journalPhotos.findMany({
 				where: eq(schema.journalPhotos.entryId, entry.id),
-				orderBy: (p, { asc }) => [asc(p.createdAt)]
+				orderBy: (p, { asc }) => [asc(p.createdAt)],
+				with: { logger: { columns: { displayName: true } } }
 			})
 		: [];
 

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -5,7 +5,7 @@
 	import { goto } from '$app/navigation';
 	import { enhance } from '$app/forms';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
-	import { canDeletePhoto } from '$lib/permissions';
+	import { canModifyPhoto } from '$lib/permissions';
 	import { localDateISO } from '$lib/date';
 	import { getContext } from 'svelte';
 
@@ -672,7 +672,7 @@
 									class="w-full h-full object-cover"
 									loading="lazy"
 								/>
-								{#if canDeletePhoto(data.user, photo)}
+								{#if canModifyPhoto(data.user, photo)}
 									<button
 										type="button"
 										onclick={() => openConfirm(() => deletePhoto(photo.id))}
@@ -719,12 +719,14 @@
 										</p>
 									{/if}
 									<div class="flex items-center gap-2 mt-1">
-										<button
-											type="button"
-											onclick={() => startEditPhotoNotes(photo)}
-											class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-											>{t(locale, 'page.journal.day.editCaption')}</button
-										>
+										{#if canModifyPhoto(data.user, photo)}
+											<button
+												type="button"
+												onclick={() => startEditPhotoNotes(photo)}
+												class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+												>{t(locale, 'page.journal.day.editCaption')}</button
+											>
+										{/if}
 										<LoggedBy logger={photo.logger} variant="inline" />
 									</div>
 								{/if}

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -5,6 +5,7 @@
 	import { goto } from '$app/navigation';
 	import { enhance } from '$app/forms';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
+	import { canDeletePhoto } from '$lib/permissions';
 	import { localDateISO } from '$lib/date';
 	import { getContext } from 'svelte';
 
@@ -132,7 +133,7 @@
 				setUploadError(err.message ?? 'Upload failed');
 				return;
 			}
-			const { id, filename } = await res.json();
+			const { id, filename, loggedBy, logger } = await res.json();
 			photos = [
 				...photos,
 				{
@@ -143,7 +144,9 @@
 					mimeType: file.type,
 					sizeBytes: file.size,
 					notes: null,
-					createdAt: new Date()
+					createdAt: new Date(),
+					loggedBy,
+					logger
 				}
 			];
 		} catch {
@@ -669,16 +672,18 @@
 									class="w-full h-full object-cover"
 									loading="lazy"
 								/>
-								<button
-									type="button"
-									onclick={() => openConfirm(() => deletePhoto(photo.id))}
-									class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
+								{#if canDeletePhoto(data.user, photo)}
+									<button
+										type="button"
+										onclick={() => openConfirm(() => deletePhoto(photo.id))}
+										class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
 										flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
 										hover:bg-red-600 transition-all"
-									aria-label={t(locale, 'aria.deletePhoto')}
-								>
-									<Trash2 class="h-3 w-3" />
-								</button>
+										aria-label={t(locale, 'aria.deletePhoto')}
+									>
+										<Trash2 class="h-3 w-3" />
+									</button>
+								{/if}
 							</div>
 							<div class="flex-1 min-w-0">
 								{#if editingPhotoId === photo.id}
@@ -713,12 +718,15 @@
 											{t(locale, 'page.journal.day.noCaption')}
 										</p>
 									{/if}
-									<button
-										type="button"
-										onclick={() => startEditPhotoNotes(photo)}
-										class="inline-flex items-center justify-center rounded-md px-2 py-0.5 mt-1 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-										>{t(locale, 'page.journal.day.editCaption')}</button
-									>
+									<div class="flex items-center gap-2 mt-1">
+										<button
+											type="button"
+											onclick={() => startEditPhotoNotes(photo)}
+											class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+											>{t(locale, 'page.journal.day.editCaption')}</button
+										>
+										<LoggedBy logger={photo.logger} variant="inline" />
+									</div>
 								{/if}
 							</div>
 						</div>

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
@@ -37,7 +37,8 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	const photos = todayEntry
 		? await db.query.journalPhotos.findMany({
 				where: eq(schema.journalPhotos.entryId, todayEntry.id),
-				orderBy: (p, { asc }) => [asc(p.createdAt)]
+				orderBy: (p, { asc }) => [asc(p.createdAt)],
+				with: { logger: { columns: { displayName: true } } }
 			})
 		: [];
 

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
+	import { canDeletePhoto } from '$lib/permissions';
+	import { Trash2 } from '@lucide/svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import LoggedBy from '$lib/components/LoggedBy.svelte';
 	import { untrack } from 'svelte';
@@ -82,7 +84,7 @@
 				setUploadError(err.message ?? 'Upload failed');
 				return;
 			}
-			const { id, filename } = await res.json();
+			const { id, filename, loggedBy, logger } = await res.json();
 			photos = [
 				...photos,
 				{
@@ -93,7 +95,9 @@
 					mimeType: file.type,
 					sizeBytes: file.size,
 					notes: null,
-					createdAt: new Date()
+					createdAt: new Date(),
+					loggedBy,
+					logger
 				}
 			];
 		} catch {
@@ -323,15 +327,17 @@
 										class="w-full h-full object-cover"
 										loading="lazy"
 									/>
-									<button
-										onclick={() => deletePhoto(photo.id)}
-										aria-label={t(locale, 'aria.deletePhoto')}
-										class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
-										flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
-										hover:bg-red-600 transition-all"
-									>
-										<span aria-hidden="true">✕</span>
-									</button>
+									{#if canDeletePhoto(data.user, photo)}
+										<button
+											onclick={() => deletePhoto(photo.id)}
+											aria-label={t(locale, 'aria.deletePhoto')}
+											class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
+											flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
+											hover:bg-red-600 transition-all"
+										>
+											<Trash2 class="h-3 w-3" />
+										</button>
+									{/if}
 								</div>
 								<div class="flex-1 min-w-0">
 									{#if editingPhotoId === photo.id}
@@ -368,13 +374,16 @@
 												{t(locale, 'page.journal.caretaker.noCaption')}
 											</p>
 										{/if}
-										<button
-											type="button"
-											onclick={() => startEditPhotoNotes(photo)}
-											class="inline-flex items-center justify-center rounded-md px-2 py-0.5 mt-1 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-										>
-											{t(locale, 'page.journal.caretaker.editCaption')}
-										</button>
+										<div class="flex items-center gap-2 mt-1">
+											<button
+												type="button"
+												onclick={() => startEditPhotoNotes(photo)}
+												class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+											>
+												{t(locale, 'page.journal.caretaker.editCaption')}
+											</button>
+											<LoggedBy logger={photo.logger} variant="inline" />
+										</div>
 									{/if}
 								</div>
 							</div>

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
-	import { canDeletePhoto } from '$lib/permissions';
+	import { canModifyPhoto } from '$lib/permissions';
 	import { Trash2 } from '@lucide/svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import LoggedBy from '$lib/components/LoggedBy.svelte';
@@ -327,7 +327,7 @@
 										class="w-full h-full object-cover"
 										loading="lazy"
 									/>
-									{#if canDeletePhoto(data.user, photo)}
+									{#if canModifyPhoto(data.user, photo)}
 										<button
 											onclick={() => deletePhoto(photo.id)}
 											aria-label={t(locale, 'aria.deletePhoto')}
@@ -375,13 +375,15 @@
 											</p>
 										{/if}
 										<div class="flex items-center gap-2 mt-1">
-											<button
-												type="button"
-												onclick={() => startEditPhotoNotes(photo)}
-												class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-											>
-												{t(locale, 'page.journal.caretaker.editCaption')}
-											</button>
+											{#if canModifyPhoto(data.user, photo)}
+												<button
+													type="button"
+													onclick={() => startEditPhotoNotes(photo)}
+													class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+												>
+													{t(locale, 'page.journal.caretaker.editCaption')}
+												</button>
+											{/if}
 											<LoggedBy logger={photo.logger} variant="inline" />
 										</div>
 									{/if}

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -9,6 +9,7 @@ import { join } from 'path';
 import sharp from 'sharp';
 import { DATA_DIR } from '$lib/server/paths';
 import { MAX_DAILY_PHOTOS, UPLOAD_MAX_MB } from '$lib/server/env';
+import { canDeletePhoto } from '$lib/permissions';
 import { isValidDate } from '$lib/server/validation';
 
 const MAX_FILE_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
@@ -102,13 +103,16 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		filename,
 		originalName: file.name,
 		mimeType,
-		sizeBytes: processed.length
+		sizeBytes: processed.length,
+		loggedBy: locals.user.id
 	});
 
 	return json({
 		id: photoId,
 		filename,
-		url: `/api/photos/journal/${companionId}/${date}/${filename}`
+		url: `/api/photos/journal/${companionId}/${date}/${filename}`,
+		loggedBy: locals.user.id,
+		logger: { displayName: locals.user.displayName }
 	});
 };
 
@@ -159,6 +163,8 @@ export const DELETE: RequestHandler = async ({ url, params, locals }) => {
 	});
 	if (!entry || entry.companionId !== params.companionId)
 		error(403, t(locals.locale, 'error.forbidden'));
+
+	if (!canDeletePhoto(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
 
 	const { unlink } = await import('fs/promises');
 	const filePath = join(

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -9,7 +9,7 @@ import { join } from 'path';
 import sharp from 'sharp';
 import { DATA_DIR } from '$lib/server/paths';
 import { MAX_DAILY_PHOTOS, UPLOAD_MAX_MB } from '$lib/server/env';
-import { canDeletePhoto } from '$lib/permissions';
+import { canModifyPhoto } from '$lib/permissions';
 import { isValidDate } from '$lib/server/validation';
 
 const MAX_FILE_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
@@ -134,6 +134,8 @@ export const PATCH: RequestHandler = async ({ url, request, params, locals }) =>
 	if (!entry || entry.companionId !== params.companionId)
 		error(403, t(locals.locale, 'error.forbidden'));
 
+	if (!canModifyPhoto(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
+
 	const contentLength = parseInt(request.headers.get('content-length') ?? '0');
 	if (contentLength > 10_000) error(400, t(locals.locale, 'error.requestBodyTooLarge'));
 	const { notes } = await request.json();
@@ -164,7 +166,7 @@ export const DELETE: RequestHandler = async ({ url, params, locals }) => {
 	if (!entry || entry.companionId !== params.companionId)
 		error(403, t(locals.locale, 'error.forbidden'));
 
-	if (!canDeletePhoto(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
+	if (!canModifyPhoto(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
 
 	const { unlink } = await import('fs/promises');
 	const filePath = join(


### PR DESCRIPTION
Closes #27

## Summary

- Tracks who uploaded each journal photo via a new `logged_by` FK on `journal_photos` (ON DELETE SET NULL). Centralizes photo authorization in `canModifyPhoto` so UI button visibility and API 403 checks cannot drift.
- Enforces on both `PATCH` (caption edit) and `DELETE`: admins may modify any photo; other users only photos they uploaded; legacy rows with `loggedBy = NULL` are admin-only.
- Surfaces `loggedBy` in the UI everywhere photos appear (member detail page, caretaker today page, and the journal-list lightbox) using the existing `<LoggedBy>` component.
- Adds a download action to the lightbox (native `<a download>` against the same-origin `/api/photos/...` endpoint, preserving the original filename).
- `POST /api/.../photos` re-reads the inserted row with its `logger` relation and returns it, so optimistically-appended photos render attribution and the gated action buttons without a reload.

## Migration notes

`drizzle/0004_hesitant_fat_cobra.sql` is hand-written as a table-recreation because SQLite cannot express `ON DELETE SET NULL` through `ALTER TABLE ADD COLUMN`. Same pattern as the prior `0003_fix_logged_by_fk` migration. Existing rows carry forward with `logged_by = NULL`.

## Release note

**Heads-up for existing deployments:** pre-existing journal photos have no uploader attribution and will become **admin-only** for edit/delete after this migration. New uploads attribute normally. There is no retroactive backfill. If a non-admin needs to modify a legacy photo, an admin must do it on their behalf (or delete and re-upload).