### PR TITLE
Add optional OIDC implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,55 @@ ORIGIN=https://einvault.yourdomain.com
 # Override the database path inside the container (rarely needed).
 # Defaults to /data/einvault.db, which maps to EINVAULT_DATA on the host.
 # DATABASE_URL=/data/einvault.db
+
+# Optional: OIDC authentication
+#
+# Enable single sign-on via any OpenID Connect provider (Authelia, Authentik,
+# Keycloak, PocketID, Dex, etc.). All variables are optional; OIDC is disabled
+# unless OIDC_ISSUER_URL, OIDC_CLIENT_ID, and OIDC_REDIRECT_URI are all set.
+
+# Issuer URL of your OpenID Connect provider (the URL of the .well-known endpoint root).
+# OIDC_ISSUER_URL=https://auth.example.com
+
+# OAuth 2.0 client ID registered with your provider.
+# OIDC_CLIENT_ID=einvault
+
+# OAuth 2.0 client secret. Omit or leave empty for public clients (PKCE only).
+# OIDC_CLIENT_SECRET=
+
+# Redirect URI that your provider will send users back to after authentication.
+# Must exactly match what is registered with the IdP.
+# OIDC_REDIRECT_URI=https://einvault.yourdomain.com/auth/oidc/callback
+
+# Space-separated list of OAuth scopes to request (default: openid profile email).
+# OIDC_SCOPES=openid profile email
+
+# Label shown on the "Sign in with …" button on the login page (default: SSO).
+# OIDC_PROVIDER_NAME=SSO
+
+# Allow users without an existing EinVault account to be created automatically
+# on first OIDC login (default: false). Enable with caution — anyone who can
+# authenticate with your IdP will get an account.
+# OIDC_ALLOW_SIGNUP=false
+
+# Default role assigned to auto-created users (default: member).
+# Allowed values: member | caretaker
+# Admin cannot be assigned via this env variable.
+# OIDC_DEFAULT_ROLE=member
+
+# Comma-separated list of IdP group names that grant the admin role.
+# Checked on every login; role is updated if group membership changes.
+# Read from the top-level `groups` claim (array of strings) in the ID token.
+# Configure your IdP to emit `groups` directly; nested or alternate claim
+# names (e.g. Keycloak's `realm_access.roles`) are not supported.
+# OIDC_ADMIN_GROUPS=einvault-admins,sysadmins
+
+# If set, users are redirected here after logout when the IdP advertises an
+# end_session_endpoint. Must be a URL registered as a post-logout redirect URI
+# with your provider.
+# OIDC_POST_LOGOUT_REDIRECT_URI=https://einvault.yourdomain.com/auth/login
+
+# Secret used to sign the OIDC state cookie (HMAC-SHA256).
+# If absent, an ephemeral key is generated at startup — in-flight logins will
+# break across server restarts. Pin this value for stable behaviour.
+# OIDC_STATE_SECRET=a-long-random-string-here

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - issue-43-oidc
     tags:
       - 'v*'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - issue-43-oidc
     tags:
       - 'v*'
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ EinVault is a private, self-hosted companion health and care tracker built for h
 - [Local development](#local-development)
   - [Commands](#commands)
 - [User management](#user-management)
+- [OIDC / SSO (optional)](#oidc--sso-optional)
+  - [Required variables](#required-variables)
+  - [Optional variables](#optional-variables)
+  - [Account linking](#account-linking)
+  - [Admin role mapping](#admin-role-mapping)
+  - [Logout](#logout)
+  - [Provider notes](#provider-notes)
 - [Adding a new locale](#adding-a-new-locale)
 - [Stack](#stack)
 - [License](#license)
@@ -242,6 +249,71 @@ When you change `src/lib/server/db/schema.ts`, run `db:generate` then `db:migrat
 
 ---
 
+## OIDC / SSO (optional)
+
+EinVault supports OpenID Connect for SSO with providers like Authelia, Authentik, Keycloak, and PocketID. OIDC runs alongside password login; existing users keep their passwords. A "Sign in with {provider}" button appears on the login page when OIDC is configured.
+
+OIDC is **disabled** unless all required variables are set. Add them to your `.env` (local) or compose file (production), then restart.
+
+Register `https://<your-domain>/auth/oidc/callback` as an allowed redirect URI with your IdP first.
+
+### Required variables
+
+| Variable             | Description                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `OIDC_ISSUER_URL`    | IdP base URL. Discovery happens at `<issuer>/.well-known/openid-configuration`. e.g. `https://auth.example.com` |
+| `OIDC_CLIENT_ID`     | Client ID registered with your IdP.                                                                             |
+| `OIDC_CLIENT_SECRET` | Client secret. Omit for public clients (PKCE-only).                                                             |
+| `OIDC_REDIRECT_URI`  | Must match what's registered with the IdP. e.g. `https://einvault.yourdomain.com/auth/oidc/callback`            |
+
+### Optional variables
+
+| Variable                        | Default                | Description                                                                                                |
+| ------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `OIDC_SCOPES`                   | `openid profile email` | Space-separated scopes requested from the IdP.                                                             |
+| `OIDC_PROVIDER_NAME`            | `SSO`                  | Display label on the login button.                                                                         |
+| `OIDC_ALLOW_SIGNUP`             | `false`                | If `true`, auto-creates accounts for users who authenticate but have no matching record. See below.        |
+| `OIDC_DEFAULT_ROLE`             | `member`               | Role assigned to auto-created users. Allowed: `member`, `caretaker`. Admin can only be granted via groups. |
+| `OIDC_ADMIN_GROUPS`             | _(unset)_              | Comma-separated. Users whose `groups` claim contains any value here are promoted to admin on every login.  |
+| `OIDC_POST_LOGOUT_REDIRECT_URI` | _(unset)_              | If set and the IdP advertises `end_session_endpoint`, logout triggers RP-initiated logout at the IdP.      |
+| `OIDC_STATE_SECRET`             | _(random)_             | Pin a long random string. Without it, in-flight logins break across server restarts.                       |
+
+### Account linking
+
+The callback decides which account to use in this order:
+
+1. **Match by OIDC subject.** If the user has logged in via OIDC before, link by stored `(issuer, subject)`.
+2. **Match by verified email.** If `email_verified` is `true` and the email matches an existing user, link the OIDC subject to that account.
+3. **Auto-create.** Only if `OIDC_ALLOW_SIGNUP=true`. Username taken from `preferred_username` claim (sanitised, with numeric suffix on collision), or email local-part as fallback.
+4. **Reject.** Otherwise, the user is returned to the login page with an "account not provisioned" message. An admin must create the account first.
+
+By default (`OIDC_ALLOW_SIGNUP=false`), users must already exist in EinVault, or share an email with an existing account, to log in.
+
+### Admin role mapping
+
+If `OIDC_ADMIN_GROUPS` is set, the user's `groups` claim is checked on **every** login. Membership in any listed group sets the user's role to `admin`; absence demotes them to the default role. Revoking admin at the IdP takes effect on next login.
+
+If `OIDC_ADMIN_GROUPS` is unset, OIDC does not touch user roles. Roles set in EinVault's admin UI are preserved across SSO logins.
+
+`OIDC_DEFAULT_ROLE` cannot grant admin; allowed values are `member` and `caretaker`.
+
+Group membership is read from the top-level `groups` claim in the ID token, as an array of strings (a single string also works). Other claim names (`roles`, Keycloak's `realm_access.roles`) and nested claims aren't read. Configure your IdP to emit `groups` directly. See provider notes below.
+
+### Logout
+
+By default, logout destroys the local EinVault session and returns the user to `/auth/login`. Set `OIDC_POST_LOGOUT_REDIRECT_URI` (and register it with your IdP) to also end the IdP session via [RP-initiated logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html).
+
+### Provider notes
+
+| Provider      | Notes                                                                                                                                                                                               |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Authelia**  | Register the redirect URI under the OIDC client config. Set `client_secret_basic` (default) or `none` for public clients.                                                                           |
+| **Authentik** | Create an OAuth2/OIDC provider; scope mapping for `groups` is built-in. `OIDC_ADMIN_GROUPS` matches the `groups` claim directly.                                                                    |
+| **Keycloak**  | Add a "Group Membership" mapper to the client with token claim name `groups` and "Full group path" off. EinVault does not read `realm_access.roles`. Add the redirect URI to "Valid Redirect URIs". |
+| **PocketID**  | Public-client first; omit `OIDC_CLIENT_SECRET`. Register the redirect URI in the client settings.                                                                                                   |
+
+---
+
 ## Adding a new locale
 
 1. Copy `src/lib/i18n/en.ts` to `src/lib/i18n/{code}.ts` (e.g. `ja.ts`) and translate every value. The file must `export default { ... } satisfies Record<keyof Messages, string>` — the compiler will catch any missing keys.
@@ -259,7 +331,7 @@ No migration is needed — SQLite text columns don't enforce enums at the databa
 - **SvelteKit:** full-stack TypeScript framework with file-based routing
 - **SQLite + Drizzle ORM:** local-first, portable database
 - **Tailwind CSS:** utility-first styling with custom components
-- **Session-based auth:** custom sessions signed with bcryptjs, no third-party auth library
+- **Session-based auth:** custom sessions with bcryptjs password hashing; optional OIDC SSO via [`openid-client`](https://github.com/panva/openid-client)
 - **Docker:** multi-stage, hardened single-container deployment
 
 ---

--- a/drizzle/0006_absurd_trauma.sql
+++ b/drizzle/0006_absurd_trauma.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `sessions` ADD `oidc_id_token_hint` text;--> statement-breakpoint
+ALTER TABLE `users` ADD `oidc_subject` text;--> statement-breakpoint
+ALTER TABLE `users` ADD `oidc_issuer` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `users_oidc_idx` ON `users` (`oidc_issuer`,`oidc_subject`);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1246 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b028af60-0a3b-461e-a148-7494a7fd99ed",
+  "prevId": "1227ffe1-ea4f-47d2-a924-2bd3d600beb4",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_due_at": {
+          "name": "next_due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurring_days": {
+          "name": "recurring_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776254803388,
       "tag": "0005_condemned_rachel_grey",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1777720933399,
+      "tag": "0006_absurd_trauma",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"drizzle-orm": "^0.45.2",
 				"isomorphic-dompurify": "^3.9.0",
 				"marked": "^17.0.5",
+				"openid-client": "^6.8.4",
 				"sharp": "^0.34.5",
 				"tailwind-merge": "^3.5.0"
 			},
@@ -4097,6 +4098,15 @@
 				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
+		"node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/jsdom": {
 			"version": "29.0.2",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
@@ -4642,6 +4652,15 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/oauth4webapi": {
+			"version": "3.8.6",
+			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+			"integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/obug": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -4660,6 +4679,19 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/openid-client": {
+			"version": "6.8.4",
+			"resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+			"integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+			"license": "MIT",
+			"dependencies": {
+				"jose": "^6.2.2",
+				"oauth4webapi": "^3.8.5"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"drizzle-orm": "^0.45.2",
 		"isomorphic-dompurify": "^3.9.0",
 		"marked": "^17.0.5",
+		"openid-client": "^6.8.4",
 		"sharp": "^0.34.5",
 		"tailwind-merge": "^3.5.0"
 	},

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,6 +3,9 @@ import { sequence } from '@sveltejs/kit/hooks';
 import { validateAuth } from '$server/auth';
 import { env } from '$env/dynamic/private';
 import { resolveLocale, parseAcceptLanguage } from '$lib/i18n';
+import { logOidcBootStatus } from '$lib/server/auth/oidc';
+
+logOidcBootStatus();
 
 const securityHeaders: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -115,6 +115,15 @@ const messages: Record<keyof Messages, string> = {
 	'error.missingShiftId': 'Fehlende Schicht-ID.',
 	'error.missingPhotoId': 'Fehlende Foto-ID',
 
+	// Errors: OIDC
+	'error.oidc.notProvisioned':
+		'Dein Konto wurde nicht eingerichtet. Bitte wende dich an einen Administrator.',
+	'error.oidc.invalidState':
+		'Die Anmeldesitzung ist abgelaufen oder ungültig. Bitte versuche es erneut.',
+	'error.oidc.exchangeFailed': 'Anmeldung fehlgeschlagen. Bitte versuche es erneut.',
+	'error.oidc.accountDisabled':
+		'Dein Konto ist deaktiviert. Bitte wende dich an einen Administrator.',
+
 	// Errors: Not found
 	'error.userNotFound': 'Benutzer nicht gefunden.',
 	'error.companionNotFound': 'Begleiter nicht gefunden',
@@ -217,6 +226,7 @@ const messages: Record<keyof Messages, string> = {
 	// Page: Login
 	'page.login.title': 'Anmelden',
 	'page.login.tagline': 'Dein privates Begleiter-Pflegetagebuch',
+	'page.login.signInWith': 'Mit {provider} anmelden',
 	'page.login.usernameLabel': 'Benutzername',
 	'page.login.usernamePlaceholder': 'Benutzername',
 	'page.login.passwordLabel': 'Passwort',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -209,8 +209,16 @@ const messages = {
 	'page.settings.languageCard': 'Language',
 	'page.settings.languageDescription': 'Choose your preferred language.',
 
+	// Errors: OIDC
+	'error.oidc.notProvisioned':
+		'Your account has not been provisioned. Please contact an administrator.',
+	'error.oidc.invalidState': 'Login session expired or invalid. Please try again.',
+	'error.oidc.exchangeFailed': 'Sign-in failed. Please try again.',
+	'error.oidc.accountDisabled': 'Your account is disabled. Please contact an administrator.',
+
 	// Page: Login
 	'page.login.title': 'Sign in',
+	'page.login.signInWith': 'Sign in with {provider}',
 	'page.login.tagline': 'Your private companion care log',
 	'page.login.usernameLabel': 'Username',
 	'page.login.usernamePlaceholder': 'username',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -114,6 +114,15 @@ const messages: Record<keyof Messages, string> = {
 	'error.missingShiftId': 'ID de turno faltante.',
 	'error.missingPhotoId': 'ID de foto faltante',
 
+	// Errors: OIDC
+	'error.oidc.notProvisioned':
+		'Tu cuenta no ha sido habilitada. Ponte en contacto con un administrador.',
+	'error.oidc.invalidState':
+		'La sesión de inicio de sesión ha expirado o no es válida. Inténtalo de nuevo.',
+	'error.oidc.exchangeFailed': 'El inicio de sesión ha fallado. Inténtalo de nuevo.',
+	'error.oidc.accountDisabled':
+		'Tu cuenta está desactivada. Ponte en contacto con un administrador.',
+
 	// Errors: Not found
 	'error.userNotFound': 'Usuario no encontrado.',
 	'error.companionNotFound': 'Compañero no encontrado',
@@ -216,6 +225,7 @@ const messages: Record<keyof Messages, string> = {
 	// Page: Login
 	'page.login.title': 'Iniciar sesión',
 	'page.login.tagline': 'Tu diario privado de cuidado de compañeros',
+	'page.login.signInWith': 'Iniciar sesión con {provider}',
 	'page.login.usernameLabel': 'Nombre de usuario',
 	'page.login.usernamePlaceholder': 'nombre de usuario',
 	'page.login.passwordLabel': 'Contraseña',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -114,6 +114,14 @@ const messages: Record<keyof Messages, string> = {
 	'error.missingShiftId': 'Identifiant de garde manquant.',
 	'error.missingPhotoId': 'Identifiant photo manquant',
 
+	// Errors: OIDC
+	'error.oidc.notProvisioned':
+		"Votre compte n'a pas été configuré. Veuillez contacter un administrateur.",
+	'error.oidc.invalidState':
+		'La session de connexion a expiré ou est invalide. Veuillez réessayer.',
+	'error.oidc.exchangeFailed': 'La connexion a échoué. Veuillez réessayer.',
+	'error.oidc.accountDisabled': 'Votre compte est désactivé. Veuillez contacter un administrateur.',
+
 	// Errors: Not found
 	'error.userNotFound': 'Utilisateur introuvable.',
 	'error.companionNotFound': 'Compagnon introuvable',
@@ -215,6 +223,7 @@ const messages: Record<keyof Messages, string> = {
 	// Page: Login
 	'page.login.title': 'Se connecter',
 	'page.login.tagline': 'Votre journal privé de soins pour compagnons',
+	'page.login.signInWith': 'Se connecter avec {provider}',
 	'page.login.usernameLabel': "Nom d'utilisateur",
 	'page.login.usernamePlaceholder': "nom d'utilisateur",
 	'page.login.passwordLabel': 'Mot de passe',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -113,6 +113,13 @@ const messages: Record<keyof Messages, string> = {
 	'error.missingShiftId': 'ID turno mancante.',
 	'error.missingPhotoId': 'ID foto mancante',
 
+	// Errors: OIDC
+	'error.oidc.notProvisioned':
+		'Il tuo account non è stato configurato. Contatta un amministratore.',
+	'error.oidc.invalidState': 'La sessione di accesso è scaduta o non è valida. Riprova.',
+	'error.oidc.exchangeFailed': 'Accesso non riuscito. Riprova.',
+	'error.oidc.accountDisabled': 'Il tuo account è disabilitato. Contatta un amministratore.',
+
 	// Errors: Not found
 	'error.userNotFound': 'Utente non trovato.',
 	'error.companionNotFound': 'Compagno non trovato',
@@ -214,6 +221,7 @@ const messages: Record<keyof Messages, string> = {
 	// Page: Login
 	'page.login.title': 'Accedi',
 	'page.login.tagline': 'Il tuo diario privato per la cura dei compagni',
+	'page.login.signInWith': 'Accedi con {provider}',
 	'page.login.usernameLabel': 'Nome utente',
 	'page.login.usernamePlaceholder': 'nome utente',
 	'page.login.passwordLabel': 'Password',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -114,6 +114,12 @@ const messages: Record<keyof Messages, string> = {
 	'error.missingShiftId': 'ID de turno em falta.',
 	'error.missingPhotoId': 'ID de foto em falta',
 
+	// Errors: OIDC
+	'error.oidc.notProvisioned': 'A sua conta não foi configurada. Contacte um administrador.',
+	'error.oidc.invalidState': 'A sessão de início de sessão expirou ou é inválida. Tente novamente.',
+	'error.oidc.exchangeFailed': 'O início de sessão falhou. Tente novamente.',
+	'error.oidc.accountDisabled': 'A sua conta está desativada. Contacte um administrador.',
+
 	// Errors: Not found
 	'error.userNotFound': 'Utilizador não encontrado.',
 	'error.companionNotFound': 'Companheiro não encontrado',
@@ -216,6 +222,7 @@ const messages: Record<keyof Messages, string> = {
 	// Page: Login
 	'page.login.title': 'Iniciar sessão',
 	'page.login.tagline': 'O seu diário privado de cuidados para companheiros',
+	'page.login.signInWith': 'Iniciar sessão com {provider}',
 	'page.login.usernameLabel': 'Nome de utilizador',
 	'page.login.usernamePlaceholder': 'nome de utilizador',
 	'page.login.passwordLabel': 'Palavra-passe',

--- a/src/lib/server/auth/oidc-state.ts
+++ b/src/lib/server/auth/oidc-state.ts
@@ -1,0 +1,139 @@
+import type { Cookies } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+
+const COOKIE_NAME = 'einvault_oidc_state';
+const COOKIE_PATH = '/auth/oidc';
+
+export interface OidcStatePayload {
+	state: string;
+	nonce: string;
+	codeVerifier: string;
+	returnTo: string;
+	createdAt: number;
+}
+
+function base64urlEncode(buf: ArrayBuffer | Uint8Array): string {
+	const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+	return btoa(String.fromCharCode(...bytes))
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '');
+}
+
+function base64urlDecode(str: string): Uint8Array {
+	const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+	const bin = atob(base64);
+	return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+}
+
+// Derive or generate a stable HMAC key for this process lifetime.
+let _keyPromise: Promise<CryptoKey> | null = null;
+
+function getKey(): Promise<CryptoKey> {
+	if (_keyPromise) return _keyPromise;
+	_keyPromise = (async () => {
+		const secret = env.OIDC_STATE_SECRET;
+		if (!secret) {
+			if (process.env.NODE_ENV === 'production') {
+				throw new Error(
+					'[oidc] OIDC_STATE_SECRET is required in production. Refusing to start OIDC login flow with an ephemeral key.'
+				);
+			}
+			console.warn(
+				'[oidc] OIDC_STATE_SECRET not set — using ephemeral key. In-flight logins will break on restart.'
+			);
+			const raw = crypto.getRandomValues(new Uint8Array(32));
+			return crypto.subtle.importKey('raw', raw, { name: 'HMAC', hash: 'SHA-256' }, false, [
+				'sign',
+				'verify'
+			]);
+		}
+		const enc = new TextEncoder().encode(secret);
+		const raw = await crypto.subtle.digest('SHA-256', enc);
+		return crypto.subtle.importKey('raw', raw, { name: 'HMAC', hash: 'SHA-256' }, false, [
+			'sign',
+			'verify'
+		]);
+	})();
+	return _keyPromise;
+}
+
+async function sign(payload: string): Promise<string> {
+	const key = await getKey();
+	const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payload));
+	return base64urlEncode(sig);
+}
+
+async function verify(payload: string, signature: string): Promise<boolean> {
+	const key = await getKey();
+	const sig = base64urlDecode(signature);
+	const data = new TextEncoder().encode(payload);
+	return crypto.subtle.verify('HMAC', key, sig.buffer as ArrayBuffer, data.buffer as ArrayBuffer);
+}
+
+export async function setOidcStateCookie(
+	cookies: Cookies,
+	payload: OidcStatePayload,
+	secure: boolean
+): Promise<void> {
+	const json = JSON.stringify(payload);
+	const encoded = base64urlEncode(new TextEncoder().encode(json));
+	const sig = await sign(encoded);
+	const value = `${encoded}.${sig}`;
+
+	cookies.set(COOKIE_NAME, value, {
+		path: COOKIE_PATH,
+		httpOnly: true,
+		sameSite: 'lax',
+		secure,
+		maxAge: 600
+	});
+}
+
+export async function readAndClearOidcStateCookie(
+	cookies: Cookies,
+	secure: boolean
+): Promise<OidcStatePayload | null> {
+	const raw = cookies.get(COOKIE_NAME);
+
+	// Always clear it — single use.
+	cookies.set(COOKIE_NAME, '', {
+		path: COOKIE_PATH,
+		httpOnly: true,
+		sameSite: 'lax',
+		secure,
+		maxAge: 0
+	});
+
+	if (!raw) return null;
+
+	const dot = raw.lastIndexOf('.');
+	if (dot === -1) return null;
+
+	const encoded = raw.slice(0, dot);
+	const sig = raw.slice(dot + 1);
+
+	const ok = await verify(encoded, sig);
+	if (!ok) return null;
+
+	try {
+		const json = new TextDecoder().decode(base64urlDecode(encoded));
+		const payload = JSON.parse(json) as OidcStatePayload;
+
+		if (!isValidReturnTo(payload.returnTo)) return null;
+
+		return payload;
+	} catch {
+		return null;
+	}
+}
+
+export function isValidReturnTo(returnTo: string): boolean {
+	if (!returnTo.startsWith('/')) return false;
+	// Block protocol-relative and backslash-authority confusions some browsers normalize.
+	if (returnTo.startsWith('//') || returnTo.startsWith('/\\')) return false;
+	// Reject control chars and whitespace that could break URL parsing.
+	// eslint-disable-next-line no-control-regex
+	if (/[\s\x00-\x1f]/.test(returnTo)) return false;
+	return true;
+}

--- a/src/lib/server/auth/oidc.ts
+++ b/src/lib/server/auth/oidc.ts
@@ -1,0 +1,130 @@
+import * as client from 'openid-client';
+import { env } from '$env/dynamic/private';
+
+export interface OidcConfig {
+	issuerUrl: string;
+	clientId: string;
+	clientSecret: string | undefined;
+	redirectUri: string;
+	scopes: string;
+}
+
+export function getOidcConfig(): OidcConfig | null {
+	const issuerUrl = env.OIDC_ISSUER_URL;
+	const clientId = env.OIDC_CLIENT_ID;
+	const redirectUri = env.OIDC_REDIRECT_URI;
+
+	if (!issuerUrl || !clientId || !redirectUri) return null;
+
+	return {
+		issuerUrl,
+		clientId,
+		clientSecret: env.OIDC_CLIENT_SECRET || undefined,
+		redirectUri,
+		scopes: env.OIDC_SCOPES || 'openid profile email'
+	};
+}
+
+export function getOidcProviderName(): string {
+	return env.OIDC_PROVIDER_NAME || 'SSO';
+}
+
+export function isOidcEnabled(): boolean {
+	return getOidcConfig() !== null;
+}
+
+const DISCOVERY_TTL_MS = 60 * 60 * 1000;
+let cached: { configuration: client.Configuration; cachedAt: number } | null = null;
+let inflight: Promise<client.Configuration> | null = null;
+
+export function discoverOidcClient(): Promise<client.Configuration> {
+	if (cached && Date.now() - cached.cachedAt < DISCOVERY_TTL_MS) {
+		return Promise.resolve(cached.configuration);
+	}
+	if (inflight) return inflight;
+
+	const config = getOidcConfig();
+	if (!config) return Promise.reject(new Error('OIDC is not configured'));
+
+	inflight = (async () => {
+		try {
+			const serverUrl = new URL(config.issuerUrl);
+			const discovered = config.clientSecret
+				? await client.discovery(serverUrl, config.clientId, config.clientSecret)
+				: await client.discovery(serverUrl, config.clientId, undefined, client.None());
+			cached = { configuration: discovered, cachedAt: Date.now() };
+			return discovered;
+		} catch (err) {
+			console.error('[oidc] discovery failed:', err);
+			throw err;
+		} finally {
+			inflight = null;
+		}
+	})();
+
+	return inflight;
+}
+
+export async function handleCallback(
+	config: client.Configuration,
+	currentUrl: URL,
+	codeVerifier: string,
+	expectedState: string,
+	expectedNonce: string
+): Promise<{ idTokenClaims: client.IDToken; idToken: string; accessToken?: string }> {
+	const tokens = await client.authorizationCodeGrant(config, currentUrl, {
+		pkceCodeVerifier: codeVerifier,
+		expectedState,
+		expectedNonce,
+		idTokenExpected: true
+	});
+
+	const claims = tokens.claims();
+	if (!claims) throw new Error('No ID token claims in response');
+	if (!tokens.id_token) throw new Error('IdP returned no id_token');
+
+	return {
+		idTokenClaims: claims,
+		idToken: tokens.id_token,
+		accessToken: tokens.access_token
+	};
+}
+
+export function isAdminGroupsConfigured(): boolean {
+	const raw = env.OIDC_ADMIN_GROUPS;
+	if (!raw) return false;
+	return raw
+		.split(',')
+		.map((g) => g.trim())
+		.some(Boolean);
+}
+
+// Returns the role for this OIDC login.
+// - If admin groups configured AND user is in one, returns 'admin'.
+// - Otherwise clamps the passed role to a non-admin role: keeps 'caretaker'/'member',
+//   demotes 'admin' (caller is responsible for skipping the call entirely if admin
+//   groups aren't configured and the existing role should be preserved).
+export function evaluateRole(
+	claims: client.IDToken,
+	fallbackRole: string
+): 'admin' | 'member' | 'caretaker' {
+	const adminGroups = env.OIDC_ADMIN_GROUPS;
+	if (adminGroups) {
+		const configured = adminGroups
+			.split(',')
+			.map((g) => g.trim())
+			.filter(Boolean);
+		if (configured.length > 0) {
+			const claimGroups = (claims as Record<string, unknown>)['groups'];
+			const userGroups: string[] = Array.isArray(claimGroups)
+				? (claimGroups as string[])
+				: typeof claimGroups === 'string'
+					? [claimGroups]
+					: [];
+			if (userGroups.some((g) => configured.includes(g))) return 'admin';
+		}
+	}
+
+	if (fallbackRole === 'caretaker') return 'caretaker';
+	return 'member';
+}

--- a/src/lib/server/auth/oidc.ts
+++ b/src/lib/server/auth/oidc.ts
@@ -9,6 +9,8 @@ export interface OidcConfig {
 	scopes: string;
 }
 
+const REQUIRED_OIDC_VARS = ['OIDC_ISSUER_URL', 'OIDC_CLIENT_ID', 'OIDC_REDIRECT_URI'] as const;
+
 export function getOidcConfig(): OidcConfig | null {
 	const issuerUrl = env.OIDC_ISSUER_URL;
 	const clientId = env.OIDC_CLIENT_ID;
@@ -31,6 +33,19 @@ export function getOidcProviderName(): string {
 
 export function isOidcEnabled(): boolean {
 	return getOidcConfig() !== null;
+}
+
+export function logOidcBootStatus(): void {
+	const missing = REQUIRED_OIDC_VARS.filter((name) => !env[name]);
+
+	if (missing.length === 0) {
+		console.info(`[oidc] enabled provider=${getOidcProviderName()} issuer=${env.OIDC_ISSUER_URL}`);
+		return;
+	}
+
+	console.warn(
+		`[oidc] disabled. Required vars: ${REQUIRED_OIDC_VARS.join(', ')}. Missing: ${missing.join(', ')}`
+	);
 }
 
 const DISCOVERY_TTL_MS = 60 * 60 * 1000;

--- a/src/lib/server/auth/session.ts
+++ b/src/lib/server/auth/session.ts
@@ -16,10 +16,16 @@ function tokenToSessionId(token: string): string {
 const SESSION_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
 const REFRESH_THRESHOLD_MS = 15 * 24 * 60 * 60 * 1000;
 
-export async function createSession(token: string, userId: string) {
+export async function createSession(
+	token: string,
+	userId: string,
+	opts?: { oidcIdTokenHint?: string }
+) {
 	const sessionId = tokenToSessionId(token);
 	const expiresAt = new Date(Date.now() + SESSION_DURATION_MS);
-	await db.insert(schema.sessions).values({ id: sessionId, userId, expiresAt });
+	await db
+		.insert(schema.sessions)
+		.values({ id: sessionId, userId, expiresAt, oidcIdTokenHint: opts?.oidcIdTokenHint });
 	return { id: sessionId, userId, expiresAt };
 }
 

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -11,28 +11,34 @@ import {
 
 // users
 
-export const users = sqliteTable('users', {
-	id: text('id').primaryKey(),
-	username: text('username').notNull().unique(),
-	displayName: text('display_name').notNull(),
-	passwordHash: text('password_hash'),
-	role: text('role', { enum: ['admin', 'member', 'caretaker'] })
-		.notNull()
-		.default('member'),
-	isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
-	createdAt: integer('created_at', { mode: 'timestamp' })
-		.notNull()
-		.default(sql`(unixepoch())`),
-	lastLoginAt: integer('last_login_at', { mode: 'timestamp' }),
-	theme: text('theme', { enum: ['light', 'dark', 'system'] })
-		.notNull()
-		.default('system'),
-	locale: text('locale', { enum: ['en', 'it', 'de', 'es', 'fr', 'pt'] })
-		.notNull()
-		.default('en'),
-	email: text('email'),
-	phone: text('phone')
-});
+export const users = sqliteTable(
+	'users',
+	{
+		id: text('id').primaryKey(),
+		username: text('username').notNull().unique(),
+		displayName: text('display_name').notNull(),
+		passwordHash: text('password_hash'),
+		role: text('role', { enum: ['admin', 'member', 'caretaker'] })
+			.notNull()
+			.default('member'),
+		isActive: integer('is_active', { mode: 'boolean' }).notNull().default(true),
+		createdAt: integer('created_at', { mode: 'timestamp' })
+			.notNull()
+			.default(sql`(unixepoch())`),
+		lastLoginAt: integer('last_login_at', { mode: 'timestamp' }),
+		theme: text('theme', { enum: ['light', 'dark', 'system'] })
+			.notNull()
+			.default('system'),
+		locale: text('locale', { enum: ['en', 'it', 'de', 'es', 'fr', 'pt'] })
+			.notNull()
+			.default('en'),
+		email: text('email'),
+		phone: text('phone'),
+		oidcSubject: text('oidc_subject'),
+		oidcIssuer: text('oidc_issuer')
+	},
+	(t) => [uniqueIndex('users_oidc_idx').on(t.oidcIssuer, t.oidcSubject)]
+);
 
 export const sessions = sqliteTable(
 	'sessions',
@@ -44,7 +50,8 @@ export const sessions = sqliteTable(
 		expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
 		createdAt: integer('created_at', { mode: 'timestamp' })
 			.notNull()
-			.default(sql`(unixepoch())`)
+			.default(sql`(unixepoch())`),
+		oidcIdTokenHint: text('oidc_id_token_hint')
 	},
 	(t) => [index('session_user_idx').on(t.userId)]
 );

--- a/src/routes/auth/login/+page.server.ts
+++ b/src/routes/auth/login/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { t } from '$lib/i18n';
+import { isOidcEnabled, getOidcProviderName } from '$lib/server/auth/oidc';
 import { db, schema } from '$lib/server/db';
 import {
 	generateSessionToken,
@@ -46,12 +47,30 @@ function clearRateLimit(ip: string) {
 	loginAttempts.delete(ip);
 }
 
-export const load: PageServerLoad = async ({ locals }) => {
+const OIDC_ERROR_KEYS = {
+	oidc_not_provisioned: 'error.oidc.notProvisioned',
+	oidc_invalid_state: 'error.oidc.invalidState',
+	oidc_exchange_failed: 'error.oidc.exchangeFailed',
+	oidc_account_disabled: 'error.oidc.accountDisabled'
+} as const;
+
+export const load: PageServerLoad = async ({ locals, url }) => {
 	if (locals.user) {
 		if (locals.user.role === 'caretaker') redirect(302, '/care');
 		redirect(302, '/');
 	}
-	return {};
+
+	const errorCode = url.searchParams.get('error');
+	const oidcErrorKey = errorCode
+		? OIDC_ERROR_KEYS[errorCode as keyof typeof OIDC_ERROR_KEYS]
+		: null;
+	const oidcError = oidcErrorKey ? t(locals.locale, oidcErrorKey) : null;
+
+	return {
+		oidcEnabled: isOidcEnabled(),
+		oidcProviderName: getOidcProviderName(),
+		oidcError
+	};
 };
 
 export const actions: Actions = {

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { ActionData } from './$types';
+	import type { ActionData, PageData } from './$types';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
@@ -8,7 +8,7 @@
 	import { t, getLocale, SUPPORTED_LOCALES, LOCALE_LABELS } from '$lib/i18n';
 	import { Select } from '$lib/components/ui/select/index.js';
 
-	let { form }: { form: ActionData } = $props();
+	let { form, data }: { form: ActionData; data: PageData } = $props();
 	let loading = $state(false);
 	const locale = getLocale();
 
@@ -41,6 +41,30 @@
 			</a>
 			<p class="text-sm text-muted-foreground">{t(locale, 'page.login.tagline')}</p>
 		</div>
+
+		{#if data.oidcError}
+			<Alert variant="destructive" class="mb-4 animate-slide-up">
+				<AlertDescription>{data.oidcError}</AlertDescription>
+			</Alert>
+		{/if}
+
+		{#if data.oidcEnabled}
+			<Card class="animate-slide-up mb-4">
+				<CardContent class="pt-6">
+					<a href="/auth/oidc/login" class="w-full">
+						<Button variant="outline" class="w-full" type="button">
+							{t(locale, 'page.login.signInWith', { provider: data.oidcProviderName })}
+						</Button>
+					</a>
+				</CardContent>
+			</Card>
+
+			<div class="relative flex items-center gap-3 mb-4">
+				<div class="flex-1 border-t border-border"></div>
+				<span class="text-xs text-muted-foreground">{t(locale, 'common.or')}</span>
+				<div class="flex-1 border-t border-border"></div>
+			</div>
+		{/if}
 
 		<Card class="animate-slide-up">
 			<CardContent class="pt-6">

--- a/src/routes/auth/logout/+page.server.ts
+++ b/src/routes/auth/logout/+page.server.ts
@@ -6,15 +6,46 @@ import {
 	makeBlankCookieOptions
 } from '$lib/server/auth/session';
 import { isSecureRequest } from '$lib/server/auth';
+import { isOidcEnabled, discoverOidcClient, getOidcConfig } from '$lib/server/auth/oidc';
+import { db, schema } from '$lib/server/db';
+import { eq } from 'drizzle-orm';
+import { env } from '$env/dynamic/private';
 
 export const actions: Actions = {
 	default: async ({ locals, cookies, request }) => {
+		const secure = isSecureRequest(request);
+
+		let oidcIdTokenHint: string | null = null;
+
 		if (locals.session) {
+			const sessionRow = await db.query.sessions.findFirst({
+				where: eq(schema.sessions.id, locals.session.id)
+			});
+			oidcIdTokenHint = sessionRow?.oidcIdTokenHint ?? null;
 			await invalidateSession(locals.session.id);
 		}
 
-		cookies.set(SESSION_COOKIE_NAME, '', makeBlankCookieOptions(isSecureRequest(request)));
+		cookies.set(SESSION_COOKIE_NAME, '', makeBlankCookieOptions(secure));
 
-		redirect(302, '/auth/login');
+		const postLogoutUri = env.OIDC_POST_LOGOUT_REDIRECT_URI;
+		let logoutHref: string | null = null;
+		if (oidcIdTokenHint && postLogoutUri && isOidcEnabled()) {
+			try {
+				const discovered = await discoverOidcClient();
+				const endSessionEndpoint = discovered.serverMetadata().end_session_endpoint;
+				if (endSessionEndpoint) {
+					const config = getOidcConfig()!;
+					const logoutUrl = new URL(endSessionEndpoint);
+					logoutUrl.searchParams.set('id_token_hint', oidcIdTokenHint);
+					logoutUrl.searchParams.set('post_logout_redirect_uri', postLogoutUri);
+					logoutUrl.searchParams.set('client_id', config.clientId);
+					logoutHref = logoutUrl.href;
+				}
+			} catch {
+				// Discovery failure — fall through to local logout.
+			}
+		}
+
+		redirect(302, logoutHref ?? '/auth/login');
 	}
 };

--- a/src/routes/auth/oidc/callback/+server.ts
+++ b/src/routes/auth/oidc/callback/+server.ts
@@ -1,0 +1,246 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import type { IDToken } from 'openid-client';
+import {
+	isOidcEnabled,
+	discoverOidcClient,
+	handleCallback,
+	evaluateRole,
+	isAdminGroupsConfigured
+} from '$lib/server/auth/oidc';
+import { readAndClearOidcStateCookie } from '$lib/server/auth/oidc-state';
+import { isSecureRequest } from '$lib/server/auth';
+import {
+	generateSessionToken,
+	createSession,
+	SESSION_COOKIE_NAME,
+	makeSessionCookieOptions
+} from '$lib/server/auth/session';
+import { db, schema } from '$lib/server/db';
+import { eq, and } from 'drizzle-orm';
+import { generateId } from '$lib/server/utils';
+import { t } from '$lib/i18n';
+import { env } from '$env/dynamic/private';
+
+// Same in-process rate limiter pattern as the password login route.
+const callbackAttempts = new Map<string, { count: number; resetAt: number }>();
+const MAX_ATTEMPTS = 10;
+const WINDOW_MS = 15 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+let lastCleanup = Date.now();
+
+function checkRateLimit(ip: string): boolean {
+	const now = Date.now();
+	if (now - lastCleanup > CLEANUP_INTERVAL_MS) {
+		for (const [key, val] of callbackAttempts) {
+			if (now > val.resetAt) callbackAttempts.delete(key);
+		}
+		lastCleanup = now;
+	}
+	const record = callbackAttempts.get(ip);
+	if (!record || now > record.resetAt) {
+		callbackAttempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+		return true;
+	}
+	if (record.count >= MAX_ATTEMPTS) return false;
+	record.count++;
+	return true;
+}
+
+function sanitizeUsername(raw: string): string {
+	return raw
+		.toLowerCase()
+		.replace(/[^a-z0-9_-]+/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-+|-+$/g, '');
+}
+
+export const GET: RequestHandler = async ({ url, cookies, locals, request, getClientAddress }) => {
+	if (!isOidcEnabled()) error(404);
+
+	const ip = getClientAddress();
+	const locale = locals.locale;
+	const secure = isSecureRequest(request);
+
+	if (!checkRateLimit(ip)) {
+		error(429, t(locale, 'error.tooManyLoginAttempts'));
+	}
+
+	const stateCookie = await readAndClearOidcStateCookie(cookies, secure);
+	if (!stateCookie) {
+		redirect(302, '/auth/login?error=oidc_invalid_state');
+	}
+
+	// Verify URL state matches cookie state before exchanging the code.
+	const urlState = url.searchParams.get('state');
+	if (!urlState || urlState !== stateCookie.state) {
+		redirect(302, '/auth/login?error=oidc_invalid_state');
+	}
+
+	let idTokenClaims: IDToken;
+	let idToken: string;
+
+	try {
+		const discovered = await discoverOidcClient();
+		({ idTokenClaims, idToken } = await handleCallback(
+			discovered,
+			url,
+			stateCookie.codeVerifier,
+			stateCookie.state,
+			stateCookie.nonce
+		));
+	} catch (err) {
+		console.error('[oidc] token exchange failed:', err);
+		redirect(302, '/auth/login?error=oidc_exchange_failed');
+	}
+
+	const sub = idTokenClaims.sub;
+	const iss = idTokenClaims.iss;
+	const email: string | undefined =
+		typeof idTokenClaims.email === 'string' ? idTokenClaims.email.toLowerCase() : undefined;
+	const emailVerified = idTokenClaims.email_verified === true;
+	const preferredUsername: string | undefined =
+		typeof (idTokenClaims as Record<string, unknown>)['preferred_username'] === 'string'
+			? ((idTokenClaims as Record<string, unknown>)['preferred_username'] as string)
+			: undefined;
+	const displayName: string | undefined =
+		typeof idTokenClaims.name === 'string' ? idTokenClaims.name : undefined;
+
+	const defaultRoleEnv = env.OIDC_DEFAULT_ROLE === 'caretaker' ? 'caretaker' : 'member';
+	const adminGroupsConfigured = isAdminGroupsConfigured();
+
+	// Linking algorithm — synchronous transaction.
+	type TxResult =
+		| { kind: 'ok'; userId: string; role: 'admin' | 'member' | 'caretaker' }
+		| { kind: 'disabled' }
+		| { kind: 'not_provisioned' };
+
+	const txResult: TxResult = db.transaction((tx) => {
+		// 1. Find by OIDC subject.
+		const byOidc = tx
+			.select()
+			.from(schema.users)
+			.where(and(eq(schema.users.oidcIssuer, iss), eq(schema.users.oidcSubject, sub)))
+			.get();
+
+		if (byOidc) {
+			if (!byOidc.isActive) return { kind: 'disabled' };
+			// Only re-evaluate role when admin groups are configured; otherwise the IdP isn't
+			// the source of truth for roles and we preserve whatever was set locally.
+			let role: 'admin' | 'member' | 'caretaker' = byOidc.role;
+			if (adminGroupsConfigured) {
+				role = evaluateRole(idTokenClaims, byOidc.role);
+				if (role !== byOidc.role) {
+					tx.update(schema.users).set({ role }).where(eq(schema.users.id, byOidc.id)).run();
+				}
+			}
+			tx.update(schema.users)
+				.set({ lastLoginAt: new Date() })
+				.where(eq(schema.users.id, byOidc.id))
+				.run();
+			console.info(`[oidc] linked login sub=${sub} userId=${byOidc.id}`);
+			return { kind: 'ok', userId: byOidc.id, role };
+		}
+
+		// 2. Find by verified email.
+		if (email && emailVerified) {
+			const byEmail = tx.select().from(schema.users).where(eq(schema.users.email, email)).get();
+
+			if (byEmail) {
+				if (!byEmail.isActive) return { kind: 'disabled' };
+				tx.update(schema.users)
+					.set({ oidcSubject: sub, oidcIssuer: iss, lastLoginAt: new Date() })
+					.where(eq(schema.users.id, byEmail.id))
+					.run();
+				let role: 'admin' | 'member' | 'caretaker' = byEmail.role;
+				if (adminGroupsConfigured) {
+					role = evaluateRole(idTokenClaims, byEmail.role);
+					if (role !== byEmail.role) {
+						tx.update(schema.users).set({ role }).where(eq(schema.users.id, byEmail.id)).run();
+					}
+				}
+				console.info(`[oidc] email-linked login sub=${sub} userId=${byEmail.id}`);
+				return { kind: 'ok', userId: byEmail.id, role };
+			}
+		}
+
+		// 3. Auto-signup.
+		if (env.OIDC_ALLOW_SIGNUP !== 'true') {
+			return { kind: 'not_provisioned' };
+		}
+
+		// Build a username candidate.
+		let usernameBase = '';
+		if (preferredUsername) {
+			usernameBase = sanitizeUsername(preferredUsername);
+		} else if (email) {
+			usernameBase = sanitizeUsername(email.split('@')[0]);
+		}
+		if (!usernameBase) {
+			usernameBase =
+				'oidc-' +
+				sub
+					.slice(0, 8)
+					.toLowerCase()
+					.replace(/[^a-z0-9]/g, '');
+		}
+
+		// Resolve collisions with numeric suffix.
+		let username = usernameBase;
+		let suffix = 2;
+		while (
+			tx
+				.select({ id: schema.users.id })
+				.from(schema.users)
+				.where(eq(schema.users.username, username))
+				.get()
+		) {
+			username = usernameBase + suffix;
+			suffix++;
+		}
+
+		const newUserId = generateId(15);
+		const role = evaluateRole(idTokenClaims, defaultRoleEnv);
+
+		tx.insert(schema.users)
+			.values({
+				id: newUserId,
+				username,
+				displayName: displayName || username,
+				passwordHash: null,
+				role,
+				email: email || null,
+				oidcSubject: sub,
+				oidcIssuer: iss,
+				lastLoginAt: new Date()
+			})
+			.run();
+
+		console.info(`[oidc] created user sub=${sub} userId=${newUserId} username=${username}`);
+		return { kind: 'ok', userId: newUserId, role };
+	});
+
+	if (txResult.kind === 'disabled') {
+		redirect(302, '/auth/login?error=oidc_account_disabled');
+	}
+
+	if (txResult.kind === 'not_provisioned') {
+		redirect(302, '/auth/login?error=oidc_not_provisioned');
+	}
+
+	const { userId, role } = txResult;
+
+	const token = generateSessionToken();
+	const session = await createSession(token, userId, { oidcIdTokenHint: idToken });
+
+	cookies.set(SESSION_COOKIE_NAME, token, makeSessionCookieOptions(session.expiresAt, secure));
+
+	const returnTo =
+		stateCookie.returnTo && stateCookie.returnTo !== '/' ? stateCookie.returnTo : null;
+	if (returnTo) {
+		redirect(302, returnTo);
+	}
+
+	redirect(302, role === 'caretaker' ? '/care' : '/');
+};

--- a/src/routes/auth/oidc/login/+server.ts
+++ b/src/routes/auth/oidc/login/+server.ts
@@ -1,0 +1,43 @@
+import { error, redirect } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import * as client from 'openid-client';
+import { isOidcEnabled, discoverOidcClient, getOidcConfig } from '$lib/server/auth/oidc';
+import { setOidcStateCookie, isValidReturnTo } from '$lib/server/auth/oidc-state';
+import { isSecureRequest } from '$lib/server/auth';
+
+export const GET: RequestHandler = async ({ url, cookies, locals, request }) => {
+	if (!isOidcEnabled()) error(404);
+
+	if (locals.user) {
+		redirect(302, locals.user.role === 'caretaker' ? '/care' : '/');
+	}
+
+	const rawReturnTo = url.searchParams.get('returnTo') ?? '/';
+	const returnTo = isValidReturnTo(rawReturnTo) ? rawReturnTo : '/';
+
+	const codeVerifier = client.randomPKCECodeVerifier();
+	const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+	const state = client.randomState();
+	const nonce = client.randomNonce();
+
+	const config = getOidcConfig()!;
+	const discovered = await discoverOidcClient();
+
+	const authUrl = client.buildAuthorizationUrl(discovered, {
+		redirect_uri: config.redirectUri,
+		scope: config.scopes,
+		code_challenge: codeChallenge,
+		code_challenge_method: 'S256',
+		state,
+		nonce
+	});
+
+	const secure = isSecureRequest(request);
+	await setOidcStateCookie(
+		cookies,
+		{ state, nonce, codeVerifier, returnTo, createdAt: Date.now() },
+		secure
+	);
+
+	redirect(302, authUrl.href);
+};


### PR DESCRIPTION
## Summary

Closes #43.

Adds optional OpenID Connect login alongside the existing password flow. OIDC is disabled unless `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, and `OIDC_REDIRECT_URI` are all set; password auth keeps working unchanged. Tested against Authelia, Authentik, Keycloak, and PocketID conventions per the spec.

Built on `openid-client`. PKCE S256, state, and nonce are validated end-to-end. State is stored in an HMAC-SHA256 signed, single-use cookie scoped to `/auth/oidc`.

## What

- **Login flow:** `/auth/oidc/login` initiates with PKCE+state+nonce; `/auth/oidc/callback` exchanges the code, links the account, and creates a session.
- **Account linking:** match by `(issuer, subject)`, then by verified email, then auto-create if `OIDC_ALLOW_SIGNUP=true`. Disabled accounts are rejected.
- **Admin role mapping:** optional `OIDC_ADMIN_GROUPS` matches against the top-level `groups` claim. If unset, OIDC never touches user roles (locally-set admins are preserved).
- **RP-initiated logout:** if `OIDC_POST_LOGOUT_REDIRECT_URI` is set and the IdP advertises `end_session_endpoint`, logout ends the IdP session too.
- **Schema:** additive migration `0006` adds `users.oidcSubject`, `users.oidcIssuer` (composite unique), and `sessions.oidcIdTokenHint`.
- **i18n:** new keys for SSO button + 4 OIDC error states across all 6 locales.
- **Login page:** "Sign in with {provider}" button, OIDC error mapping.
- **Docs:** README OIDC/SSO section with provider notes (Authelia, Authentik, Keycloak, PocketID); `.env.example` block.

## Security

- Rate-limited callback (10 / 15 min / IP), parity with password login.
- Session and state cookies: `httpOnly`, `secure` per request, correct `sameSite` per role (`strict` for session, `lax` for cross-site OIDC redirect).
- Production fails closed if `OIDC_STATE_SECRET` is unset; ephemeral key path retained for dev.
- No tokens, codes, or emails in logs. Successful link/signup events log at `info` for the audit trail.
- Two security audit and two code review rounds; all blockers fixed before merge.

## Test

- [x] Password login still works with OIDC env unset
- [x] OIDC login with new IdP user, `OIDC_ALLOW_SIGNUP=false` → "not provisioned" error
- [x] OIDC login with new IdP user, `OIDC_ALLOW_SIGNUP=true` → account auto-created
- [x] OIDC login with email matching an existing local user → linked, password still works after
- [x] OIDC login with disabled account → "account disabled" error
- [x] Admin role assigned via `OIDC_ADMIN_GROUPS`; revoking group at IdP demotes on next login
- [x] With `OIDC_ADMIN_GROUPS` unset, locally-set admin retained across SSO logins
- [x] Logout without `OIDC_POST_LOGOUT_REDIRECT_URI` → returns to `/auth/login`
- [ ] Logout with `OIDC_POST_LOGOUT_REDIRECT_URI` set → IdP session ends too
- [x] Production with `OIDC_STATE_SECRET` unset → login fails closed
- [x] Localized error strings render in non-English locales