### PR TITLE
Provide the ability to complete Reminders for members/admins from the Dashboard

### DIFF
--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -354,6 +354,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.cardReminders': 'Erinnerungen',
 	'page.dashboard.remindersViewAll': 'Alle anzeigen',
 	'page.dashboard.remindersEmpty': 'Keine anstehenden Erinnerungen.',
+	'page.dashboard.reminderDone': 'Erledigt',
+	'page.dashboard.reminderMarkDone': 'Als erledigt markieren',
 	'page.dashboard.cardWeight': 'Gewicht',
 	'page.dashboard.weightLog': 'Erfassen',
 	'page.dashboard.weightAsOf': 'Stand',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -350,6 +350,8 @@ const messages = {
 	'page.dashboard.cardReminders': 'Reminders',
 	'page.dashboard.remindersViewAll': 'View All',
 	'page.dashboard.remindersEmpty': 'No upcoming reminders.',
+	'page.dashboard.reminderDone': 'Done',
+	'page.dashboard.reminderMarkDone': 'Mark as done',
 	'page.dashboard.cardWeight': 'Weight',
 	'page.dashboard.weightLog': 'Log',
 	'page.dashboard.weightAsOf': 'as of',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -354,6 +354,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.cardReminders': 'Recordatorios',
 	'page.dashboard.remindersViewAll': 'Ver todos',
 	'page.dashboard.remindersEmpty': 'No hay recordatorios próximos.',
+	'page.dashboard.reminderDone': 'Hecho',
+	'page.dashboard.reminderMarkDone': 'Marcar como hecho',
 	'page.dashboard.cardWeight': 'Peso',
 	'page.dashboard.weightLog': 'Registrar',
 	'page.dashboard.weightAsOf': 'a fecha de',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -354,6 +354,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.cardReminders': 'Rappels',
 	'page.dashboard.remindersViewAll': 'Tout voir',
 	'page.dashboard.remindersEmpty': 'Aucun rappel à venir.',
+	'page.dashboard.reminderDone': 'Fait',
+	'page.dashboard.reminderMarkDone': 'Marquer comme fait',
 	'page.dashboard.cardWeight': 'Poids',
 	'page.dashboard.weightLog': 'Enregistrer',
 	'page.dashboard.weightAsOf': 'au',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -352,6 +352,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.cardReminders': 'Promemoria',
 	'page.dashboard.remindersViewAll': 'Vedi tutti',
 	'page.dashboard.remindersEmpty': 'Nessun promemoria in arrivo.',
+	'page.dashboard.reminderDone': 'Fatto',
+	'page.dashboard.reminderMarkDone': 'Segna come fatto',
 	'page.dashboard.cardWeight': 'Peso',
 	'page.dashboard.weightLog': 'Registra',
 	'page.dashboard.weightAsOf': 'al',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -354,6 +354,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.cardReminders': 'Lembretes',
 	'page.dashboard.remindersViewAll': 'Ver todos',
 	'page.dashboard.remindersEmpty': 'Sem lembretes próximos.',
+	'page.dashboard.reminderDone': 'Feito',
+	'page.dashboard.reminderMarkDone': 'Marcar como feito',
 	'page.dashboard.cardWeight': 'Peso',
 	'page.dashboard.weightLog': 'Registar',
 	'page.dashboard.weightAsOf': 'em',

--- a/src/routes/(app)/(companion)/[companionId]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/+page.server.ts
@@ -1,8 +1,10 @@
-import { redirect } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
+import { fail, redirect } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
+import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq, gte, and, lte } from 'drizzle-orm';
 import { localDateISO } from '$lib/date';
+import { dismissReminder } from '$lib/server/reminders';
 
 export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -85,4 +87,22 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		todayJournal,
 		activeCaretakerShift
 	};
+};
+
+export const actions: Actions = {
+	dismiss: async ({ request, params, locals }) => {
+		if (!locals.user) return fail(401, { error: t(locals.locale, 'error.unauthorized') });
+
+		const data = await request.formData();
+		const id = String(data.get('id') ?? '');
+
+		const existing = await db.query.reminders.findFirst({
+			where: and(eq(schema.reminders.id, id), eq(schema.reminders.companionId, params.companionId))
+		});
+		if (!existing) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
+
+		await dismissReminder(existing);
+
+		return { dismissSuccess: true };
+	}
 };

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -16,8 +16,10 @@
 		Pencil,
 		UserCheck,
 		NotebookPen,
