### PR TITLE
Fixed the duplication of recurring Reminders

### DIFF
--- a/drizzle/0005_condemned_rachel_grey.sql
+++ b/drizzle/0005_condemned_rachel_grey.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `reminders` ADD `series_id` text;--> statement-breakpoint
+ALTER TABLE `reminders` ADD `completed_at` integer;--> statement-breakpoint
+ALTER TABLE `reminders` ADD `completed_by` text REFERENCES users(id);--> statement-breakpoint
+CREATE INDEX `reminder_series_due_idx` ON `reminders` (`series_id`,`due_at`);--> statement-breakpoint
+ALTER TABLE `reminders` DROP COLUMN `is_dismissed`;

--- a/drizzle/0005_condemned_rachel_grey.sql
+++ b/drizzle/0005_condemned_rachel_grey.sql
@@ -2,4 +2,7 @@ ALTER TABLE `reminders` ADD `series_id` text;--> statement-breakpoint
 ALTER TABLE `reminders` ADD `completed_at` integer;--> statement-breakpoint
 ALTER TABLE `reminders` ADD `completed_by` text REFERENCES users(id);--> statement-breakpoint
 CREATE INDEX `reminder_series_due_idx` ON `reminders` (`series_id`,`due_at`);--> statement-breakpoint
+-- Backfill: existing recurring reminders each become their own series origin.
+-- Chains will self-heal and link properly on the next completion cycle.
+UPDATE `reminders` SET `series_id` = `id` WHERE `is_recurring` = 1;--> statement-breakpoint
 ALTER TABLE `reminders` DROP COLUMN `is_dismissed`;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1217 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1227ffe1-ea4f-47d2-a924-2bd3d600beb4",
+  "prevId": "8f65942e-1940-49e5-afaf-0e2601b6a796",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_due_at": {
+          "name": "next_due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurring_days": {
+          "name": "recurring_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1775908177456,
       "tag": "0004_hesitant_fat_cobra",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1776254803388,
+      "tag": "0005_condemned_rachel_grey",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/ByLine.svelte
+++ b/src/lib/components/ByLine.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { t, getLocale } from '$lib/i18n';
-	import type { Logger } from '$lib/types';
+	import type { UserRef } from '$lib/types';
 
 	let {
 		user,
 		variant = 'block',
 		class: className = ''
-	}: { user: Logger | undefined; variant?: 'inline' | 'block'; class?: string } = $props();
+	}: { user: UserRef | undefined; variant?: 'inline' | 'block'; class?: string } = $props();
 	const locale = getLocale();
 </script>
 

--- a/src/lib/components/ByLine.svelte
+++ b/src/lib/components/ByLine.svelte
@@ -3,21 +3,21 @@
 	import type { Logger } from '$lib/types';
 
 	let {
-		logger,
+		user,
 		variant = 'block',
 		class: className = ''
-	}: { logger: Logger | undefined; variant?: 'inline' | 'block'; class?: string } = $props();
+	}: { user: Logger | undefined; variant?: 'inline' | 'block'; class?: string } = $props();
 	const locale = getLocale();
 </script>
 
