### PR TITLE
Add ability to immediately complete a Reminder and allow for configuring the undo window duration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,11 @@ ORIGIN=https://einvault.yourdomain.com
 # Maximum number of journal photos per companion per day (default: 5).
 # MAX_DAILY_PHOTOS=5
 
+# Default undo window (in seconds) for dismissing a Reminder (default: 7).
+# Set to 0 to disable the undo window entirely (dismissals commit immediately).
+# Per-user override available in the settings UI.
+# REMINDER_UNDO_SECONDS=7
+
 # SvelteKit's internal request body cap (default: 50M).
 # Must be >= UPLOAD_MAX_MB. SvelteKit enforces this before the upload handler runs,
 # so it needs to be high enough to let requests through. Accepts K, M, G suffixes.

--- a/README.md
+++ b/README.md
@@ -152,14 +152,15 @@ einvault.yourdomain.com {
 
 Everything else in the compose file can be edited directly:
 
-|                    | Default             | Description                                                                                                                     |
-| ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `TZ`               | `UTC`               | Container timezone. Set to your local timezone (e.g. `America/New_York`, `Europe/London`) so dates and times display correctly. |
-| `UPLOAD_MAX_MB`    | `10`                | Maximum upload size in MB. SvelteKit's internal `BODY_SIZE_LIMIT` is derived from this automatically at container start.        |
-| `MAX_DAILY_PHOTOS` | `5`                 | Maximum number of journal photos per companion per day.                                                                         |
-| `user`             | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                       |
-| `./data` volume    | `./data`            | Where the database and uploads are stored on the host.                                                                          |
-| `DATABASE_URL`     | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                  |
+|                         | Default             | Description                                                                                                                       |
+| ----------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `TZ`                    | `UTC`               | Container timezone. Set to your local timezone (e.g. `America/New_York`, `Europe/London`) so dates and times display correctly.   |
+| `UPLOAD_MAX_MB`         | `10`                | Maximum upload size in MB. SvelteKit's internal `BODY_SIZE_LIMIT` is derived from this automatically at container start.          |
+| `MAX_DAILY_PHOTOS`      | `5`                 | Maximum number of journal photos per companion per day.                                                                           |
+| `REMINDER_UNDO_SECONDS` | `7`                 | Default undo window (seconds) when dismissing a Reminder. `0` disables the undo window. Each user can override in their settings. |
+| `user`                  | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                         |
+| `./data` volume         | `./data`            | Where the database and uploads are stored on the host.                                                                            |
+| `DATABASE_URL`          | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                    |
 
 ### Data and backup
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,6 +33,8 @@ services:
       UPLOAD_MAX_MB: ${UPLOAD_MAX_MB:-10}
       # Maximum journal photos per companion per day.
       MAX_DAILY_PHOTOS: ${MAX_DAILY_PHOTOS:-5}
+      # Default undo window (seconds) for dismissing a Reminder. 0 disables it.
+      REMINDER_UNDO_SECONDS: ${REMINDER_UNDO_SECONDS:-7}
 
       # Set to your local timezone so dates and times display correctly.
       # Defaults to UTC if omitted. Example: America/New_York, Europe/London

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,6 +38,9 @@ services:
       UPLOAD_MAX_MB: 10
       # Maximum journal photos per companion per day.
       MAX_DAILY_PHOTOS: 5
+      # Default undo window (seconds) for dismissing a Reminder. 0 disables it.
+      # Each user can override in their settings.
+      REMINDER_UNDO_SECONDS: 7
 
       # Set to your local timezone so dates and times display correctly.
       # Defaults to UTC if omitted. Example: America/New_York, Europe/London

--- a/drizzle/0007_dear_steel_serpent.sql
+++ b/drizzle/0007_dear_steel_serpent.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `reminder_undo_seconds` integer;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1253 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3eae9e62-b8cc-468c-8583-e75199749459",
+  "prevId": "b028af60-0a3b-461e-a148-7494a7fd99ed",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_due_at": {
+          "name": "next_due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurring_days": {
+          "name": "recurring_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777720933399,
       "tag": "0006_absurd_trauma",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1777820851991,
+      "tag": "0007_dear_steel_serpent",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -13,6 +13,7 @@ declare global {
 				locale: Locale;
 				email: string | null;
 				phone: string | null;
+				reminderUndoSeconds: number | null;
 			} | null;
 			session: {
 				id: string;

--- a/src/lib/components/settings/ReminderUndoCard.svelte
+++ b/src/lib/components/settings/ReminderUndoCard.svelte
@@ -5,7 +5,7 @@
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { t, getLocale } from '$lib/i18n';
-	import { REMINDER_UNDO_DEFAULT_SENTINEL } from '$lib/server/env';
+	import { REMINDER_UNDO_DEFAULT_SENTINEL } from '$lib/reminderUndo';
 
 	let {
 		currentValue,

--- a/src/lib/components/settings/ReminderUndoCard.svelte
+++ b/src/lib/components/settings/ReminderUndoCard.svelte
@@ -5,18 +5,16 @@
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { t, getLocale } from '$lib/i18n';
-	import { REMINDER_UNDO_DEFAULT_SENTINEL } from '$lib/reminderUndo';
+	import { REMINDER_UNDO_DEFAULT_SENTINEL, REMINDER_UNDO_PRESETS } from '$lib/reminderUndo';
 
 	let {
 		currentValue,
 		defaultSeconds,
-		presets,
 		successMessage,
 		errorMessage
 	}: {
 		currentValue: number | null;
 		defaultSeconds: number;
-		presets: readonly number[];
 		successMessage: string | undefined;
 		errorMessage: string | undefined;
 	} = $props();
@@ -24,7 +22,9 @@
 	const locale = getLocale();
 	let formEl: HTMLFormElement;
 
-	const options = $derived(Array.from(new Set([...presets, defaultSeconds])).sort((a, b) => a - b));
+	const options = $derived(
+		Array.from(new Set([...REMINDER_UNDO_PRESETS, defaultSeconds])).sort((a, b) => a - b)
+	);
 
 	const selectValue = $derived(
 		currentValue == null ? REMINDER_UNDO_DEFAULT_SENTINEL : String(currentValue)

--- a/src/lib/components/settings/ReminderUndoCard.svelte
+++ b/src/lib/components/settings/ReminderUndoCard.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { Select } from '$lib/components/ui/select/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import { t, getLocale } from '$lib/i18n';
+	import { REMINDER_UNDO_DEFAULT_SENTINEL } from '$lib/server/env';
+
+	let {
+		currentValue,
+		defaultSeconds,
+		presets,
+		successMessage,
+		errorMessage
+	}: {
+		currentValue: number | null;
+		defaultSeconds: number;
+		presets: readonly number[];
+		successMessage: string | undefined;
+		errorMessage: string | undefined;
+	} = $props();
+
+	const locale = getLocale();
+	let formEl: HTMLFormElement;
+
+	const options = $derived(Array.from(new Set([...presets, defaultSeconds])).sort((a, b) => a - b));
+
+	const selectValue = $derived(
+		currentValue == null ? REMINDER_UNDO_DEFAULT_SENTINEL : String(currentValue)
+	);
+</script>
+
+<Card>
+	<CardHeader>
+		<CardTitle>{t(locale, 'page.settings.reminderUndoCard')}</CardTitle>
+	</CardHeader>
+	<CardContent>
+		<p class="text-sm text-muted-foreground mb-3">
+			{t(locale, 'page.settings.reminderUndoDescription')}
+		</p>
+		{#if successMessage}
+			<Alert variant="success" class="mb-3">
+				<AlertDescription>{successMessage}</AlertDescription>
+			</Alert>
+		{/if}
+		{#if errorMessage}
+			<Alert variant="destructive" class="mb-3">
+				<AlertDescription>{errorMessage}</AlertDescription>
+			</Alert>
+		{/if}
+		<form method="POST" action="?/reminderUndo" bind:this={formEl} use:enhance>
+			<div class="max-w-[280px]">
+				<Label for="reminderUndoSeconds" class="sr-only"
+					>{t(locale, 'page.settings.reminderUndoLabel')}</Label
+				>
+				<Select
+					name="reminderUndoSeconds"
+					id="reminderUndoSeconds"
+					value={selectValue}
+					onchange={() => formEl.requestSubmit()}
+				>
+					<option value={REMINDER_UNDO_DEFAULT_SENTINEL}
+						>{t(locale, 'page.settings.reminderUndoDefault', {
+							seconds: defaultSeconds
+						})}</option
+					>
+					{#each options as preset (preset)}
+						<option value={String(preset)}>
+							{preset === 0
+								? t(locale, 'page.settings.reminderUndoOff')
+								: t(locale, 'page.settings.reminderUndoSeconds', { seconds: preset })}
+						</option>
+					{/each}
+				</Select>
+			</div>
+		</form>
+	</CardContent>
+</Card>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -24,10 +24,11 @@ const messages: Record<keyof Messages, string> = {
 	// Common: Reminder actions
 	'common.reminder.undo': 'Rückgängig',
 	'common.reminder.done': 'Erledigt',
-	'common.reminder.dismissNow': 'Jetzt schließen',
+	'common.reminder.dismissNow': 'Jetzt erledigen',
 	'common.reminder.dismissedAnnounce':
 		'{title} verworfen. Rückgängig aktivieren, um wiederherzustellen.',
 	'common.reminder.restoredAnnounce': '{title} wiederhergestellt.',
+	'common.reminder.untitled': 'Unbenannte Erinnerung',
 
 	// Enum: Moods
 	'enum.mood.great': 'Super',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -24,6 +24,7 @@ const messages: Record<keyof Messages, string> = {
 	// Common: Reminder actions
 	'common.reminder.undo': 'Rückgängig',
 	'common.reminder.done': 'Erledigt',
+	'common.reminder.dismissNow': 'Jetzt schließen',
 	'common.reminder.dismissedAnnounce':
 		'{title} verworfen. Rückgängig aktivieren, um wiederherzustellen.',
 	'common.reminder.restoredAnnounce': '{title} wiederhergestellt.',
@@ -99,6 +100,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.usernameAlreadyTaken': 'Benutzername bereits vergeben.',
 	'error.invalidTheme': 'Ungültiges Design.',
 	'error.invalidLocale': 'Ungültige Sprache.',
+	'error.invalidReminderUndo': 'Ungültiger Wert für Rückgängig-Fenster.',
 	'error.invalidRole': 'Ungültige Rolle.',
 	'error.invalidDate': 'Ungültiges Datum',
 	'error.invalidArchiveDate': 'Ungültiges Archivierungsdatum.',
@@ -222,6 +224,14 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.shiftGroupLater': 'Später',
 	'page.settings.languageCard': 'Sprache',
 	'page.settings.languageDescription': 'Wähle deine bevorzugte Sprache.',
+	'page.settings.reminderUndoCard': 'Erinnerung-Rückgängig-Fenster',
+	'page.settings.reminderUndoDescription':
+		'Wie lange gewartet wird, bevor eine abgewiesene Erinnerung übernommen wird. Aus = sofort übernehmen.',
+	'page.settings.reminderUndoLabel': 'Rückgängig-Fenster',
+	'page.settings.reminderUndoDefault': 'Standard verwenden ({seconds}s)',
+	'page.settings.reminderUndoOff': 'Aus (sofort übernehmen)',
+	'page.settings.reminderUndoSeconds': '{seconds} Sekunden',
+	'page.settings.reminderUndoUpdated': '✓ Rückgängig-Fenster aktualisiert.',
 
 	// Page: Login
 	'page.login.title': 'Anmelden',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -25,6 +25,7 @@ const messages = {
 	'common.reminder.dismissNow': 'Dismiss now',
 	'common.reminder.dismissedAnnounce': '{title} dismissed. Activate Undo to restore.',
 	'common.reminder.restoredAnnounce': '{title} restored.',
+	'common.reminder.untitled': 'Untitled reminder',
 
 	// Enum: Moods
 	'enum.mood.great': 'Great',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -22,6 +22,7 @@ const messages = {
 	// Common: Reminder actions (shared across companion dashboard, reminders list, caretaker)
 	'common.reminder.undo': 'Undo',
 	'common.reminder.done': 'Done',
+	'common.reminder.dismissNow': 'Dismiss now',
 	'common.reminder.dismissedAnnounce': '{title} dismissed. Activate Undo to restore.',
 	'common.reminder.restoredAnnounce': '{title} restored.',
 
@@ -95,6 +96,7 @@ const messages = {
 	'error.usernameAlreadyTaken': 'Username already taken.',
 	'error.invalidTheme': 'Invalid theme.',
 	'error.invalidLocale': 'Invalid locale.',
+	'error.invalidReminderUndo': 'Invalid undo window value.',
 	'error.invalidRole': 'Invalid role.',
 	'error.invalidDate': 'Invalid date',
 	'error.invalidArchiveDate': 'Invalid archive date.',
@@ -208,6 +210,14 @@ const messages = {
 	'page.settings.shiftGroupLater': 'Later',
 	'page.settings.languageCard': 'Language',
 	'page.settings.languageDescription': 'Choose your preferred language.',
+	'page.settings.reminderUndoCard': 'Reminder undo window',
+	'page.settings.reminderUndoDescription':
+		'How long to wait before a dismissed Reminder is committed. Use Off to commit immediately.',
+	'page.settings.reminderUndoLabel': 'Undo window',
+	'page.settings.reminderUndoDefault': 'Use site default ({seconds}s)',
+	'page.settings.reminderUndoOff': 'Off (commit immediately)',
+	'page.settings.reminderUndoSeconds': '{seconds} seconds',
+	'page.settings.reminderUndoUpdated': '✓ Undo window updated.',
 
 	// Errors: OIDC
 	'error.oidc.notProvisioned':

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -24,6 +24,7 @@ const messages: Record<keyof Messages, string> = {
 	// Common: Reminder actions
 	'common.reminder.undo': 'Deshacer',
 	'common.reminder.done': 'Hecho',
+	'common.reminder.dismissNow': 'Descartar ahora',
 	'common.reminder.dismissedAnnounce': '{title} descartado. Activa Deshacer para restaurar.',
 	'common.reminder.restoredAnnounce': '{title} restaurado.',
 
@@ -98,6 +99,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.usernameAlreadyTaken': 'Nombre de usuario ya en uso.',
 	'error.invalidTheme': 'Tema no válido.',
 	'error.invalidLocale': 'Idioma no válido.',
+	'error.invalidReminderUndo': 'Valor de ventana de deshacer no válido.',
 	'error.invalidRole': 'Rol no válido.',
 	'error.invalidDate': 'Fecha no válida',
 	'error.invalidArchiveDate': 'Fecha de archivo no válida.',
@@ -221,6 +223,14 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.shiftGroupLater': 'Más adelante',
 	'page.settings.languageCard': 'Idioma',
 	'page.settings.languageDescription': 'Elige tu idioma preferido.',
+	'page.settings.reminderUndoCard': 'Ventana para deshacer Recordatorio',
+	'page.settings.reminderUndoDescription':
+		'Cuánto esperar antes de confirmar un Recordatorio descartado. Usa Apagado para confirmar al instante.',
+	'page.settings.reminderUndoLabel': 'Ventana de deshacer',
+	'page.settings.reminderUndoDefault': 'Usar predeterminado ({seconds}s)',
+	'page.settings.reminderUndoOff': 'Apagado (confirmar al instante)',
+	'page.settings.reminderUndoSeconds': '{seconds} segundos',
+	'page.settings.reminderUndoUpdated': '✓ Ventana de deshacer actualizada.',
 
 	// Page: Login
 	'page.login.title': 'Iniciar sesión',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -27,6 +27,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.reminder.dismissNow': 'Descartar ahora',
 	'common.reminder.dismissedAnnounce': '{title} descartado. Activa Deshacer para restaurar.',
 	'common.reminder.restoredAnnounce': '{title} restaurado.',
+	'common.reminder.untitled': 'Recordatorio sin título',
 
 	// Enum: Moods
 	'enum.mood.great': 'Genial',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -27,6 +27,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.reminder.dismissNow': 'Confirmer maintenant',
 	'common.reminder.dismissedAnnounce': '{title} rejeté. Activez Annuler pour restaurer.',
 	'common.reminder.restoredAnnounce': '{title} restauré.',
+	'common.reminder.untitled': 'Rappel sans titre',
 
 	// Enum: Moods
 	'enum.mood.great': 'Super',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -24,6 +24,7 @@ const messages: Record<keyof Messages, string> = {
 	// Common: Reminder actions
 	'common.reminder.undo': 'Annuler',
 	'common.reminder.done': 'Fait',
+	'common.reminder.dismissNow': 'Confirmer maintenant',
 	'common.reminder.dismissedAnnounce': '{title} rejeté. Activez Annuler pour restaurer.',
 	'common.reminder.restoredAnnounce': '{title} restauré.',
 
@@ -98,6 +99,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.usernameAlreadyTaken': "Nom d'utilisateur déjà pris.",
 	'error.invalidTheme': 'Thème invalide.',
 	'error.invalidLocale': 'Langue invalide.',
+	'error.invalidReminderUndo': "Valeur de fenêtre d'annulation invalide.",
 	'error.invalidRole': 'Rôle invalide.',
 	'error.invalidDate': 'Date invalide',
 	'error.invalidArchiveDate': "Date d'archivage invalide.",
@@ -219,6 +221,14 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.shiftGroupLater': 'Plus tard',
 	'page.settings.languageCard': 'Langue',
 	'page.settings.languageDescription': 'Choisissez votre langue préférée.',
+	'page.settings.reminderUndoCard': "Fenêtre d'annulation des Rappels",
+	'page.settings.reminderUndoDescription':
+		"Délai avant qu'un Rappel rejeté soit confirmé. Utilisez Désactivé pour confirmer immédiatement.",
+	'page.settings.reminderUndoLabel': "Fenêtre d'annulation",
+	'page.settings.reminderUndoDefault': 'Valeur par défaut ({seconds}s)',
+	'page.settings.reminderUndoOff': 'Désactivé (confirmer immédiatement)',
+	'page.settings.reminderUndoSeconds': '{seconds} secondes',
+	'page.settings.reminderUndoUpdated': "✓ Fenêtre d'annulation mise à jour.",
 
 	// Page: Login
 	'page.login.title': 'Se connecter',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -27,6 +27,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.reminder.dismissNow': 'Conferma ora',
 	'common.reminder.dismissedAnnounce': '{title} ignorato. Attiva Annulla per ripristinare.',
 	'common.reminder.restoredAnnounce': '{title} ripristinato.',
+	'common.reminder.untitled': 'Promemoria senza titolo',
 
 	// Enum: Moods
 	'enum.mood.great': 'Ottimo',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -24,6 +24,7 @@ const messages: Record<keyof Messages, string> = {
 	// Common: Reminder actions
 	'common.reminder.undo': 'Annulla',
 	'common.reminder.done': 'Fatto',
+	'common.reminder.dismissNow': 'Conferma ora',
 	'common.reminder.dismissedAnnounce': '{title} ignorato. Attiva Annulla per ripristinare.',
 	'common.reminder.restoredAnnounce': '{title} ripristinato.',
 
@@ -97,6 +98,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.usernameAlreadyTaken': 'Nome utente già in uso.',
 	'error.invalidTheme': 'Tema non valido.',
 	'error.invalidLocale': 'Lingua non valida.',
+	'error.invalidReminderUndo': 'Valore finestra annulla non valido.',
 	'error.invalidRole': 'Ruolo non valido.',
 	'error.invalidDate': 'Data non valida',
 	'error.invalidArchiveDate': 'Data di archiviazione non valida.',
@@ -217,6 +219,14 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.shiftGroupLater': 'Più avanti',
 	'page.settings.languageCard': 'Lingua',
 	'page.settings.languageDescription': 'Scegli la tua lingua preferita.',
+	'page.settings.reminderUndoCard': 'Finestra annulla promemoria',
+	'page.settings.reminderUndoDescription':
+		'Quanto attendere prima che un Promemoria scartato venga confermato. Disattiva per confermare subito.',
+	'page.settings.reminderUndoLabel': 'Finestra annulla',
+	'page.settings.reminderUndoDefault': 'Usa predefinito ({seconds}s)',
+	'page.settings.reminderUndoOff': 'Disattivata (conferma subito)',
+	'page.settings.reminderUndoSeconds': '{seconds} secondi',
+	'page.settings.reminderUndoUpdated': '✓ Finestra annulla aggiornata.',
 
 	// Page: Login
 	'page.login.title': 'Accedi',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -24,6 +24,7 @@ const messages: Record<keyof Messages, string> = {
 	// Common: Reminder actions
 	'common.reminder.undo': 'Desfazer',
 	'common.reminder.done': 'Feito',
+	'common.reminder.dismissNow': 'Dispensar agora',
 	'common.reminder.dismissedAnnounce': '{title} dispensado. Ative Desfazer para restaurar.',
 	'common.reminder.restoredAnnounce': '{title} restaurado.',
 
@@ -98,6 +99,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.usernameAlreadyTaken': 'Nome de utilizador já em uso.',
 	'error.invalidTheme': 'Tema inválido.',
 	'error.invalidLocale': 'Idioma inválido.',
+	'error.invalidReminderUndo': 'Valor de janela para desfazer inválido.',
 	'error.invalidRole': 'Função inválida.',
 	'error.invalidDate': 'Data inválida',
 	'error.invalidArchiveDate': 'Data de arquivo inválida.',
@@ -218,6 +220,14 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.shiftGroupLater': 'Mais tarde',
 	'page.settings.languageCard': 'Idioma',
 	'page.settings.languageDescription': 'Escolha o seu idioma preferido.',
+	'page.settings.reminderUndoCard': 'Janela para desfazer Lembrete',
+	'page.settings.reminderUndoDescription':
+		'Quanto tempo esperar antes de confirmar um Lembrete dispensado. Use Desligado para confirmar imediatamente.',
+	'page.settings.reminderUndoLabel': 'Janela para desfazer',
+	'page.settings.reminderUndoDefault': 'Usar padrão ({seconds}s)',
+	'page.settings.reminderUndoOff': 'Desligado (confirmar imediatamente)',
+	'page.settings.reminderUndoSeconds': '{seconds} segundos',
+	'page.settings.reminderUndoUpdated': '✓ Janela para desfazer atualizada.',
 
 	// Page: Login
 	'page.login.title': 'Iniciar sessão',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -27,6 +27,7 @@ const messages: Record<keyof Messages, string> = {
 	'common.reminder.dismissNow': 'Dispensar agora',
 	'common.reminder.dismissedAnnounce': '{title} dispensado. Ative Desfazer para restaurar.',
 	'common.reminder.restoredAnnounce': '{title} restaurado.',
+	'common.reminder.untitled': 'Lembrete sem título',
 
 	// Enum: Moods
 	'enum.mood.great': 'Ótimo',

--- a/src/lib/pendingDismiss.svelte.ts
+++ b/src/lib/pendingDismiss.svelte.ts
@@ -144,7 +144,6 @@ export function createPendingDismissals(
 		queue,
 		undo,
 		undoLast,
-		/** Commit the pending dismissal immediately (skip remaining undo window). */
 		commit,
 		pause,
 		resume,

--- a/src/lib/pendingDismiss.svelte.ts
+++ b/src/lib/pendingDismiss.svelte.ts
@@ -28,6 +28,7 @@ export function createPendingDismissals(
 	let pending = $state<Record<string, PendingEntry>>({});
 	let order: string[] = [];
 	let announcement = $state('');
+	let announcementCounter = 0;
 
 	function scheduleSubmit(id: string, ms: number) {
 		return setTimeout(() => {
@@ -43,12 +44,13 @@ export function createPendingDismissals(
 	}
 
 	function setAnnouncement(msg: string) {
-		// Force screen-reader re-announcement even when message is identical
-		// by clearing synchronously and setting in a microtask.
-		announcement = '';
-		queueMicrotask(() => {
-			announcement = msg;
-		});
+		// Toggle a zero-width space suffix on each call so identical strings
+		// still produce a value change, forcing aria-live to re-announce.
+		// Avoids the prior microtask race where rapid sequential calls in the
+		// same tick could overwrite an unread message.
+		announcementCounter++;
+		const token = announcementCounter % 2 === 0 ? '​' : '';
+		announcement = msg + token;
 	}
 
 	function queue(id: string, form: HTMLFormElement, title: string) {
@@ -134,6 +136,7 @@ export function createPendingDismissals(
 		pending = {};
 		order = [];
 		announcement = '';
+		announcementCounter = 0;
 	}
 
 	return {

--- a/src/lib/pendingDismiss.svelte.ts
+++ b/src/lib/pendingDismiss.svelte.ts
@@ -14,11 +14,17 @@ type PendingEntry = {
  * Per-component reactive store for the "pending dismiss" UX
  * (see GitHub issue #32). Each call creates an isolated state scope.
  *
- * Pattern: clicking dismiss delays the server submit by DISMISS_DELAY_MS
+ * Pattern: clicking dismiss delays the server submit by `delayMs`
  * and shows an in-row Undo button. Undo cancels the timer. No server
  * call ever happens.
+ *
+ * `getDelayMs()` returns the current undo window in milliseconds. A
+ * value of 0 means no undo window. `queue()` submits immediately in that case.
  */
-export function createPendingDismissals(getLocale: () => Locale) {
+export function createPendingDismissals(
+	getLocale: () => Locale,
+	getDelayMs: () => number = () => DISMISS_DELAY_MS
+) {
 	let pending = $state<Record<string, PendingEntry>>({});
 	let order: string[] = [];
 	let announcement = $state('');
@@ -43,18 +49,32 @@ export function createPendingDismissals(getLocale: () => Locale) {
 	}
 
 	function queue(id: string, form: HTMLFormElement, title: string) {
+		const delayMs = getDelayMs();
+		if (delayMs <= 0) {
+			form.requestSubmit();
+			return;
+		}
 		const existing = pending[id];
 		if (existing) clearTimeout(existing.timer);
-		const timer = scheduleSubmit(id, DISMISS_DELAY_MS);
+		const timer = scheduleSubmit(id, delayMs);
 		pending[id] = {
 			timer,
 			form,
 			startedAt: performance.now(),
-			remainingMs: DISMISS_DELAY_MS,
+			remainingMs: delayMs,
 			paused: false
 		};
 		order = [...order.filter((x) => x !== id), id];
 		setAnnouncement(t(getLocale(), 'common.reminder.dismissedAnnounce', { title }));
+	}
+
+	function commitNow(id: string) {
+		const entry = pending[id];
+		if (!entry) return;
+		clearTimeout(entry.timer);
+		delete pending[id];
+		order = order.filter((x) => x !== id);
+		if (entry.form.isConnected) entry.form.requestSubmit();
 	}
 
 	function undo(id: string, title: string) {
@@ -117,6 +137,7 @@ export function createPendingDismissals(getLocale: () => Locale) {
 		queue,
 		undo,
 		undoLast,
+		commitNow,
 		pause,
 		resume,
 		cleanup

--- a/src/lib/pendingDismiss.svelte.ts
+++ b/src/lib/pendingDismiss.svelte.ts
@@ -31,11 +31,14 @@ export function createPendingDismissals(
 
 	function scheduleSubmit(id: string, ms: number) {
 		return setTimeout(() => {
+			// Re-read inside the timer: commit/undo may have already cleared
+			// the entry, in which case we must NOT submit again (would double-POST).
 			const entry = pending[id];
+			if (!entry) return;
 			delete pending[id];
 			order = order.filter((x) => x !== id);
-			if (entry && !entry.form.isConnected) return;
-			entry?.form.requestSubmit();
+			if (!entry.form.isConnected) return;
+			entry.form.requestSubmit();
 		}, ms);
 	}
 
@@ -51,6 +54,7 @@ export function createPendingDismissals(
 	function queue(id: string, form: HTMLFormElement, title: string) {
 		const delayMs = getDelayMs();
 		if (delayMs <= 0) {
+			setAnnouncement(t(getLocale(), 'common.reminder.dismissedAnnounce', { title }));
 			form.requestSubmit();
 			return;
 		}
@@ -68,12 +72,13 @@ export function createPendingDismissals(
 		setAnnouncement(t(getLocale(), 'common.reminder.dismissedAnnounce', { title }));
 	}
 
-	function commitNow(id: string) {
+	function commit(id: string, title: string) {
 		const entry = pending[id];
 		if (!entry) return;
 		clearTimeout(entry.timer);
 		delete pending[id];
 		order = order.filter((x) => x !== id);
+		setAnnouncement(t(getLocale(), 'common.reminder.dismissedAnnounce', { title }));
 		if (entry.form.isConnected) entry.form.requestSubmit();
 	}
 
@@ -93,12 +98,14 @@ export function createPendingDismissals(
 	/**
 	 * Undo the most-recently queued dismissal. Returns true if one was undone.
 	 * Caller provides a title lookup since reminders may live anywhere.
+	 * Falls back to a generic localized "Untitled reminder" string when the
+	 * lookup returns undefined (e.g. the reminder list reactivity briefly drops
+	 * the entry).
 	 */
 	function undoLast(titleForId: (id: string) => string | undefined): boolean {
 		if (order.length === 0) return false;
 		const id = order[order.length - 1];
-		const title = titleForId(id);
-		if (title === undefined) return false;
+		const title = titleForId(id) ?? t(getLocale(), 'common.reminder.untitled');
 		undo(id, title);
 		return true;
 	}
@@ -137,7 +144,8 @@ export function createPendingDismissals(
 		queue,
 		undo,
 		undoLast,
-		commitNow,
+		/** Commit the pending dismissal immediately (skip remaining undo window). */
+		commit,
 		pause,
 		resume,
 		cleanup

--- a/src/lib/reminderUndo.ts
+++ b/src/lib/reminderUndo.ts
@@ -1,0 +1,20 @@
+// Client-safe constants for the Reminder undo window. Imported by both
+// server-only code (src/lib/server/env.ts, server actions) and the
+// client-side ReminderUndoCard. Must not import any $env or $lib/server
+// modules so it stays browser-bundle safe.
+
+export const REMINDER_UNDO_PRESETS: readonly number[] = [0, 3, 7, 15];
+
+/**
+ * Upper bound for the reminder undo window, in seconds. Values above this
+ * are clamped, both at env-resolution time and when reading user prefs that
+ * may have been stored before validation tightening.
+ */
+export const REMINDER_UNDO_MAX_SECONDS = 60;
+
+/**
+ * Sentinel value used by the settings form to signal "use the site default
+ * (env-resolved) value" rather than overriding it. Shared between the server
+ * validator and the client form so the contract has one source of truth.
+ */
+export const REMINDER_UNDO_DEFAULT_SENTINEL = 'default';

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -13,6 +13,7 @@ import { isSecureRequest } from '$lib/server/auth';
 import type { Cookies } from '@sveltejs/kit';
 import { t } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
+import { REMINDER_UNDO_PRESETS, REMINDER_UNDO_DEFAULT_SENTINEL } from '$lib/server/env';
 
 export async function handleAccountUpdate(
 	userId: string,
@@ -92,4 +93,27 @@ export async function handleAccountUpdate(
 	}
 
 	return { accountSuccess: true };
+}
+
+export async function handleReminderUndoUpdate(userId: string, request: Request, locale: Locale) {
+	const data = await request.formData();
+	const raw = String(data.get('reminderUndoSeconds') ?? '');
+
+	let value: number | null;
+	if (raw === '' || raw === REMINDER_UNDO_DEFAULT_SENTINEL) {
+		value = null;
+	} else {
+		const n = Number(raw);
+		if (!Number.isInteger(n) || !REMINDER_UNDO_PRESETS.includes(n)) {
+			return fail(400, { reminderUndoError: t(locale, 'error.invalidReminderUndo') });
+		}
+		value = n;
+	}
+
+	await db
+		.update(schema.users)
+		.set({ reminderUndoSeconds: value })
+		.where(eq(schema.users.id, userId));
+
+	return { reminderUndoSuccess: true };
 }

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -13,7 +13,11 @@ import { isSecureRequest } from '$lib/server/auth';
 import type { Cookies } from '@sveltejs/kit';
 import { t } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
-import { REMINDER_UNDO_PRESETS, REMINDER_UNDO_DEFAULT_SENTINEL } from '$lib/server/env';
+import {
+	REMINDER_UNDO_PRESETS,
+	REMINDER_UNDO_DEFAULT_SENTINEL,
+	REMINDER_UNDO_SECONDS_DEFAULT
+} from '$lib/server/env';
 
 export async function handleAccountUpdate(
 	userId: string,
@@ -104,7 +108,11 @@ export async function handleReminderUndoUpdate(userId: string, request: Request,
 		value = null;
 	} else {
 		const n = Number(raw);
-		if (!Number.isInteger(n) || !REMINDER_UNDO_PRESETS.includes(n)) {
+		// Accept any preset OR the env-resolved site default. The dropdown
+		// merges the env default into the list, so a non-preset env value
+		// must round-trip through this validator.
+		const allowed = REMINDER_UNDO_PRESETS.includes(n) || n === REMINDER_UNDO_SECONDS_DEFAULT;
+		if (!Number.isInteger(n) || !allowed) {
 			return fail(400, { reminderUndoError: t(locale, 'error.invalidReminderUndo') });
 		}
 		value = n;

--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -48,7 +48,8 @@ export async function validateAuth(event: RequestEvent, { refreshCookie = true }
 			theme: (user.theme ?? 'system') as 'light' | 'dark' | 'system',
 			locale: (user.locale ?? 'en') as 'en' | 'it' | 'de' | 'es' | 'fr' | 'pt',
 			email: user.email ?? null,
-			phone: user.phone ?? null
+			phone: user.phone ?? null,
+			reminderUndoSeconds: user.reminderUndoSeconds ?? null
 		}
 	};
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -35,7 +35,8 @@ export const users = sqliteTable(
 		email: text('email'),
 		phone: text('phone'),
 		oidcSubject: text('oidc_subject'),
-		oidcIssuer: text('oidc_issuer')
+		oidcIssuer: text('oidc_issuer'),
+		reminderUndoSeconds: integer('reminder_undo_seconds')
 	},
 	(t) => [uniqueIndex('users_oidc_idx').on(t.oidcIssuer, t.oidcSubject)]
 );

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -1,14 +1,20 @@
 import { env } from '$env/dynamic/private';
 
 /**
- * Parse an env var as a positive integer. Falls back to `defaultValue`
- * when the value is missing, non-numeric, or not > 0.
+ * Parse an env var as a positive integer (n > 0). Falls back to
+ * `defaultValue` when the value is missing, non-numeric, or not positive.
  */
 function envInt(value: string | undefined, defaultValue: number): number {
 	const n = Number(value);
 	return Number.isInteger(n) && n > 0 ? n : defaultValue;
 }
 
+/**
+ * Parse an env var as a non-negative integer (n >= 0). Falls back to
+ * `defaultValue` when the value is missing, non-numeric, or negative.
+ * Use this for values where 0 is a meaningful "off" sentinel (e.g. an
+ * undo window of 0 seconds means "commit immediately").
+ */
 function envNonNegativeInt(value: string | undefined, defaultValue: number): number {
 	const n = Number(value);
 	return Number.isInteger(n) && n >= 0 ? n : defaultValue;
@@ -17,14 +23,31 @@ function envNonNegativeInt(value: string | undefined, defaultValue: number): num
 export const UPLOAD_MAX_MB = envInt(env.UPLOAD_MAX_MB, 10);
 export const MAX_DAILY_PHOTOS = envInt(env.MAX_DAILY_PHOTOS, 5);
 
+/**
+ * Upper bound for the reminder undo window, in seconds. Values above this
+ * are clamped, both at env-resolution time and when reading user prefs that
+ * may have been stored before validation tightening.
+ */
+export const REMINDER_UNDO_MAX_SECONDS = 60;
+
 // 0 = no undo window (instant commit). >0 = seconds before dismissal commits.
-export const REMINDER_UNDO_SECONDS_DEFAULT = envNonNegativeInt(env.REMINDER_UNDO_SECONDS, 7);
+export const REMINDER_UNDO_SECONDS_DEFAULT = Math.min(
+	envNonNegativeInt(env.REMINDER_UNDO_SECONDS, 7),
+	REMINDER_UNDO_MAX_SECONDS
+);
 
 export const REMINDER_UNDO_PRESETS: readonly number[] = [0, 3, 7, 15];
 
+/**
+ * Sentinel value used by the settings form to signal "use the site default
+ * (env-resolved) value" rather than overriding it. Shared between the server
+ * validator and the client form so the contract has one source of truth.
+ */
+export const REMINDER_UNDO_DEFAULT_SENTINEL = 'default';
+
 export function resolveReminderUndoSeconds(userPref: number | null | undefined): number {
 	if (typeof userPref === 'number' && Number.isInteger(userPref) && userPref >= 0) {
-		return userPref;
+		return Math.min(userPref, REMINDER_UNDO_MAX_SECONDS);
 	}
 	return REMINDER_UNDO_SECONDS_DEFAULT;
 }

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -9,5 +9,22 @@ function envInt(value: string | undefined, defaultValue: number): number {
 	return Number.isInteger(n) && n > 0 ? n : defaultValue;
 }
 
+function envNonNegativeInt(value: string | undefined, defaultValue: number): number {
+	const n = Number(value);
+	return Number.isInteger(n) && n >= 0 ? n : defaultValue;
+}
+
 export const UPLOAD_MAX_MB = envInt(env.UPLOAD_MAX_MB, 10);
 export const MAX_DAILY_PHOTOS = envInt(env.MAX_DAILY_PHOTOS, 5);
+
+// 0 = no undo window (instant commit). >0 = seconds before dismissal commits.
+export const REMINDER_UNDO_SECONDS_DEFAULT = envNonNegativeInt(env.REMINDER_UNDO_SECONDS, 7);
+
+export const REMINDER_UNDO_PRESETS: readonly number[] = [0, 3, 7, 15];
+
+export function resolveReminderUndoSeconds(userPref: number | null | undefined): number {
+	if (typeof userPref === 'number' && Number.isInteger(userPref) && userPref >= 0) {
+		return userPref;
+	}
+	return REMINDER_UNDO_SECONDS_DEFAULT;
+}

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -1,4 +1,11 @@
 import { env } from '$env/dynamic/private';
+import { REMINDER_UNDO_MAX_SECONDS } from '$lib/reminderUndo';
+
+export {
+	REMINDER_UNDO_MAX_SECONDS,
+	REMINDER_UNDO_PRESETS,
+	REMINDER_UNDO_DEFAULT_SENTINEL
+} from '$lib/reminderUndo';
 
 /**
  * Parse an env var as a positive integer (n > 0). Falls back to
@@ -23,27 +30,11 @@ function envNonNegativeInt(value: string | undefined, defaultValue: number): num
 export const UPLOAD_MAX_MB = envInt(env.UPLOAD_MAX_MB, 10);
 export const MAX_DAILY_PHOTOS = envInt(env.MAX_DAILY_PHOTOS, 5);
 
-/**
- * Upper bound for the reminder undo window, in seconds. Values above this
- * are clamped, both at env-resolution time and when reading user prefs that
- * may have been stored before validation tightening.
- */
-export const REMINDER_UNDO_MAX_SECONDS = 60;
-
 // 0 = no undo window (instant commit). >0 = seconds before dismissal commits.
 export const REMINDER_UNDO_SECONDS_DEFAULT = Math.min(
 	envNonNegativeInt(env.REMINDER_UNDO_SECONDS, 7),
 	REMINDER_UNDO_MAX_SECONDS
 );
-
-export const REMINDER_UNDO_PRESETS: readonly number[] = [0, 3, 7, 15];
-
-/**
- * Sentinel value used by the settings form to signal "use the site default
- * (env-resolved) value" rather than overriding it. Shared between the server
- * validator and the client form so the contract has one source of truth.
- */
-export const REMINDER_UNDO_DEFAULT_SENTINEL = 'default';
 
 export function resolveReminderUndoSeconds(userPref: number | null | undefined): number {
 	if (typeof userPref === 'number' && Number.isInteger(userPref) && userPref >= 0) {

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -25,7 +25,7 @@
 	import { renderMarkdown } from '$lib/markdown';
 	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { t, getLocale } from '$lib/i18n';
-	import { createPendingDismissals, DISMISS_DELAY_MS } from '$lib/pendingDismiss.svelte';
+	import { createPendingDismissals } from '$lib/pendingDismiss.svelte';
 	import { registerDismissForm } from '$lib/actions/registerDismissForm';
 
 	let { data }: { data: PageData } = $props();
@@ -78,7 +78,8 @@
 	}
 
 	// Pending reminder dismissals
-	const pendingDismiss = createPendingDismissals(getLocale);
+	const undoDelayMs = $derived((data.reminderUndoSeconds ?? 7) * 1000);
+	const pendingDismiss = createPendingDismissals(getLocale, () => undoDelayMs);
 	const dismissFormRegistry = new Map<string, HTMLFormElement>();
 
 	$effect(() => () => pendingDismiss.cleanup());
@@ -629,20 +630,31 @@
 							>
 								<input type="hidden" name="id" value={reminder.id} />
 								{#if isPending}
-									<button
-										type="button"
-										onclick={() => pendingDismiss.undo(reminder.id, reminder.title)}
-										title={t(locale, 'common.reminder.undo')}
-										aria-label={t(locale, 'common.reminder.undo')}
-										class="inline-flex items-center justify-center gap-1 rounded-md h-8 px-2 text-xs font-medium text-primary hover:bg-accent transition-colors shrink-0"
-										onmouseenter={() => pendingDismiss.pause(reminder.id)}
-										onmouseleave={() => pendingDismiss.resume(reminder.id)}
-										onfocusin={() => pendingDismiss.pause(reminder.id)}
-										onfocusout={() => pendingDismiss.resume(reminder.id)}
-									>
-										<Undo2 class="h-3.5 w-3.5" />
-										<span>{t(locale, 'common.reminder.undo')}</span>
-									</button>
+									<div class="flex items-center gap-1 shrink-0">
+										<button
+											type="button"
+											onclick={() => pendingDismiss.undo(reminder.id, reminder.title)}
+											title={t(locale, 'common.reminder.undo')}
+											aria-label={t(locale, 'common.reminder.undo')}
+											class="inline-flex items-center justify-center gap-1 rounded-md h-8 px-2 text-xs font-medium text-primary hover:bg-accent transition-colors"
+											onmouseenter={() => pendingDismiss.pause(reminder.id)}
+											onmouseleave={() => pendingDismiss.resume(reminder.id)}
+											onfocusin={() => pendingDismiss.pause(reminder.id)}
+											onfocusout={() => pendingDismiss.resume(reminder.id)}
+										>
+											<Undo2 class="h-3.5 w-3.5" />
+											<span>{t(locale, 'common.reminder.undo')}</span>
+										</button>
+										<button
+											type="button"
+											onclick={() => pendingDismiss.commitNow(reminder.id)}
+											title={t(locale, 'common.reminder.dismissNow')}
+											aria-label={t(locale, 'common.reminder.dismissNow')}
+											class="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+										>
+											<CheckCheck class="h-3.5 w-3.5" />
+										</button>
+									</div>
 								{:else}
 									<button
 										type="button"
@@ -661,7 +673,7 @@
 							{#if isPending}
 								<span
 									class="dismiss-countdown absolute bottom-0 left-0 h-0.5 bg-primary/70"
-									style="--dismiss-ms: {DISMISS_DELAY_MS}ms"
+									style="--dismiss-ms: {undoDelayMs}ms"
 									aria-hidden="true"
 								></span>
 							{/if}

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -647,7 +647,7 @@
 										</button>
 										<button
 											type="button"
-											onclick={() => pendingDismiss.commitNow(reminder.id)}
+											onclick={() => pendingDismiss.commit(reminder.id, reminder.title)}
 											title={t(locale, 'common.reminder.dismissNow')}
 											aria-label={t(locale, 'common.reminder.dismissNow')}
 											class="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -78,7 +78,7 @@
 	}
 
 	// Pending reminder dismissals
-	const undoDelayMs = $derived((data.reminderUndoSeconds ?? 7) * 1000);
+	const undoDelayMs = $derived(data.reminderUndoSeconds! * 1000);
 	const pendingDismiss = createPendingDismissals(getLocale, () => undoDelayMs);
 	const dismissFormRegistry = new Map<string, HTMLFormElement>();
 

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -20,7 +20,7 @@
 	import { localDatetimes } from '$lib/actions/localDatetimes';
 	import { t, getLocale } from '$lib/i18n';
 	import { reminderTypeOptions } from '$lib/i18n/labels';
-	import { createPendingDismissals, DISMISS_DELAY_MS } from '$lib/pendingDismiss.svelte';
+	import { createPendingDismissals } from '$lib/pendingDismiss.svelte';
 	import { registerDismissForm } from '$lib/actions/registerDismissForm';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
@@ -71,7 +71,8 @@
 	let deleteReminderForm = $state<HTMLFormElement | null>(null);
 
 	// Pending reminder dismissals
-	const pendingDismiss = createPendingDismissals(getLocale);
+	const undoDelayMs = $derived((data.reminderUndoSeconds ?? 7) * 1000);
+	const pendingDismiss = createPendingDismissals(getLocale, () => undoDelayMs);
 	const dismissFormRegistry = new Map<string, HTMLFormElement>();
 
 	$effect(() => () => pendingDismiss.cleanup());
@@ -585,6 +586,20 @@
 													<Undo2 class="h-3.5 w-3.5" />
 													<span class="hidden sm:inline">{t(locale, 'common.reminder.undo')}</span>
 												</Button>
+												<Button
+													type="button"
+													variant="ghost"
+													size="sm"
+													class="h-7 gap-1.5 px-2 text-xs"
+													onclick={() => pendingDismiss.commitNow(reminder.id)}
+													title={t(locale, 'common.reminder.dismissNow')}
+													aria-label={t(locale, 'common.reminder.dismissNow')}
+												>
+													<CheckCheck class="h-3.5 w-3.5" />
+													<span class="hidden sm:inline"
+														>{t(locale, 'common.reminder.dismissNow')}</span
+													>
+												</Button>
 											{:else}
 												<Button
 													type="button"
@@ -624,7 +639,7 @@
 					{#if isPending}
 						<span
 							class="dismiss-countdown absolute bottom-0 left-0 h-0.5 bg-primary/70"
-							style="--dismiss-ms: {DISMISS_DELAY_MS}ms"
+							style="--dismiss-ms: {undoDelayMs}ms"
 							aria-hidden="true"
 						></span>
 					{/if}

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -591,7 +591,7 @@
 													variant="ghost"
 													size="sm"
 													class="h-7 gap-1.5 px-2 text-xs"
-													onclick={() => pendingDismiss.commitNow(reminder.id)}
+													onclick={() => pendingDismiss.commit(reminder.id, reminder.title)}
 													title={t(locale, 'common.reminder.dismissNow')}
 													aria-label={t(locale, 'common.reminder.dismissNow')}
 												>

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -71,7 +71,7 @@
 	let deleteReminderForm = $state<HTMLFormElement | null>(null);
 
 	// Pending reminder dismissals
-	const undoDelayMs = $derived((data.reminderUndoSeconds ?? 7) * 1000);
+	const undoDelayMs = $derived(data.reminderUndoSeconds! * 1000);
 	const pendingDismiss = createPendingDismissals(getLocale, () => undoDelayMs);
 	const dismissFormRegistry = new Map<string, HTMLFormElement>();
 

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -6,7 +6,7 @@ import { handleAccountUpdate, handleReminderUndoUpdate } from '$lib/server/accou
 import { isSecureRequest } from '$lib/server/auth';
 import { t, SUPPORTED_LOCALES } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
-import { REMINDER_UNDO_PRESETS, REMINDER_UNDO_SECONDS_DEFAULT } from '$lib/server/env';
+import { REMINDER_UNDO_SECONDS_DEFAULT } from '$lib/server/env';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -31,8 +31,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 		user: locals.user,
 		companions,
 		archivedCompanions,
-		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT,
-		reminderUndoPresets: REMINDER_UNDO_PRESETS
+		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT
 	};
 };
 

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -2,7 +2,7 @@ import { error, fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
-import { handleAccountUpdate } from '$lib/server/account';
+import { handleAccountUpdate, handleReminderUndoUpdate } from '$lib/server/account';
 import { isSecureRequest } from '$lib/server/auth';
 import { t, SUPPORTED_LOCALES } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
@@ -94,27 +94,7 @@ export const actions: Actions = {
 
 	reminderUndo: async ({ request, locals }) => {
 		if (!locals.user) redirect(302, '/auth/login');
-
-		const data = await request.formData();
-		const raw = String(data.get('reminderUndoSeconds') ?? '');
-
-		let value: number | null;
-		if (raw === '' || raw === 'default') {
-			value = null;
-		} else {
-			const n = Number(raw);
-			if (!Number.isInteger(n) || !REMINDER_UNDO_PRESETS.includes(n)) {
-				return fail(400, { reminderUndoError: t(locals.locale, 'error.invalidReminderUndo') });
-			}
-			value = n;
-		}
-
-		await db
-			.update(schema.users)
-			.set({ reminderUndoSeconds: value })
-			.where(eq(schema.users.id, locals.user.id));
-
-		return { reminderUndoSuccess: true };
+		return handleReminderUndoUpdate(locals.user.id, request, locals.locale);
 	},
 
 	restore: async ({ request, locals }) => {

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -6,6 +6,7 @@ import { handleAccountUpdate } from '$lib/server/account';
 import { isSecureRequest } from '$lib/server/auth';
 import { t, SUPPORTED_LOCALES } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
+import { REMINDER_UNDO_PRESETS, REMINDER_UNDO_SECONDS_DEFAULT } from '$lib/server/env';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -26,7 +27,13 @@ export const load: PageServerLoad = async ({ locals }) => {
 				})
 			: [];
 
-	return { user: locals.user, companions, archivedCompanions };
+	return {
+		user: locals.user,
+		companions,
+		archivedCompanions,
+		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT,
+		reminderUndoPresets: REMINDER_UNDO_PRESETS
+	};
 };
 
 export const actions: Actions = {
@@ -83,6 +90,31 @@ export const actions: Actions = {
 	account: async ({ request, locals, cookies }) => {
 		if (!locals.user) redirect(302, '/auth/login');
 		return handleAccountUpdate(locals.user.id, request, cookies, locals.locale);
+	},
+
+	reminderUndo: async ({ request, locals }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+
+		const data = await request.formData();
+		const raw = String(data.get('reminderUndoSeconds') ?? '');
+
+		let value: number | null;
+		if (raw === '' || raw === 'default') {
+			value = null;
+		} else {
+			const n = Number(raw);
+			if (!Number.isInteger(n) || !REMINDER_UNDO_PRESETS.includes(n)) {
+				return fail(400, { reminderUndoError: t(locals.locale, 'error.invalidReminderUndo') });
+			}
+			value = n;
+		}
+
+		await db
+			.update(schema.users)
+			.set({ reminderUndoSeconds: value })
+			.where(eq(schema.users.id, locals.user.id));
+
+		return { reminderUndoSuccess: true };
 	},
 
 	restore: async ({ request, locals }) => {

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -21,6 +21,7 @@
 
 	let showPasswordFields = $state(false);
 	let localeForm: HTMLFormElement;
+	let reminderUndoForm: HTMLFormElement;
 
 	function formatArchivedDate(d: Date | null | undefined): string {
 		if (!d) return '';
@@ -216,6 +217,55 @@
 					>
 						{#each SUPPORTED_LOCALES as loc (loc)}
 							<option value={loc}>{LOCALE_LABELS[loc]}</option>
+						{/each}
+					</Select>
+				</div>
+			</form>
+		</CardContent>
+	</Card>
+
+	<Card>
+		<CardHeader>
+			<CardTitle>{t(locale, 'page.settings.reminderUndoCard')}</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<p class="text-sm text-muted-foreground mb-3">
+				{t(locale, 'page.settings.reminderUndoDescription')}
+			</p>
+			{#if form?.reminderUndoSuccess}
+				<Alert class="mb-3">
+					<AlertDescription>{t(locale, 'page.settings.reminderUndoUpdated')}</AlertDescription>
+				</Alert>
+			{/if}
+			{#if form?.reminderUndoError}
+				<Alert variant="destructive" class="mb-3">
+					<AlertDescription>{form.reminderUndoError}</AlertDescription>
+				</Alert>
+			{/if}
+			<form method="POST" action="?/reminderUndo" bind:this={reminderUndoForm} use:enhance>
+				<div class="max-w-[280px]">
+					<Label for="reminderUndoSeconds" class="sr-only"
+						>{t(locale, 'page.settings.reminderUndoLabel')}</Label
+					>
+					<Select
+						name="reminderUndoSeconds"
+						id="reminderUndoSeconds"
+						value={data.user?.reminderUndoSeconds == null
+							? 'default'
+							: String(data.user.reminderUndoSeconds)}
+						onchange={() => reminderUndoForm.requestSubmit()}
+					>
+						<option value="default"
+							>{t(locale, 'page.settings.reminderUndoDefault', {
+								seconds: data.reminderUndoDefault
+							})}</option
+						>
+						{#each data.reminderUndoPresets as preset (preset)}
+							<option value={String(preset)}>
+								{preset === 0
+									? t(locale, 'page.settings.reminderUndoOff')
+									: t(locale, 'page.settings.reminderUndoSeconds', { seconds: preset })}
+							</option>
 						{/each}
 					</Select>
 				</div>

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -227,7 +227,6 @@
 	<ReminderUndoCard
 		currentValue={data.user?.reminderUndoSeconds ?? null}
 		defaultSeconds={data.reminderUndoDefault}
-		presets={data.reminderUndoPresets}
 		successMessage={form?.reminderUndoSuccess
 			? t(locale, 'page.settings.reminderUndoUpdated')
 			: undefined}

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -10,6 +10,7 @@
 
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
+	import ReminderUndoCard from '$lib/components/settings/ReminderUndoCard.svelte';
 	import { Pencil, Plus, RotateCcw } from '@lucide/svelte';
 	import { getContext } from 'svelte';
 	import { t, getLocale, SUPPORTED_LOCALES, LOCALE_LABELS } from '$lib/i18n';
@@ -21,7 +22,6 @@
 
 	let showPasswordFields = $state(false);
 	let localeForm: HTMLFormElement;
-	let reminderUndoForm: HTMLFormElement;
 
 	function formatArchivedDate(d: Date | null | undefined): string {
 		if (!d) return '';
@@ -224,54 +224,15 @@
 		</CardContent>
 	</Card>
 
-	<Card>
-		<CardHeader>
-			<CardTitle>{t(locale, 'page.settings.reminderUndoCard')}</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<p class="text-sm text-muted-foreground mb-3">
-				{t(locale, 'page.settings.reminderUndoDescription')}
-			</p>
-			{#if form?.reminderUndoSuccess}
-				<Alert class="mb-3">
-					<AlertDescription>{t(locale, 'page.settings.reminderUndoUpdated')}</AlertDescription>
-				</Alert>
-			{/if}
-			{#if form?.reminderUndoError}
-				<Alert variant="destructive" class="mb-3">
-					<AlertDescription>{form.reminderUndoError}</AlertDescription>
-				</Alert>
-			{/if}
-			<form method="POST" action="?/reminderUndo" bind:this={reminderUndoForm} use:enhance>
-				<div class="max-w-[280px]">
-					<Label for="reminderUndoSeconds" class="sr-only"
-						>{t(locale, 'page.settings.reminderUndoLabel')}</Label
-					>
-					<Select
-						name="reminderUndoSeconds"
-						id="reminderUndoSeconds"
-						value={data.user?.reminderUndoSeconds == null
-							? 'default'
-							: String(data.user.reminderUndoSeconds)}
-						onchange={() => reminderUndoForm.requestSubmit()}
-					>
-						<option value="default"
-							>{t(locale, 'page.settings.reminderUndoDefault', {
-								seconds: data.reminderUndoDefault
-							})}</option
-						>
-						{#each data.reminderUndoPresets as preset (preset)}
-							<option value={String(preset)}>
-								{preset === 0
-									? t(locale, 'page.settings.reminderUndoOff')
-									: t(locale, 'page.settings.reminderUndoSeconds', { seconds: preset })}
-							</option>
-						{/each}
-					</Select>
-				</div>
-			</form>
-		</CardContent>
-	</Card>
+	<ReminderUndoCard
+		currentValue={data.user?.reminderUndoSeconds ?? null}
+		defaultSeconds={data.reminderUndoDefault}
+		presets={data.reminderUndoPresets}
+		successMessage={form?.reminderUndoSuccess
+			? t(locale, 'page.settings.reminderUndoUpdated')
+			: undefined}
+		errorMessage={form?.reminderUndoError}
+	/>
 
 	{#if data.companions.length > 0 || data.user?.role !== 'caretaker'}
 		<Card>

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -12,7 +12,7 @@
 	import { ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { tick } from 'svelte';
 	import { t, getLocale } from '$lib/i18n';
-	import { createPendingDismissals, DISMISS_DELAY_MS } from '$lib/pendingDismiss.svelte';
+	import { createPendingDismissals } from '$lib/pendingDismiss.svelte';
 	import { registerDismissForm } from '$lib/actions/registerDismissForm';
 
 	let { data }: { data: PageData } = $props();
@@ -141,7 +141,8 @@
 	let visibleOwners = $derived((owners ?? []).filter((o) => o.phone || o.email));
 
 	// Pending reminder dismissals
-	const pendingDismiss = createPendingDismissals(getLocale);
+	const undoDelayMs = $derived((data.reminderUndoSeconds ?? 7) * 1000);
+	const pendingDismiss = createPendingDismissals(getLocale, () => undoDelayMs);
 	const dismissFormRegistry = new Map<string, HTMLFormElement>();
 
 	$effect(() => () => pendingDismiss.cleanup());
@@ -540,20 +541,34 @@
 								>
 									<input type="hidden" name="id" value={reminder.id} />
 									{#if isPending}
-										<button
-											type="button"
-											onclick={() => pendingDismiss.undo(reminder.id, reminder.title)}
-											title={t(locale, 'common.reminder.undo')}
-											aria-label={t(locale, 'common.reminder.undo')}
-											class="inline-flex items-center gap-1 justify-center rounded-md h-9 px-3 text-sm font-medium border border-input bg-background transition-colors hover:bg-accent shrink-0 text-primary"
-											onmouseenter={() => pendingDismiss.pause(reminder.id)}
-											onmouseleave={() => pendingDismiss.resume(reminder.id)}
-											onfocusin={() => pendingDismiss.pause(reminder.id)}
-											onfocusout={() => pendingDismiss.resume(reminder.id)}
-										>
-											<Undo2 class="h-3.5 w-3.5" />
-											<span class="hidden sm:inline">{t(locale, 'common.reminder.undo')}</span>
-										</button>
+										<div class="flex items-center gap-1 shrink-0">
+											<button
+												type="button"
+												onclick={() => pendingDismiss.undo(reminder.id, reminder.title)}
+												title={t(locale, 'common.reminder.undo')}
+												aria-label={t(locale, 'common.reminder.undo')}
+												class="inline-flex items-center gap-1 justify-center rounded-md h-9 px-3 text-sm font-medium border border-input bg-background transition-colors hover:bg-accent text-primary"
+												onmouseenter={() => pendingDismiss.pause(reminder.id)}
+												onmouseleave={() => pendingDismiss.resume(reminder.id)}
+												onfocusin={() => pendingDismiss.pause(reminder.id)}
+												onfocusout={() => pendingDismiss.resume(reminder.id)}
+											>
+												<Undo2 class="h-3.5 w-3.5" />
+												<span class="hidden sm:inline">{t(locale, 'common.reminder.undo')}</span>
+											</button>
+											<button
+												type="button"
+												onclick={() => pendingDismiss.commitNow(reminder.id)}
+												title={t(locale, 'common.reminder.dismissNow')}
+												aria-label={t(locale, 'common.reminder.dismissNow')}
+												class="inline-flex items-center gap-1 justify-center rounded-md h-9 px-3 text-sm font-medium border border-input bg-background transition-colors hover:bg-accent"
+											>
+												<CheckCheck class="h-3.5 w-3.5" />
+												<span class="hidden sm:inline"
+													>{t(locale, 'common.reminder.dismissNow')}</span
+												>
+											</button>
+										</div>
 									{:else}
 										<button
 											type="button"
@@ -573,7 +588,7 @@
 								{#if isPending}
 									<span
 										class="dismiss-countdown absolute bottom-0 left-0 h-0.5 bg-primary/70"
-										style="--dismiss-ms: {DISMISS_DELAY_MS}ms"
+										style="--dismiss-ms: {undoDelayMs}ms"
 										aria-hidden="true"
 									></span>
 								{/if}

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -558,7 +558,7 @@
 											</button>
 											<button
 												type="button"
-												onclick={() => pendingDismiss.commitNow(reminder.id)}
+												onclick={() => pendingDismiss.commit(reminder.id, reminder.title)}
 												title={t(locale, 'common.reminder.dismissNow')}
 												aria-label={t(locale, 'common.reminder.dismissNow')}
 												class="inline-flex items-center gap-1 justify-center rounded-md h-9 px-3 text-sm font-medium border border-input bg-background transition-colors hover:bg-accent"

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -120,6 +120,15 @@
 		}
 	}
 
+	let visibleOwners = $derived((owners ?? []).filter((o) => o.phone || o.email));
+
+	// Pending reminder dismissals
+	const undoDelayMs = $derived(data.reminderUndoSeconds! * 1000);
+	const pendingDismiss = createPendingDismissals(getLocale, () => undoDelayMs);
+	const dismissFormRegistry = new Map<string, HTMLFormElement>();
+
+	$effect(() => () => pendingDismiss.cleanup());
+
 	function handleWindowKey(e: KeyboardEvent) {
 		if (e.key === 'Escape') {
 			if (avatarLightboxOpen) {
@@ -137,15 +146,6 @@
 			pendingDismiss.undoLast((id) => upcomingReminders.find((r) => r.id === id)?.title);
 		}
 	}
-
-	let visibleOwners = $derived((owners ?? []).filter((o) => o.phone || o.email));
-
-	// Pending reminder dismissals
-	const undoDelayMs = $derived((data.reminderUndoSeconds ?? 7) * 1000);
-	const pendingDismiss = createPendingDismissals(getLocale, () => undoDelayMs);
-	const dismissFormRegistry = new Map<string, HTMLFormElement>();
-
-	$effect(() => () => pendingDismiss.cleanup());
 </script>
 
 <svelte:window onkeydown={handleWindowKey} />

--- a/src/routes/(caretaker)/care/settings/+page.server.ts
+++ b/src/routes/(caretaker)/care/settings/+page.server.ts
@@ -7,7 +7,7 @@ import type { Locale } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
 import { isSecureRequest } from '$lib/server/auth';
-import { REMINDER_UNDO_PRESETS, REMINDER_UNDO_SECONDS_DEFAULT } from '$lib/server/env';
+import { REMINDER_UNDO_SECONDS_DEFAULT } from '$lib/server/env';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -15,8 +15,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	return {
 		user: locals.user,
 		upcomingShifts,
-		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT,
-		reminderUndoPresets: REMINDER_UNDO_PRESETS
+		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT
 	};
 };
 

--- a/src/routes/(caretaker)/care/settings/+page.server.ts
+++ b/src/routes/(caretaker)/care/settings/+page.server.ts
@@ -7,11 +7,17 @@ import type { Locale } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
 import { isSecureRequest } from '$lib/server/auth';
+import { REMINDER_UNDO_PRESETS, REMINDER_UNDO_SECONDS_DEFAULT } from '$lib/server/env';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
 	const upcomingShifts = await getUpcomingShifts(locals.user.id);
-	return { user: locals.user, upcomingShifts };
+	return {
+		user: locals.user,
+		upcomingShifts,
+		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT,
+		reminderUndoPresets: REMINDER_UNDO_PRESETS
+	};
 };
 
 export const actions: Actions = {
@@ -43,5 +49,30 @@ export const actions: Actions = {
 	account: async ({ request, locals, cookies }) => {
 		if (!locals.user) redirect(302, '/auth/login');
 		return handleAccountUpdate(locals.user.id, request, cookies, locals.locale);
+	},
+
+	reminderUndo: async ({ request, locals }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+
+		const data = await request.formData();
+		const raw = String(data.get('reminderUndoSeconds') ?? '');
+
+		let value: number | null;
+		if (raw === '' || raw === 'default') {
+			value = null;
+		} else {
+			const n = Number(raw);
+			if (!Number.isInteger(n) || !REMINDER_UNDO_PRESETS.includes(n)) {
+				return fail(400, { reminderUndoError: t(locals.locale, 'error.invalidReminderUndo') });
+			}
+			value = n;
+		}
+
+		await db
+			.update(schema.users)
+			.set({ reminderUndoSeconds: value })
+			.where(eq(schema.users.id, locals.user.id));
+
+		return { reminderUndoSuccess: true };
 	}
 };

--- a/src/routes/(caretaker)/care/settings/+page.server.ts
+++ b/src/routes/(caretaker)/care/settings/+page.server.ts
@@ -1,7 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { getUpcomingShifts } from '$lib/server/shifts';
-import { handleAccountUpdate } from '$lib/server/account';
+import { handleAccountUpdate, handleReminderUndoUpdate } from '$lib/server/account';
 import { t, SUPPORTED_LOCALES } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
@@ -53,26 +53,6 @@ export const actions: Actions = {
 
 	reminderUndo: async ({ request, locals }) => {
 		if (!locals.user) redirect(302, '/auth/login');
-
-		const data = await request.formData();
-		const raw = String(data.get('reminderUndoSeconds') ?? '');
-
-		let value: number | null;
-		if (raw === '' || raw === 'default') {
-			value = null;
-		} else {
-			const n = Number(raw);
-			if (!Number.isInteger(n) || !REMINDER_UNDO_PRESETS.includes(n)) {
-				return fail(400, { reminderUndoError: t(locals.locale, 'error.invalidReminderUndo') });
-			}
-			value = n;
-		}
-
-		await db
-			.update(schema.users)
-			.set({ reminderUndoSeconds: value })
-			.where(eq(schema.users.id, locals.user.id));
-
-		return { reminderUndoSuccess: true };
+		return handleReminderUndoUpdate(locals.user.id, request, locals.locale);
 	}
 };

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -9,6 +9,7 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import LocalTime from '$lib/components/LocalTime.svelte';
+	import ReminderUndoCard from '$lib/components/settings/ReminderUndoCard.svelte';
 	import { Calendar } from '@lucide/svelte';
 	import { SvelteDate } from 'svelte/reactivity';
 	import { t, getLocale, SUPPORTED_LOCALES, LOCALE_LABELS, type MessageKey } from '$lib/i18n';
@@ -18,7 +19,6 @@
 	const locale = getLocale();
 	let showPasswordFields = $state(false);
 	let localeForm: HTMLFormElement;
-	let reminderUndoForm: HTMLFormElement;
 	let expandedShiftId = $state<string | null>(null);
 
 	const now = new SvelteDate();
@@ -259,54 +259,15 @@
 		</CardContent>
 	</Card>
 
-	<Card>
-		<CardHeader>
-			<CardTitle>{t(locale, 'page.settings.reminderUndoCard')}</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<p class="text-sm text-muted-foreground mb-3">
-				{t(locale, 'page.settings.reminderUndoDescription')}
-			</p>
-			{#if form?.reminderUndoSuccess}
-				<Alert class="mb-3">
-					<AlertDescription>{t(locale, 'page.settings.reminderUndoUpdated')}</AlertDescription>
-				</Alert>
-			{/if}
-			{#if form?.reminderUndoError}
-				<Alert variant="destructive" class="mb-3">
-					<AlertDescription>{form.reminderUndoError}</AlertDescription>
-				</Alert>
-			{/if}
-			<form method="POST" action="?/reminderUndo" bind:this={reminderUndoForm} use:enhance>
-				<div class="max-w-[280px]">
-					<Label for="reminderUndoSeconds" class="sr-only"
-						>{t(locale, 'page.settings.reminderUndoLabel')}</Label
-					>
-					<Select
-						name="reminderUndoSeconds"
-						id="reminderUndoSeconds"
-						value={data.user?.reminderUndoSeconds == null
-							? 'default'
-							: String(data.user.reminderUndoSeconds)}
-						onchange={() => reminderUndoForm.requestSubmit()}
-					>
-						<option value="default"
-							>{t(locale, 'page.settings.reminderUndoDefault', {
-								seconds: data.reminderUndoDefault
-							})}</option
-						>
-						{#each data.reminderUndoPresets as preset (preset)}
-							<option value={String(preset)}>
-								{preset === 0
-									? t(locale, 'page.settings.reminderUndoOff')
-									: t(locale, 'page.settings.reminderUndoSeconds', { seconds: preset })}
-							</option>
-						{/each}
-					</Select>
-				</div>
-			</form>
-		</CardContent>
-	</Card>
+	<ReminderUndoCard
+		currentValue={data.user?.reminderUndoSeconds ?? null}
+		defaultSeconds={data.reminderUndoDefault}
+		presets={data.reminderUndoPresets}
+		successMessage={form?.reminderUndoSuccess
+			? t(locale, 'page.settings.reminderUndoUpdated')
+			: undefined}
+		errorMessage={form?.reminderUndoError}
+	/>
 
 	<!-- My Shifts -->
 	<Card id="shifts">

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -18,6 +18,7 @@
 	const locale = getLocale();
 	let showPasswordFields = $state(false);
 	let localeForm: HTMLFormElement;
+	let reminderUndoForm: HTMLFormElement;
 	let expandedShiftId = $state<string | null>(null);
 
 	const now = new SvelteDate();
@@ -251,6 +252,55 @@
 					>
 						{#each SUPPORTED_LOCALES as loc (loc)}
 							<option value={loc}>{LOCALE_LABELS[loc]}</option>
+						{/each}
+					</Select>
+				</div>
+			</form>
+		</CardContent>
+	</Card>
+
+	<Card>
+		<CardHeader>
+			<CardTitle>{t(locale, 'page.settings.reminderUndoCard')}</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<p class="text-sm text-muted-foreground mb-3">
+				{t(locale, 'page.settings.reminderUndoDescription')}
+			</p>
+			{#if form?.reminderUndoSuccess}
+				<Alert class="mb-3">
+					<AlertDescription>{t(locale, 'page.settings.reminderUndoUpdated')}</AlertDescription>
+				</Alert>
+			{/if}
+			{#if form?.reminderUndoError}
+				<Alert variant="destructive" class="mb-3">
+					<AlertDescription>{form.reminderUndoError}</AlertDescription>
+				</Alert>
+			{/if}
+			<form method="POST" action="?/reminderUndo" bind:this={reminderUndoForm} use:enhance>
+				<div class="max-w-[280px]">
+					<Label for="reminderUndoSeconds" class="sr-only"
+						>{t(locale, 'page.settings.reminderUndoLabel')}</Label
+					>
+					<Select
+						name="reminderUndoSeconds"
+						id="reminderUndoSeconds"
+						value={data.user?.reminderUndoSeconds == null
+							? 'default'
+							: String(data.user.reminderUndoSeconds)}
+						onchange={() => reminderUndoForm.requestSubmit()}
+					>
+						<option value="default"
+							>{t(locale, 'page.settings.reminderUndoDefault', {
+								seconds: data.reminderUndoDefault
+							})}</option
+						>
+						{#each data.reminderUndoPresets as preset (preset)}
+							<option value={String(preset)}>
+								{preset === 0
+									? t(locale, 'page.settings.reminderUndoOff')
+									: t(locale, 'page.settings.reminderUndoSeconds', { seconds: preset })}
+							</option>
 						{/each}
 					</Select>
 				</div>

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -262,7 +262,6 @@
 	<ReminderUndoCard
 		currentValue={data.user?.reminderUndoSeconds ?? null}
 		defaultSeconds={data.reminderUndoDefault}
-		presets={data.reminderUndoPresets}
 		successMessage={form?.reminderUndoSuccess
 			? t(locale, 'page.settings.reminderUndoUpdated')
 			: undefined}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -37,8 +37,6 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 		serverTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 		version,
 		year: new Date().getFullYear(),
-		reminderUndoSeconds: locals.user
-			? resolveReminderUndoSeconds(locals.user.reminderUndoSeconds)
-			: undefined
+		reminderUndoSeconds: resolveReminderUndoSeconds(locals.user?.reminderUndoSeconds ?? null)
 	};
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -37,6 +37,8 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 		serverTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 		version,
 		year: new Date().getFullYear(),
-		reminderUndoSeconds: resolveReminderUndoSeconds(locals.user?.reminderUndoSeconds)
+		reminderUndoSeconds: locals.user
+			? resolveReminderUndoSeconds(locals.user.reminderUndoSeconds)
+			: undefined
 	};
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -3,6 +3,7 @@ import type { LayoutServerLoad } from './$types';
 import { db, schema } from '$lib/server/db';
 import { version } from '../../package.json';
 import { t } from '$lib/i18n';
+import { resolveReminderUndoSeconds } from '$lib/server/env';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
 	const isApiRoute = url.pathname.startsWith('/api');
@@ -35,6 +36,7 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 		locale: locals.locale,
 		serverTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 		version,
-		year: new Date().getFullYear()
+		year: new Date().getFullYear(),
+		reminderUndoSeconds: resolveReminderUndoSeconds(locals.user?.reminderUndoSeconds)
 	};
 };


### PR DESCRIPTION
Closes #47 

Adds two ways to bypass the 7-second undo window when dismissing a Reminder:

- A **Dismiss now** button on the undo toast that commits the dismissal immediately.
- A **Reminder undo window** preset in user settings (Off / 3s / 7s / 15s, plus the site default). A new `REMINDER_UNDO_SECONDS` env var sets the site default and is shown in the dropdown so users can pick it explicitly.

When a user picks `Off`, dismissing a Reminder commits straight to the server with no toast. Per-user preference takes precedence over the env default. The env default is clamped to 60 seconds.

## What changed

**Schema**

- New nullable column `users.reminder_undo_seconds`. Migration `0007`. Null inherits the env default; `0` means no undo window.

**Config**

- `REMINDER_UNDO_SECONDS` env var (default `7`, max `60`). Documented in `.env.example`, `README.md`, and both compose files.

**Client store** (`src/lib/pendingDismiss.svelte.ts`)

- `commit(id, title)` replaces `commitNow(id)` and announces dismissal for screen readers.
- Instant-commit path (`delayMs <= 0`) also announces before submit.
- Timer callback in `scheduleSubmit` re-reads `pending[id]` before submitting. Fixes a double-POST race when commit/undo fires near the timer.
- `setAnnouncement` swaps a microtask trick for a monotonic counter plus zero-width space toggle so identical strings still re-announce reliably.
- `undoLast` falls back to a localized "Untitled reminder" when the title lookup misses.

**UI**

- New `Dismiss now` button on the undo toast across the member dashboard, reminders list, and caretaker dashboard.
- New `ReminderUndoCard` component (`src/lib/components/settings/`) used by both settings pages so the card no longer lives inline twice.
- The preset dropdown merges the env default into the option list, deduped and sorted, alongside a `Use site default` sentinel option.

**Server**

- `handleReminderUndoUpdate` in `src/lib/server/account.ts` is the single validator/writer. Both settings server actions delegate.
- Validates against `REMINDER_UNDO_PRESETS` plus the env default. Scopes the UPDATE to `locals.user.id`.
- Layout server load resolves `reminderUndoSeconds` for every authenticated request and falls back to the env default for anonymous routes (a non-sensitive integer).

**i18n**

- `common.reminder.dismissNow`, `common.reminder.untitled`, and seven `page.settings.reminderUndo*` keys added in en/de/es/fr/it/pt.
- German `dismissNow` reads `Jetzt erledigen` to match `Erledigt` for "Done".
- New `error.invalidReminderUndo` for failed validation.

**Client-safe split**

- Constants shared between server validator and client form (`REMINDER_UNDO_PRESETS`, `REMINDER_UNDO_MAX_SECONDS`, `REMINDER_UNDO_DEFAULT_SENTINEL`) live in `src/lib/reminderUndo.ts`. Server `env.ts` re-exports them. Avoids pulling `$env/dynamic/private` into the client bundle.