-		X
+		X,
+		CheckCheck
 	} from '@lucide/svelte';
+	import { enhance } from '$app/forms';
 	import { tick } from 'svelte';
 	import { renderMarkdown } from '$lib/markdown';
 	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
@@ -382,6 +384,24 @@
 							<Pencil class="h-3.5 w-3.5 mr-1.5" />
 							{t(locale, 'page.dashboard.modalEditReminders')}
 						</Button>
+						<form
+							method="POST"
+							action="?/dismiss"
+							use:enhance={() =>
+								async ({ update }) => {
+									closeDetail();
+									await update();
+								}}
+						>
+							<input type="hidden" name="id" value={selected.item.id} />
+							<button
+								type="submit"
+								class="inline-flex items-center gap-1.5 justify-center rounded-md bg-primary text-primary-foreground h-9 px-3 text-sm font-medium shadow hover:bg-primary/90 transition-colors"
+							>
+								<CheckCheck class="h-3.5 w-3.5" />
+								{t(locale, 'page.dashboard.reminderDone')}
+							</button>
+						</form>
 					{:else if selected.kind === 'weight' || selected.kind === 'health'}
 						<Button
 							href="/{companion.id}/health?edit={selected.item.id}"
@@ -563,17 +583,37 @@
 					</p>
 				{:else}
 					{#each upcomingReminders.slice(0, 3) as reminder (reminder.id)}
-						<button
-							type="button"
-							onclick={() => openDetail({ kind: 'reminder', item: reminder })}
-							class="w-full flex items-center justify-between text-sm rounded-md px-2 py-1.5 -mx-2
-								hover:bg-accent transition-colors text-left"
-						>
-							<span class="truncate text-foreground">{reminder.title}</span>
-							<span class="shrink-0 ml-2 text-xs text-muted-foreground">
-								<LocalTime date={reminder.dueAt} />
-							</span>
-						</button>
+						<div class="flex items-center gap-1 -mx-2">
+							<button
+								type="button"
+								onclick={() => openDetail({ kind: 'reminder', item: reminder })}
+								class="flex-1 flex items-center justify-between text-sm rounded-md px-2 py-1.5
+									hover:bg-accent transition-colors text-left min-w-0"
+							>
+								<span class="truncate text-foreground">{reminder.title}</span>
+								<span class="shrink-0 ml-2 text-xs text-muted-foreground">
+									<LocalTime date={reminder.dueAt} />
+								</span>
+							</button>
+							<form
+								method="POST"
+								action="?/dismiss"
+								use:enhance={() =>
+									async ({ update }) => {
+										await update();
+									}}
+							>
+								<input type="hidden" name="id" value={reminder.id} />
+								<button
+									type="submit"
+									title={t(locale, 'page.dashboard.reminderMarkDone')}
+									aria-label={t(locale, 'page.dashboard.reminderMarkDone')}
+									class="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors shrink-0"
+								>
+									<CheckCheck class="h-3.5 w-3.5" />
+								</button>
+							</form>
+						</div>
 					{/each}
 				{/if}
 			</CardContent>


### PR DESCRIPTION
Closes #29 

## Summary

- Adds a `dismiss` action to the member/admin dashboard (`(app)/(companion)/[companionId]/+page.server.ts`) that delegates to the shared `dismissReminder` helper, so recurring-reminder rollover behaves identically to the reminders page and caretaker dashboard.
- Inline "Done" icon button on each reminder row in the dashboard card (mirrors the caretaker UX), so users can mark a reminder done without navigating to the reminders page.
- "Done" primary button in the reminder detail modal footer alongside Edit, for users who drill into the detail before acting. Closes the modal on submit and reloads via `use:enhance` → `update()`.
- New i18n keys `page.dashboard.reminderDone` / `page.dashboard.reminderMarkDone` added to all six locales (en/it/de/es/fr/pt).