-{#if logger}
+{#if user}
 	{#if variant === 'inline'}
 		<span class="text-muted-foreground text-xs ml-1 {className}"
-			>{t(locale, 'common.loggedBy', { name: logger.displayName })}</span
+			>{t(locale, 'common.loggedBy', { name: user.displayName })}</span
 		>
 	{:else}
 		<p class="text-xs text-muted-foreground opacity-60 {className}">
-			{t(locale, 'common.loggedBy', { name: logger.displayName })}
+			{t(locale, 'common.loggedBy', { name: user.displayName })}
 		</p>
 	{/if}
 {/if}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -127,7 +127,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.noActiveShift': 'Keine aktive Schicht.',
 	'error.notAssignedToCompanion': 'Diesem Begleiter nicht zugewiesen.',
 	'error.canOnlyDeleteOwnEntries': 'Du kannst nur deine eigenen Einträge löschen.',
-	'error.mustBeOnShiftToDismiss': 'Du musst in einer Schicht sein, um Erinnerungen zu schließen.',
+	'error.mustBeOnShiftToComplete': 'Du musst in einer Schicht sein, um Erinnerungen abzuschließen.',
 
 	// Errors: Account
 	'error.displayNameAndUsernameRequired': 'Anzeigename und Benutzername sind erforderlich.',
@@ -561,10 +561,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.detailEveryDays': 'Alle {count} Tag',
 	'page.reminders.detailEveryDaysPlural': 'Alle {count} Tage',
 	'page.reminders.detailNotes': 'Notizen',
-	'page.reminders.dismiss': 'Schließen',
+	'page.reminders.complete': 'Erledigen',
 	'page.reminders.restore': 'Wiederherstellen',
-	'page.reminders.dismissedCount': '{count} geschlossene Erinnerung',
-	'page.reminders.dismissedCountPlural': '{count} geschlossene Erinnerungen',
+	'page.reminders.completedCount': '{count} erledigte Erinnerung',
+	'page.reminders.completedCountPlural': '{count} erledigte Erinnerungen',
 
 	// Page: Admin users
 	'page.admin.usersTitle': 'Benutzer',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -123,7 +123,7 @@ const messages = {
 	'error.noActiveShift': 'No active shift.',
 	'error.notAssignedToCompanion': 'Not assigned to this companion.',
 	'error.canOnlyDeleteOwnEntries': 'You can only delete your own entries.',
-	'error.mustBeOnShiftToDismiss': 'You must be on shift to dismiss reminders.',
+	'error.mustBeOnShiftToComplete': 'You must be on shift to complete reminders.',
 
 	// Errors: Account
 	'error.displayNameAndUsernameRequired': 'Display name and username are required.',
@@ -555,10 +555,10 @@ const messages = {
 	'page.reminders.detailEveryDays': 'Every {count} day',
 	'page.reminders.detailEveryDaysPlural': 'Every {count} days',
 	'page.reminders.detailNotes': 'Notes',
-	'page.reminders.dismiss': 'Dismiss',
+	'page.reminders.complete': 'Complete',
 	'page.reminders.restore': 'Restore',
-	'page.reminders.dismissedCount': '{count} dismissed reminder',
-	'page.reminders.dismissedCountPlural': '{count} dismissed reminders',
+	'page.reminders.completedCount': '{count} completed reminder',
+	'page.reminders.completedCountPlural': '{count} completed reminders',
 
 	// Page: Admin users
 	'page.admin.usersTitle': 'Users',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -126,7 +126,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.noActiveShift': 'No hay turno activo.',
 	'error.notAssignedToCompanion': 'No asignado a este compañero.',
 	'error.canOnlyDeleteOwnEntries': 'Solo puedes eliminar tus propias entradas.',
-	'error.mustBeOnShiftToDismiss': 'Debes estar en turno para descartar recordatorios.',
+	'error.mustBeOnShiftToComplete': 'Debes estar en turno para completar recordatorios.',
 
 	// Errors: Account
 	'error.displayNameAndUsernameRequired':
@@ -559,10 +559,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.detailEveryDays': 'Cada {count} día',
 	'page.reminders.detailEveryDaysPlural': 'Cada {count} días',
 	'page.reminders.detailNotes': 'Notas',
-	'page.reminders.dismiss': 'Descartar',
+	'page.reminders.complete': 'Completar',
 	'page.reminders.restore': 'Restaurar',
-	'page.reminders.dismissedCount': '{count} recordatorio descartado',
-	'page.reminders.dismissedCountPlural': '{count} recordatorios descartados',
+	'page.reminders.completedCount': '{count} recordatorio completado',
+	'page.reminders.completedCountPlural': '{count} recordatorios completados',
 
 	// Page: Admin users
 	'page.admin.usersTitle': 'Usuarios',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -126,7 +126,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.noActiveShift': 'Aucune garde active.',
 	'error.notAssignedToCompanion': 'Non assigné à ce compagnon.',
 	'error.canOnlyDeleteOwnEntries': 'Vous ne pouvez supprimer que vos propres entrées.',
-	'error.mustBeOnShiftToDismiss': 'Vous devez être de garde pour fermer les rappels.',
+	'error.mustBeOnShiftToComplete': 'Vous devez être de garde pour compléter les rappels.',
 
 	// Errors: Account
 	'error.displayNameAndUsernameRequired': "Le nom d'affichage et le nom d'utilisateur sont requis.",
@@ -561,10 +561,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.detailEveryDays': 'Tous les {count} jour',
 	'page.reminders.detailEveryDaysPlural': 'Tous les {count} jours',
 	'page.reminders.detailNotes': 'Notes',
-	'page.reminders.dismiss': 'Fermer',
+	'page.reminders.complete': 'Terminer',
 	'page.reminders.restore': 'Restaurer',
-	'page.reminders.dismissedCount': '{count} rappel fermé',
-	'page.reminders.dismissedCountPlural': '{count} rappels fermés',
+	'page.reminders.completedCount': '{count} rappel terminé',
+	'page.reminders.completedCountPlural': '{count} rappels terminés',
 
 	// Page: Admin users
 	'page.admin.usersTitle': 'Utilisateurs',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -125,7 +125,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.noActiveShift': 'Nessun turno attivo.',
 	'error.notAssignedToCompanion': 'Non assegnato a questo compagno.',
 	'error.canOnlyDeleteOwnEntries': 'Puoi eliminare solo le tue voci.',
-	'error.mustBeOnShiftToDismiss': 'Devi essere in turno per chiudere i promemoria.',
+	'error.mustBeOnShiftToComplete': 'Devi essere in turno per completare i promemoria.',
 
 	// Errors: Account
 	'error.displayNameAndUsernameRequired': 'Nome visualizzato e nome utente sono obbligatori.',
@@ -558,10 +558,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.detailEveryDays': 'Ogni {count} giorno',
 	'page.reminders.detailEveryDaysPlural': 'Ogni {count} giorni',
 	'page.reminders.detailNotes': 'Note',
-	'page.reminders.dismiss': 'Chiudi',
+	'page.reminders.complete': 'Completa',
 	'page.reminders.restore': 'Ripristina',
-	'page.reminders.dismissedCount': '{count} promemoria chiuso',
-	'page.reminders.dismissedCountPlural': '{count} promemoria chiusi',
+	'page.reminders.completedCount': '{count} promemoria completato',
+	'page.reminders.completedCountPlural': '{count} promemoria completati',
 
 	// Page: Admin users
 	'page.admin.usersTitle': 'Utenti',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -126,7 +126,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.noActiveShift': 'Sem turno ativo.',
 	'error.notAssignedToCompanion': 'Não atribuído a este companheiro.',
 	'error.canOnlyDeleteOwnEntries': 'Só pode eliminar as suas próprias entradas.',
-	'error.mustBeOnShiftToDismiss': 'Deve estar em turno para dispensar lembretes.',
+	'error.mustBeOnShiftToComplete': 'Deve estar em turno para completar lembretes.',
 
 	// Errors: Account
 	'error.displayNameAndUsernameRequired':
@@ -559,10 +559,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.detailEveryDays': 'A cada {count} dia',
 	'page.reminders.detailEveryDaysPlural': 'A cada {count} dias',
 	'page.reminders.detailNotes': 'Notas',
-	'page.reminders.dismiss': 'Dispensar',
+	'page.reminders.complete': 'Completar',
 	'page.reminders.restore': 'Restaurar',
-	'page.reminders.dismissedCount': '{count} lembrete dispensado',
-	'page.reminders.dismissedCountPlural': '{count} lembretes dispensados',
+	'page.reminders.completedCount': '{count} lembrete completado',
+	'page.reminders.completedCountPlural': '{count} lembretes completados',
 
 	// Page: Admin users
 	'page.admin.usersTitle': 'Utilizadores',

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -226,7 +226,9 @@ export const reminders = sqliteTable(
 		dueAt: integer('due_at', { mode: 'timestamp' }).notNull(),
 		isRecurring: integer('is_recurring', { mode: 'boolean' }).notNull().default(false),
 		recurringDays: integer('recurring_days'),
-		isDismissed: integer('is_dismissed', { mode: 'boolean' }).notNull().default(false),
+		seriesId: text('series_id'),
+		completedAt: integer('completed_at', { mode: 'timestamp' }),
+		completedBy: text('completed_by').references(() => users.id, { onDelete: 'set null' }),
 		createdAt: integer('created_at', { mode: 'timestamp' })
 			.notNull()
 			.default(sql`(unixepoch())`),
@@ -234,7 +236,8 @@ export const reminders = sqliteTable(
 	},
 	(t) => ({
 		companionIdx: index('reminder_companion_idx').on(t.companionId),
-		dueIdx: index('reminder_due_idx').on(t.dueAt)
+		dueIdx: index('reminder_due_idx').on(t.dueAt),
+		seriesDueIdx: index('reminder_series_due_idx').on(t.seriesId, t.dueAt)
 	})
 );
 
@@ -305,7 +308,8 @@ export const usersRelations = relations(users, ({ many }) => ({
 	loggedDailyEvents: many(dailyEvents),
 	loggedHealthEvents: many(healthEvents),
 	loggedWeightEntries: many(weightEntries),
-	loggedReminders: many(reminders)
+	loggedReminders: many(reminders, { relationName: 'reminderLogger' }),
+	completedReminders: many(reminders, { relationName: 'reminderCompleter' })
 }));
 
 export const companionCaretakersRelations = relations(companionCaretakers, ({ one }) => ({
@@ -346,5 +350,14 @@ export const weightEntriesRelations = relations(weightEntries, ({ one }) => ({
 }));
 
 export const remindersRelations = relations(reminders, ({ one }) => ({
-	logger: one(users, { fields: [reminders.loggedBy], references: [users.id] })
+	logger: one(users, {
+		fields: [reminders.loggedBy],
+		references: [users.id],
+		relationName: 'reminderLogger'
+	}),
+	completer: one(users, {
+		fields: [reminders.completedBy],
+		references: [users.id],
+		relationName: 'reminderCompleter'
+	})
 }));

--- a/src/lib/server/journal.ts
+++ b/src/lib/server/journal.ts
@@ -3,7 +3,7 @@ import { eq, lt, gte, and, inArray } from 'drizzle-orm';
 import { localDateISO } from '$lib/date';
 import { generateId } from '$lib/server/utils';
 import type { Mood } from '$lib/server/validation';
-import type { Logger } from '$lib/types';
+import type { UserRef } from '$lib/types';
 
 const PAGE_SIZE = 20;
 
@@ -27,14 +27,14 @@ export async function getEnrichedJournalEntries(
 	const hasMore = entries.length > pageSize;
 	const pageEntries = entries.slice(0, pageSize);
 
-	type EventWithLogger = typeof schema.dailyEvents.$inferSelect & {
-		logger: Logger;
+	type EventWithUserRef = typeof schema.dailyEvents.$inferSelect & {
+		logger: UserRef;
 	};
-	type PhotoWithLogger = typeof schema.journalPhotos.$inferSelect & {
-		logger: Logger;
+	type PhotoWithUserRef = typeof schema.journalPhotos.$inferSelect & {
+		logger: UserRef;
 	};
-	let photosByEntry = new Map<string, PhotoWithLogger[]>();
-	let eventsByDate = new Map<string, EventWithLogger[]>();
+	let photosByEntry = new Map<string, PhotoWithUserRef[]>();
+	let eventsByDate = new Map<string, EventWithUserRef[]>();
 
 	if (pageEntries.length > 0) {
 		const entryIds = pageEntries.map((e) => e.id);

--- a/src/lib/server/reminders.ts
+++ b/src/lib/server/reminders.ts
@@ -2,29 +2,33 @@ import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 
-export async function completeReminder(
+export function completeReminder(
 	reminder: typeof schema.reminders.$inferSelect,
 	userId: string
-): Promise<void> {
-	await db
-		.update(schema.reminders)
-		.set({ completedAt: new Date(), completedBy: userId })
-		.where(eq(schema.reminders.id, reminder.id));
+): void {
+	db.transaction((tx) => {
+		tx.update(schema.reminders)
+			.set({ completedAt: new Date(), completedBy: userId })
+			.where(eq(schema.reminders.id, reminder.id))
+			.run();
 
-	if (reminder.isRecurring && reminder.recurringDays && reminder.recurringDays > 0) {
-		const nextDueAt = new Date(reminder.dueAt);
-		nextDueAt.setDate(nextDueAt.getDate() + reminder.recurringDays);
-		await db.insert(schema.reminders).values({
-			id: generateId(15),
-			companionId: reminder.companionId,
-			title: reminder.title,
-			description: reminder.description,
-			type: reminder.type,
-			dueAt: nextDueAt,
-			isRecurring: true,
-			recurringDays: reminder.recurringDays,
-			seriesId: reminder.seriesId ?? reminder.id,
-			loggedBy: reminder.loggedBy
-		});
-	}
+		if (reminder.isRecurring && reminder.recurringDays && reminder.recurringDays > 0) {
+			const nextDueAt = new Date(reminder.dueAt);
+			nextDueAt.setDate(nextDueAt.getDate() + reminder.recurringDays);
+			tx.insert(schema.reminders)
+				.values({
+					id: generateId(15),
+					companionId: reminder.companionId,
+					title: reminder.title,
+					description: reminder.description,
+					type: reminder.type,
+					dueAt: nextDueAt,
+					isRecurring: true,
+					recurringDays: reminder.recurringDays,
+					seriesId: reminder.seriesId ?? reminder.id,
+					loggedBy: reminder.loggedBy
+				})
+				.run();
+		}
+	});
 }

--- a/src/lib/server/reminders.ts
+++ b/src/lib/server/reminders.ts
@@ -2,12 +2,13 @@ import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 
-export async function dismissReminder(
-	reminder: typeof schema.reminders.$inferSelect
+export async function completeReminder(
+	reminder: typeof schema.reminders.$inferSelect,
+	userId: string
 ): Promise<void> {
 	await db
 		.update(schema.reminders)
-		.set({ isDismissed: true })
+		.set({ completedAt: new Date(), completedBy: userId })
 		.where(eq(schema.reminders.id, reminder.id));
 
 	if (reminder.isRecurring && reminder.recurringDays && reminder.recurringDays > 0) {
@@ -22,6 +23,7 @@ export async function dismissReminder(
 			dueAt: nextDueAt,
 			isRecurring: true,
 			recurringDays: reminder.recurringDays,
+			seriesId: reminder.seriesId ?? reminder.id,
 			loggedBy: reminder.loggedBy
 		});
 	}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,2 +1,2 @@
-/** Lightweight author info attached to loggable entities via Drizzle's `with: { logger }` relation. */
-export type Logger = { displayName: string } | null;
+/** Lightweight user info attached to entities via Drizzle relations (logger, completer, etc.). */
+export type UserRef = { displayName: string } | null;

--- a/src/routes/(app)/(companion)/[companionId]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/+page.server.ts
@@ -101,7 +101,7 @@ export const actions: Actions = {
 		});
 		if (!existing) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 
-		await completeReminder(existing, locals.user.id);
+		completeReminder(existing, locals.user.id);
 
 		return { completeSuccess: true };
 	}

--- a/src/routes/(app)/(companion)/[companionId]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/+page.server.ts
@@ -2,9 +2,9 @@ import { fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
-import { eq, gte, and, lte } from 'drizzle-orm';
+import { eq, gte, and, lte, isNull } from 'drizzle-orm';
 import { localDateISO } from '$lib/date';
-import { dismissReminder } from '$lib/server/reminders';
+import { completeReminder } from '$lib/server/reminders';
 
 export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -35,7 +35,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		db.query.reminders.findMany({
 			where: and(
 				eq(schema.reminders.companionId, params.companionId),
-				eq(schema.reminders.isDismissed, false)
+				isNull(schema.reminders.completedAt)
 			),
 			orderBy: (r, { asc }) => [asc(r.dueAt)],
 			limit: 5,
@@ -90,7 +90,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 };
 
 export const actions: Actions = {
-	dismiss: async ({ request, params, locals }) => {
+	complete: async ({ request, params, locals }) => {
 		if (!locals.user) return fail(401, { error: t(locals.locale, 'error.unauthorized') });
 
 		const data = await request.formData();
@@ -101,8 +101,8 @@ export const actions: Actions = {
 		});
 		if (!existing) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 
-		await dismissReminder(existing);
+		await completeReminder(existing, locals.user.id);
 
-		return { dismissSuccess: true };
+		return { completeSuccess: true };
 	}
 };

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData } from './$types';
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import LoggedBy from '$lib/components/LoggedBy.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
 	import { localDateISO } from '$lib/date';
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -249,7 +249,7 @@
 							</div>
 						</div>
 					{/if}
-					<LoggedBy logger={r.logger} />
+					<ByLine user={r.logger} />
 				{:else if selected.kind === 'weight'}
 					{@const w = selected.item}
 					<div class="flex items-center gap-3">
@@ -266,8 +266,8 @@
 							>{t(locale, 'page.dashboard.modalLabelRecorded')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={w.recordedAt} format="datetime" /><LoggedBy
-								logger={w.logger}
+							><LocalTime date={w.recordedAt} format="datetime" /><ByLine
+								user={w.logger}
 								variant="inline"
 							/></span
 						>
@@ -295,8 +295,8 @@
 							>{t(locale, 'page.dashboard.modalLabelLogged')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={e.loggedAt} format="datetime" /><LoggedBy
-								logger={e.logger}
+							><LocalTime date={e.loggedAt} format="datetime" /><ByLine
+								user={e.logger}
 								variant="inline"
 							/></span
 						>
@@ -332,8 +332,8 @@
 							>{t(locale, 'page.dashboard.modalLabelDate')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={h.occurredAt} format="datetime" /><LoggedBy
-								logger={h.logger}
+							><LocalTime date={h.occurredAt} format="datetime" /><ByLine
+								user={h.logger}
 								variant="inline"
 							/></span
 						>
@@ -386,7 +386,7 @@
 						</Button>
 						<form
 							method="POST"
-							action="?/dismiss"
+							action="?/complete"
 							use:enhance={() =>
 								async ({ update }) => {
 									closeDetail();
@@ -597,7 +597,7 @@
 							</button>
 							<form
 								method="POST"
-								action="?/dismiss"
+								action="?/complete"
 								use:enhance={() =>
 									async ({ update }) => {
 										await update();
@@ -732,7 +732,7 @@
 							{#if event.logger}
 								<div class="flex items-center gap-3 text-sm">
 									<span class="w-24 shrink-0"></span>
-									<LoggedBy logger={event.logger} />
+									<ByLine user={event.logger} />
 								</div>
 							{/if}
 						</button>
@@ -784,7 +784,7 @@
 							{#if event.logger}
 								<div class="flex items-center gap-3 text-sm">
 									<span class="w-24 shrink-0"></span>
-									<LoggedBy logger={event.logger} />
+									<ByLine user={event.logger} />
 								</div>
 							{/if}
 						</button>

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -3,7 +3,7 @@
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import { enhance } from '$app/forms';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import LoggedBy from '$lib/components/LoggedBy.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -176,8 +176,8 @@
 							>{t(locale, 'page.health.detailRecorded')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={w.recordedAt} format="datetime" /><LoggedBy
-								logger={w.logger}
+							><LocalTime date={w.recordedAt} format="datetime" /><ByLine
+								user={w.logger}
 								variant="inline"
 							/></span
 						>
@@ -205,8 +205,8 @@
 							>{t(locale, 'page.health.detailDate')}</span
 						>
 						<span class="text-foreground"
-							><LocalTime date={h.occurredAt} format="datetime" /><LoggedBy
-								logger={h.logger}
+							><LocalTime date={h.occurredAt} format="datetime" /><ByLine
+								user={h.logger}
 								variant="inline"
 							/></span
 						>
@@ -636,7 +636,7 @@
 									<span class="truncate block"
 										>{entry.notes ? entry.notes.replace(/[#*_`~>[\]]/g, '').trim() : ''}</span
 									>
-									<LoggedBy logger={entry.logger} />
+									<ByLine user={entry.logger} />
 								</div>
 							</button>
 							{#if data.companion.isActive !== false}
@@ -834,7 +834,7 @@
 												<LocalTime date={event.nextDueAt} />
 											</p>
 										{/if}
-										<LoggedBy logger={event.logger} class="mt-0.5" />
+										<ByLine user={event.logger} class="mt-0.5" />
 									</div>
 								</button>
 								{#if data.companion.isActive !== false}

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -15,7 +15,7 @@
 		Download
 	} from '@lucide/svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import LoggedBy from '$lib/components/LoggedBy.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
 	import { tick } from 'svelte';
 	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { t, getLocale } from '$lib/i18n';
@@ -285,7 +285,7 @@
 			{/if}
 			{#if lightboxPhoto.logger}
 				<div class="mt-2 flex justify-center">
-					<LoggedBy logger={lightboxPhoto.logger} variant="inline" class="!text-white/60 !ml-0" />
+					<ByLine user={lightboxPhoto.logger} variant="inline" class="!text-white/60 !ml-0" />
 				</div>
 			{/if}
 		</div>
@@ -338,8 +338,8 @@
 						>{t(locale, 'page.journal.activityDetailLogged')}</span
 					>
 					<span class="text-foreground"
-						><LocalTime date={detailEvent.loggedAt} format="datetime" /><LoggedBy
-							logger={detailEvent.logger}
+						><LocalTime date={detailEvent.loggedAt} format="datetime" /><ByLine
+							user={detailEvent.logger}
 							variant="inline"
 						/></span
 					>
@@ -455,7 +455,7 @@
 											>{t(locale, 'page.journal.today')}</span
 										>
 									{/if}
-									<LoggedBy logger={entry.logger} variant="inline" class="ml-0" />
+									<ByLine user={entry.logger} variant="inline" class="ml-0" />
 								</div>
 							</div>
 							{#if companion.isActive !== false}

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -27,7 +27,7 @@
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import LoggedBy from '$lib/components/LoggedBy.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
 	import { SvelteDate } from 'svelte/reactivity';
 	import { localDatetimes } from '$lib/actions/localDatetimes';
 	import { t, getLocale } from '$lib/i18n';
@@ -347,8 +347,8 @@
 						>{t(locale, 'page.journal.day.detailLogged')}</span
 					>
 					<span class="text-foreground"
-						><LocalTime date={detailEvent.loggedAt} format="datetime" /><LoggedBy
-							logger={detailEvent.logger}
+						><LocalTime date={detailEvent.loggedAt} format="datetime" /><ByLine
+							user={detailEvent.logger}
 							variant="inline"
 						/></span
 					>
@@ -462,7 +462,7 @@
 				>
 			{/if}
 		</div>
-		<LoggedBy logger={data.entry?.logger} variant="inline" class="ml-0" />
+		<ByLine user={data.entry?.logger} variant="inline" class="ml-0" />
 	</div>
 
 	<!-- Mood -->
@@ -727,7 +727,7 @@
 												>{t(locale, 'page.journal.day.editCaption')}</button
 											>
 										{/if}
-										<LoggedBy logger={photo.logger} variant="inline" />
+										<ByLine user={photo.logger} variant="inline" />
 									</div>
 								{/if}
 							</div>
@@ -996,7 +996,7 @@
 											...(serverTimezone ? { timeZone: serverTimezone } : {})
 										})}</span
 									>
-									<LoggedBy logger={event.logger} />
+									<ByLine user={event.logger} />
 								</div>
 							</button>
 							<button

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.server.ts
@@ -102,7 +102,7 @@ export const actions: Actions = {
 		});
 		if (!existing) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 
-		await completeReminder(existing, locals.user.id);
+		completeReminder(existing, locals.user.id);
 
 		// Prune completed non-recurring reminders older than 30 days
 		const thirtyDaysAgo = new Date();
@@ -132,22 +132,24 @@ export const actions: Actions = {
 		});
 		if (!existing) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 
-		await db
-			.update(schema.reminders)
-			.set({ completedAt: null, completedBy: null })
-			.where(eq(schema.reminders.id, id));
+		db.transaction((tx) => {
+			tx.update(schema.reminders)
+				.set({ completedAt: null, completedBy: null })
+				.where(eq(schema.reminders.id, id))
+				.run();
 
-		// If recurring, delete all future instances in this series
-		if (existing.isRecurring && existing.seriesId) {
-			await db
-				.delete(schema.reminders)
-				.where(
-					and(
-						eq(schema.reminders.seriesId, existing.seriesId),
-						gt(schema.reminders.dueAt, existing.dueAt)
+			// If recurring, delete all future instances in this series
+			if (existing.isRecurring && existing.seriesId) {
+				tx.delete(schema.reminders)
+					.where(
+						and(
+							eq(schema.reminders.seriesId, existing.seriesId),
+							gt(schema.reminders.dueAt, existing.dueAt)
+						)
 					)
-				);
-		}
+					.run();
+			}
+		});
 
 		return { restoreSuccess: true };
 	},

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.server.ts
@@ -2,10 +2,10 @@ import { fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
-import { eq, and, lt } from 'drizzle-orm';
+import { eq, and, lt, gt, isNotNull } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 import { parseReminderType } from '$lib/server/validation';
-import { dismissReminder } from '$lib/server/reminders';
+import { completeReminder } from '$lib/server/reminders';
 
 export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -14,7 +14,10 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	const reminders = await db.query.reminders.findMany({
 		where: eq(schema.reminders.companionId, params.companionId),
 		orderBy: (r, { asc }) => [asc(r.dueAt)],
-		with: { logger: { columns: { displayName: true } } }
+		with: {
+			logger: { columns: { displayName: true } },
+			completer: { columns: { displayName: true } }
+		}
 	});
 
 	return { companion, reminders };
@@ -35,8 +38,9 @@ export const actions: Actions = {
 		if (isNaN(dueAt.getTime()))
 			return fail(400, { error: t(locals.locale, 'error.validDueDateRequired') });
 
+		const id = generateId(15);
 		await db.insert(schema.reminders).values({
-			id: generateId(15),
+			id,
 			companionId: params.companionId,
 			title,
 			description,
@@ -44,6 +48,7 @@ export const actions: Actions = {
 			dueAt,
 			isRecurring,
 			recurringDays: recurringDays && recurringDays > 0 ? recurringDays : null,
+			seriesId: isRecurring ? id : null,
 			loggedBy: locals.user.id
 		});
 
@@ -87,7 +92,7 @@ export const actions: Actions = {
 		return { updateSuccess: true };
 	},
 
-	dismiss: async ({ request, params, locals }) => {
+	complete: async ({ request, params, locals }) => {
 		if (!locals.user) return fail(401, { error: t(locals.locale, 'error.unauthorized') });
 		const data = await request.formData();
 		const id = String(data.get('id') ?? '');
@@ -97,9 +102,9 @@ export const actions: Actions = {
 		});
 		if (!existing) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 
-		await dismissReminder(existing);
+		await completeReminder(existing, locals.user.id);
 
-		// Prune dismissed non-recurring reminders older than 30 days
+		// Prune completed non-recurring reminders older than 30 days
 		const thirtyDaysAgo = new Date();
 		thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 		await db
@@ -107,32 +112,44 @@ export const actions: Actions = {
 			.where(
 				and(
 					eq(schema.reminders.companionId, params.companionId),
-					eq(schema.reminders.isDismissed, true),
+					isNotNull(schema.reminders.completedAt),
 					eq(schema.reminders.isRecurring, false),
 					lt(schema.reminders.createdAt, thirtyDaysAgo)
 				)
 			);
 
-		return { dismissSuccess: true };
+		return { completeSuccess: true };
 	},
 
-	undismiss: async ({ request, params, locals }) => {
+	restore: async ({ request, params, locals }) => {
 		if (!locals.user) return fail(401, { error: t(locals.locale, 'error.unauthorized') });
 		const data = await request.formData();
 		const id = String(data.get('id') ?? '');
 		if (!id) return fail(400, { error: t(locals.locale, 'error.missingId') });
 
 		const existing = await db.query.reminders.findFirst({
-			where: and(eq(schema.reminders.id, id), eq(schema.reminders.companionId, params.companionId)),
-			columns: { id: true }
+			where: and(eq(schema.reminders.id, id), eq(schema.reminders.companionId, params.companionId))
 		});
 		if (!existing) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 
 		await db
 			.update(schema.reminders)
-			.set({ isDismissed: false })
+			.set({ completedAt: null, completedBy: null })
 			.where(eq(schema.reminders.id, id));
-		return { undismissSuccess: true };
+
+		// If recurring, delete all future instances in this series
+		if (existing.isRecurring && existing.seriesId) {
+			await db
+				.delete(schema.reminders)
+				.where(
+					and(
+						eq(schema.reminders.seriesId, existing.seriesId),
+						gt(schema.reminders.dueAt, existing.dueAt)
+					)
+				);
+		}
+
+		return { restoreSuccess: true };
 	},
 
 	delete: async ({ request, params, locals }) => {

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData, ActionData } from './$types';
 	import { enhance } from '$app/forms';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import LoggedBy from '$lib/components/LoggedBy.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import { renderMarkdown } from '$lib/markdown';
 	import { Card, CardContent } from '$lib/components/ui/card/index.js';
@@ -13,7 +13,7 @@
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Select } from '$lib/components/ui/select/index.js';
 	import { Separator } from '$lib/components/ui/separator/index.js';
-	import { Plus, Pencil, Trash2, BellOff, RotateCcw, X } from '@lucide/svelte';
+	import { Plus, Pencil, Trash2, Check, RotateCcw, X } from '@lucide/svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import { tick } from 'svelte';
 	import { page } from '$app/state';
@@ -29,8 +29,8 @@
 
 	const REMINDER_TYPES = reminderTypeOptions(locale);
 
-	let active = $derived(data.reminders.filter((r) => !r.isDismissed));
-	let dismissed = $derived(data.reminders.filter((r) => r.isDismissed));
+	let active = $derived(data.reminders.filter((r) => !r.completedAt));
+	let completed = $derived(data.reminders.filter((r) => r.completedAt));
 
 	function isOverdue(dueAt: Date | string) {
 		return new Date(dueAt) < new Date();
@@ -71,7 +71,7 @@
 	// Detail modal
 	let selected = $state<(typeof data.reminders)[0] | null>(null);
 	let dialogEl = $state<HTMLElement | null>(null);
-	let modalDismissForm = $state<HTMLFormElement | null>(null);
+	let modalCompleteForm = $state<HTMLFormElement | null>(null);
 
 	async function openDetail(reminder: (typeof data.reminders)[0]) {
 		selected = reminder;
@@ -187,7 +187,7 @@
 						</div>
 					</div>
 				{/if}
-				<LoggedBy logger={r.logger} />
+				<ByLine user={r.logger} />
 			</div>
 
 			<Separator />
@@ -213,11 +213,11 @@
 						size="sm"
 						onclick={() => {
 							closeDetail();
-							modalDismissForm?.requestSubmit();
+							modalCompleteForm?.requestSubmit();
 						}}
 					>
-						<BellOff class="h-3.5 w-3.5 mr-1.5" />
-						{t(locale, 'page.reminders.dismiss')}
+						<Check class="h-3.5 w-3.5 mr-1.5" />
+						{t(locale, 'page.reminders.complete')}
 					</Button>
 					<Button
 						variant="destructive"
@@ -236,8 +236,8 @@
 			{/if}
 		</div>
 	</div>
-	<!-- Hidden dismiss form for modal action -->
-	<form bind:this={modalDismissForm} method="POST" action="?/dismiss" use:enhance class="hidden">
+	<!-- Hidden complete form for modal action -->
+	<form bind:this={modalCompleteForm} method="POST" action="?/complete" use:enhance class="hidden">
 		<input type="hidden" name="id" value={r.id} />
 	</form>
 {/if}
@@ -514,8 +514,8 @@
 										<p
 											class="text-xs mt-1 {overdue ? 'text-destructive' : 'text-muted-foreground'}"
 										>
-											Due <LocalTime date={reminder.dueAt} format="datetime" /><LoggedBy
-												logger={reminder.logger}
+											Due <LocalTime date={reminder.dueAt} format="datetime" /><ByLine
+												user={reminder.logger}
 												variant="inline"
 											/>
 										</p>
@@ -533,7 +533,7 @@
 											<Pencil class="h-3.5 w-3.5" />
 											<span class="hidden sm:inline">{t(locale, 'common.edit')}</span>
 										</Button>
-										<form method="POST" action="?/dismiss" use:enhance>
+										<form method="POST" action="?/complete" use:enhance>
 											<input type="hidden" name="id" value={reminder.id} />
 											<Button
 												type="submit"
@@ -541,8 +541,8 @@
 												size="sm"
 												class="h-7 gap-1.5 px-2 text-xs"
 											>
-												<BellOff class="h-3.5 w-3.5" />
-												<span class="hidden sm:inline">{t(locale, 'page.reminders.dismiss')}</span>
+												<Check class="h-3.5 w-3.5" />
+												<span class="hidden sm:inline">{t(locale, 'page.reminders.complete')}</span>
 											</Button>
 										</form>
 										<Button
@@ -568,15 +568,15 @@
 		</div>
 	{/if}
 
-	{#if dismissed.length > 0}
+	{#if completed.length > 0}
 		<details>
 			<summary class="cursor-pointer text-sm select-none hover:opacity-80 text-muted-foreground">
-				{dismissed.length !== 1
-					? t(locale, 'page.reminders.dismissedCountPlural', { count: dismissed.length })
-					: t(locale, 'page.reminders.dismissedCount', { count: dismissed.length })}
+				{completed.length !== 1
+					? t(locale, 'page.reminders.completedCountPlural', { count: completed.length })
+					: t(locale, 'page.reminders.completedCount', { count: completed.length })}
 			</summary>
 			<div class="mt-3 space-y-2">
-				{#each dismissed as reminder (reminder.id)}
+				{#each completed as reminder (reminder.id)}
 					<Card class={editingId !== reminder.id ? 'opacity-60' : ''}>
 						{#if editingId === reminder.id}
 							<CardContent class="pt-6">
@@ -694,6 +694,9 @@
 										<span class="text-xs text-muted-foreground"
 											><LocalTime date={reminder.dueAt} /></span
 										>
+										{#if reminder.completer}
+											<ByLine user={reminder.completer} variant="inline" />
+										{/if}
 									</div>
 									<div class="flex gap-1 shrink-0">
 										<Button
@@ -706,7 +709,7 @@
 											<Pencil class="h-3.5 w-3.5" />
 											<span class="hidden sm:inline">{t(locale, 'common.edit')}</span>
 										</Button>
-										<form method="POST" action="?/undismiss" use:enhance>
+										<form method="POST" action="?/restore" use:enhance>
 											<input type="hidden" name="id" value={reminder.id} />
 											<Button
 												type="submit"

--- a/src/routes/(caretaker)/care/[companionId]/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/+page.server.ts
@@ -105,7 +105,7 @@ export const actions: Actions = {
 		});
 		if (!existing) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 
-		await completeReminder(existing, locals.user.id);
+		completeReminder(existing, locals.user.id);
 
 		return { completeSuccess: true };
 	}

--- a/src/routes/(caretaker)/care/[companionId]/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/+page.server.ts
@@ -2,9 +2,9 @@ import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
-import { eq, and, ne, gte } from 'drizzle-orm';
+import { eq, and, ne, gte, isNull } from 'drizzle-orm';
 import { getShiftStatus } from '$lib/server/shifts';
-import { dismissReminder } from '$lib/server/reminders';
+import { completeReminder } from '$lib/server/reminders';
 
 export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	const { companions } = await parent();
@@ -62,7 +62,7 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 		db.query.reminders.findMany({
 			where: and(
 				eq(schema.reminders.companionId, params.companionId),
-				eq(schema.reminders.isDismissed, false)
+				isNull(schema.reminders.completedAt)
 			),
 			orderBy: (r, { asc }) => [asc(r.dueAt)],
 			with: { logger: { columns: { displayName: true } } }
@@ -91,11 +91,11 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 };
 
 export const actions: Actions = {
-	dismiss: async ({ request, params, locals }) => {
+	complete: async ({ request, params, locals }) => {
 		if (!locals.user) return fail(401, { error: t(locals.locale, 'error.unauthorized') });
 
 		const { isOnShift } = await getShiftStatus(locals.user.id);
-		if (!isOnShift) return fail(403, { error: t(locals.locale, 'error.mustBeOnShiftToDismiss') });
+		if (!isOnShift) return fail(403, { error: t(locals.locale, 'error.mustBeOnShiftToComplete') });
 
 		const data = await request.formData();
 		const id = String(data.get('id') ?? '');
@@ -105,8 +105,8 @@ export const actions: Actions = {
 		});
 		if (!existing) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 
-		await dismissReminder(existing);
+		await completeReminder(existing, locals.user.id);
 
-		return { dismissSuccess: true };
+		return { completeSuccess: true };
 	}
 };

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData } from './$types';
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import LoggedBy from '$lib/components/LoggedBy.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
 	import { Card, CardHeader, CardContent, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Phone, Mail, X, Bell, CheckCheck } from '@lucide/svelte';
@@ -225,8 +225,8 @@
 						>{t(locale, 'page.dashboard.caretaker.modalLabelLogged')}</span
 					>
 					<span class="text-foreground"
-						><LocalTime date={selected.loggedAt} format="datetime" /><LoggedBy
-							logger={selected.logger}
+						><LocalTime date={selected.loggedAt} format="datetime" /><ByLine
+							user={selected.logger}
 							variant="inline"
 						/></span
 					>
@@ -326,7 +326,7 @@
 						</div>
 					</div>
 				{/if}
-				<LoggedBy logger={selectedReminder.logger} />
+				<ByLine user={selectedReminder.logger} />
 			</div>
 
 			<Separator />
@@ -334,7 +334,7 @@
 			<div class="flex gap-2 px-5 py-4">
 				<form
 					method="POST"
-					action="?/dismiss"
+					action="?/complete"
 					use:enhance={() =>
 						async ({ update }) => {
 							closeReminderDetail();
@@ -514,7 +514,7 @@
 							</button>
 							<form
 								method="POST"
-								action="?/dismiss"
+								action="?/complete"
 								use:enhance={() =>
 									async ({ update }) => {
 										await update();
@@ -689,7 +689,7 @@
 									<LocalTime date={event.loggedAt} format="time" />
 								</span>
 							</div>
-							<LoggedBy logger={event.logger} class="pl-8" />
+							<ByLine user={event.logger} class="pl-8" />
 						</button>
 					{/each}
 				</div>

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -4,7 +4,7 @@
 	import { canModifyPhoto } from '$lib/permissions';
 	import { Trash2 } from '@lucide/svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import LoggedBy from '$lib/components/LoggedBy.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
 	import { untrack } from 'svelte';
 	import { Card, CardHeader, CardContent } from '$lib/components/ui/card/index.js';
 	import { t, getLocale } from '$lib/i18n';
@@ -202,7 +202,7 @@
 					>
 				{/if}
 			</span>
-			<LoggedBy logger={data.todayEntry?.logger} variant="inline" />
+			<ByLine user={data.todayEntry?.logger} variant="inline" />
 		</div>
 
 		<!-- Mood -->
@@ -384,7 +384,7 @@
 													{t(locale, 'page.journal.caretaker.editCaption')}
 												</button>
 											{/if}
-											<LoggedBy logger={photo.logger} variant="inline" />
+											<ByLine user={photo.logger} variant="inline" />
 										</div>
 									{/if}
 								</div>

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData, ActionData } from './$types';
 	import { enhance } from '$app/forms';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import LoggedBy from '$lib/components/LoggedBy.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import { Card, CardHeader, CardContent } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -221,7 +221,7 @@
 								</div>
 								<div class="text-xs shrink-0 text-muted-foreground text-right">
 									<LocalTime date={event.loggedAt} format="time" />
-									<LoggedBy logger={event.logger} />
+									<ByLine user={event.logger} />
 								</div>
 								{#if event.loggedBy === data.user?.id}
 									<form


### PR DESCRIPTION
Closes #34 

## Summary
Note: Sorry, the scope on this one grew a little bit once I started working on the fix. But all for the better, I believe!

- **Fix:** Dismissing then restoring a recurring reminder no longer creates duplicate entries. Added a `series_id` column to link recurring reminder instances, so the restore action can reliably find and delete all future instances spawned from the dismiss chain.
- **Schema:** Replaced `is_dismissed` (boolean) with `completed_at` (timestamp) and `completed_by` (FK to users) for a proper audit trail of who completed each reminder and when.
- **Rename:** Updated all "dismiss" nomenclature to "complete" across server actions, i18n keys, translations, and UI elements. Icon changed from BellOff to Check.
- **Refactor:** Renamed `LoggedBy` component to `ByLine` with a `user` prop, better reflecting its general-purpose usage for both loggers and completers.
- **Backfill:** Existing recurring reminders are backfilled with `series_id` during migration. Each existing row becomes its own series origin; chains will self-heal and link properly on the next completion cycle.

## Migration

- Adds `series_id`, `completed_at`, `completed_by` columns to `reminders`
- Backfills existing recurring reminders `series_id` to allow for self-healing
- Drops `is_dismissed` column
- Adds composite index on `(series_id, due_at)`