### PR TITLE
Add Overview page for members/admins when there is more than one companion

### DIFF
--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -167,6 +167,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Navigation
 	'nav.dashboard': 'Übersicht',
+	'nav.overview': 'Übersicht',
 	'nav.journal': 'Tagebuch',
 	'nav.health': 'Gesundheit',
 	'nav.reminders': 'Erinnerungen',
@@ -369,6 +370,20 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Archivieren',
 	'page.companion.edit.labelArchiveDate': 'Datum',
 	'page.companion.edit.labelArchiveNote': 'Notiz',
+
+	// Page: overview (multi-companion landing)
+	'overview.title': 'Übersicht',
+	'overview.heading.reminders': 'Anstehende Erinnerungen (nächste 7 Tage)',
+	'overview.heading.todayJournal': 'Heutiges Tagebuch',
+	'overview.heading.recentActivity': 'Letzte Aktivitäten (letzte 7 Tage)',
+	'overview.empty.reminders': 'Nichts in den nächsten 7 Tagen fällig.',
+	'overview.empty.recent': 'In den letzten 7 Tagen keine Aktivität erfasst.',
+	'overview.empty.journal': 'Noch kein Eintrag für heute.',
+	'overview.journal.addToday': 'Heutigen Eintrag hinzufügen',
+	'overview.journal.editToday': 'Eintrag bearbeiten',
+	'overview.markDone': 'Als erledigt markieren',
+	'overview.day.today': 'Heute',
+	'overview.day.tomorrow': 'Morgen',
 
 	// Page: dashboard
 	'page.dashboard.archivedBanner': '{name} ist archiviert. Nur-Lese-Modus.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -153,6 +153,7 @@ const messages = {
 
 	// Navigation
 	'nav.dashboard': 'Dashboard',
+	'nav.overview': 'Overview',
 	'nav.journal': 'Journal',
 	'nav.health': 'Health',
 	'nav.reminders': 'Reminders',
@@ -362,6 +363,20 @@ const messages = {
 	'page.companion.edit.archive': 'Archive',
 	'page.companion.edit.labelArchiveDate': 'Date',
 	'page.companion.edit.labelArchiveNote': 'Note',
+
+	// Page: overview (multi-companion landing)
+	'overview.title': 'Overview',
+	'overview.heading.reminders': 'Upcoming Reminders (Next 7 Days)',
+	'overview.heading.todayJournal': "Today's Journal",
+	'overview.heading.recentActivity': 'Recent Activity (Last 7 Days)',
+	'overview.empty.reminders': 'Nothing due in the next 7 days.',
+	'overview.empty.recent': 'No activity logged in the last 7 days.',
+	'overview.empty.journal': 'No entry yet today.',
+	'overview.journal.addToday': "Add today's entry",
+	'overview.journal.editToday': 'Edit entry',
+	'overview.markDone': 'Mark as done',
+	'overview.day.today': 'Today',
+	'overview.day.tomorrow': 'Tomorrow',
 
 	// Page: dashboard (app companion dashboard)
 	'page.dashboard.archivedBanner': '{name} is archived. Viewing in read-only mode.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -166,6 +166,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Navigation
 	'nav.dashboard': 'Panel',
+	'nav.overview': 'Resumen',
 	'nav.journal': 'Diario',
 	'nav.health': 'Salud',
 	'nav.reminders': 'Recordatorios',
@@ -368,6 +369,20 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Archivar',
 	'page.companion.edit.labelArchiveDate': 'Fecha',
 	'page.companion.edit.labelArchiveNote': 'Nota',
+
+	// Page: overview (multi-companion landing)
+	'overview.title': 'Resumen',
+	'overview.heading.reminders': 'Recordatorios próximos (próximos 7 días)',
+	'overview.heading.todayJournal': 'Diario de hoy',
+	'overview.heading.recentActivity': 'Actividad reciente (últimos 7 días)',
+	'overview.empty.reminders': 'Nada pendiente en los próximos 7 días.',
+	'overview.empty.recent': 'Sin actividad registrada en los últimos 7 días.',
+	'overview.empty.journal': 'Aún no hay entrada hoy.',
+	'overview.journal.addToday': 'Añadir entrada de hoy',
+	'overview.journal.editToday': 'Editar entrada',
+	'overview.markDone': 'Marcar como hecho',
+	'overview.day.today': 'Hoy',
+	'overview.day.tomorrow': 'Mañana',
 
 	// Page: dashboard
 	'page.dashboard.archivedBanner': '{name} está archivado. Modo de solo lectura.',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -164,6 +164,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Navigation
 	'nav.dashboard': 'Tableau de bord',
+	'nav.overview': 'Aperçu',
 	'nav.journal': 'Journal',
 	'nav.health': 'Santé',
 	'nav.reminders': 'Rappels',
@@ -367,6 +368,20 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Archiver',
 	'page.companion.edit.labelArchiveDate': 'Date',
 	'page.companion.edit.labelArchiveNote': 'Note',
+
+	// Page: overview (multi-companion landing)
+	'overview.title': 'Aperçu',
+	'overview.heading.reminders': 'Rappels à venir (7 prochains jours)',
+	'overview.heading.todayJournal': "Journal d'aujourd'hui",
+	'overview.heading.recentActivity': 'Activité récente (7 derniers jours)',
+	'overview.empty.reminders': 'Rien à faire dans les 7 prochains jours.',
+	'overview.empty.recent': 'Aucune activité enregistrée ces 7 derniers jours.',
+	'overview.empty.journal': "Aucune entrée pour aujourd'hui.",
+	'overview.journal.addToday': "Ajouter l'entrée du jour",
+	'overview.journal.editToday': "Modifier l'entrée",
+	'overview.markDone': 'Marquer comme fait',
+	'overview.day.today': "Aujourd'hui",
+	'overview.day.tomorrow': 'Demain',
 
 	// Page: dashboard
 	'page.dashboard.archivedBanner': '{name} est archivé. Mode lecture seule.',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -162,6 +162,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Navigation
 	'nav.dashboard': 'Bacheca',
+	'nav.overview': 'Panoramica',
 	'nav.journal': 'Diario',
 	'nav.health': 'Salute',
 	'nav.reminders': 'Promemoria',
@@ -364,6 +365,20 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Archivia',
 	'page.companion.edit.labelArchiveDate': 'Data',
 	'page.companion.edit.labelArchiveNote': 'Nota',
+
+	// Page: overview (multi-companion landing)
+	'overview.title': 'Panoramica',
+	'overview.heading.reminders': 'Promemoria in arrivo (prossimi 7 giorni)',
+	'overview.heading.todayJournal': 'Diario di oggi',
+	'overview.heading.recentActivity': 'Attività recente (ultimi 7 giorni)',
+	'overview.empty.reminders': 'Niente in scadenza nei prossimi 7 giorni.',
+	'overview.empty.recent': 'Nessuna attività registrata negli ultimi 7 giorni.',
+	'overview.empty.journal': 'Ancora nessun appunto per oggi.',
+	'overview.journal.addToday': 'Aggiungi appunto di oggi',
+	'overview.journal.editToday': 'Modifica appunto',
+	'overview.markDone': 'Segna come fatto',
+	'overview.day.today': 'Oggi',
+	'overview.day.tomorrow': 'Domani',
 
 	// Page: dashboard (app companion dashboard)
 	'page.dashboard.archivedBanner': '{name} è archiviato. Visualizzazione in sola lettura.',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -163,6 +163,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Navigation
 	'nav.dashboard': 'Painel',
+	'nav.overview': 'Resumo',
 	'nav.journal': 'Diário',
 	'nav.health': 'Saúde',
 	'nav.reminders': 'Lembretes',
@@ -365,6 +366,20 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Arquivar',
 	'page.companion.edit.labelArchiveDate': 'Data',
 	'page.companion.edit.labelArchiveNote': 'Nota',
+
+	// Page: overview (multi-companion landing)
+	'overview.title': 'Resumo',
+	'overview.heading.reminders': 'Lembretes próximos (próximos 7 dias)',
+	'overview.heading.todayJournal': 'Diário de hoje',
+	'overview.heading.recentActivity': 'Atividade recente (últimos 7 dias)',
+	'overview.empty.reminders': 'Nada para os próximos 7 dias.',
+	'overview.empty.recent': 'Sem atividade registada nos últimos 7 dias.',
+	'overview.empty.journal': 'Ainda sem entrada hoje.',
+	'overview.journal.addToday': 'Adicionar entrada de hoje',
+	'overview.journal.editToday': 'Editar entrada',
+	'overview.markDone': 'Marcar como concluído',
+	'overview.day.today': 'Hoje',
+	'overview.day.tomorrow': 'Amanhã',
 
 	// Page: dashboard
 	'page.dashboard.archivedBanner': '{name} está arquivado. Modo de leitura.',

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -24,12 +24,16 @@
 
 	const locale = getLocale();
 
+	const OVERVIEW_VALUE = '__overview__';
+
 	let activeCompanionId = $derived(page.params.companionId ?? null);
 	let activeCompanion = $derived(
 		data.companions.find((c) => c.id === activeCompanionId) ??
 			data.archivedCompanions?.find((c) => c.id === activeCompanionId) ??
-			data.companions[0] ??
 			null
+	);
+	let isOverview = $derived(
+		activeCompanionId === null && page.url.pathname === '/' && data.companions.length > 1
 	);
 	let isViewingArchived = $derived(activeCompanion != null && !activeCompanion.isActive);
 
@@ -57,6 +61,10 @@
 	);
 
 	function switchCompanion(id: string) {
+		if (id === OVERVIEW_VALUE) {
+			goto('/');
+			return;
+		}
 		const parts = page.url.pathname.split('/');
 		// Only carry the section forward on standard companion sub-routes: /{companionId}/{section}
 		// Other routes (e.g. /companions/{id}/edit, /settings) go to the companion dashboard
@@ -127,11 +135,12 @@
 							>
 						{:else}
 							<Select
-								class="max-w-[160px]"
+								class="max-w-[180px]"
 								aria-label={t(locale, 'layout.switchCompanion')}
-								value={activeCompanionId ?? activeCompanion?.id}
+								value={isOverview ? OVERVIEW_VALUE : (activeCompanionId ?? OVERVIEW_VALUE)}
 								onchange={(e) => switchCompanion(e.currentTarget.value)}
 							>
+								<option value={OVERVIEW_VALUE}>{t(locale, 'nav.overview')}</option>
 								{#each data.companions as c (c.id)}
 									<option value={c.id}>{c.name}</option>
 								{/each}

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -74,6 +74,8 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 export const actions: Actions = {
 	complete: async ({ request, locals }) => {
 		if (!locals.user) return fail(401, { error: t(locals.locale, 'error.unauthorized') });
+		if (locals.user.role === 'caretaker')
+			return fail(403, { error: t(locals.locale, 'error.forbidden') });
 
 		const data = await request.formData();
 		const id = String(data.get('id') ?? '');
@@ -84,7 +86,10 @@ export const actions: Actions = {
 		if (!reminder) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 
 		const companion = await db.query.companions.findFirst({
-			where: eq(schema.companions.id, reminder.companionId)
+			where: and(
+				eq(schema.companions.id, reminder.companionId),
+				eq(schema.companions.isActive, true)
+			)
 		});
 		if (!companion) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
 

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -1,19 +1,95 @@
-import { redirect } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
+import { fail, redirect } from '@sveltejs/kit';
+import type { PageServerLoad, Actions } from './$types';
 import { db, schema } from '$lib/server/db';
-import { eq } from 'drizzle-orm';
+import { and, eq, gte, inArray, isNull, lte } from 'drizzle-orm';
+import { localDateISO } from '$lib/date';
+import { completeReminder } from '$lib/server/reminders';
+import { t } from '$lib/i18n';
 
-export const load: PageServerLoad = async ({ locals }) => {
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const RECENT_EVENT_LIMIT = 30;
+
+export const load: PageServerLoad = async ({ locals, parent }) => {
 	if (!locals.user) redirect(302, '/auth/login');
 
-	const first = await db.query.companions.findFirst({
-		where: eq(schema.companions.isActive, true),
-		orderBy: (c, { asc }) => [asc(c.name)]
-	});
+	const { companions } = await parent();
 
-	if (first) {
-		redirect(302, `/${first.id}`);
-	} else {
-		redirect(302, '/companions/new');
+	if (companions.length === 0) redirect(302, '/companions/new');
+	if (companions.length === 1) redirect(302, `/${companions[0].id}`);
+
+	const now = new Date();
+	const in7d = new Date(now.getTime() + SEVEN_DAYS_MS);
+	const ago7d = new Date(now.getTime() - SEVEN_DAYS_MS);
+	const today = localDateISO(now);
+	const ids = companions.map((c) => c.id);
+
+	const [upcomingReminders, recentDaily, recentHealth, todayJournal] = await Promise.all([
+		db.query.reminders.findMany({
+			where: and(
+				inArray(schema.reminders.companionId, ids),
+				isNull(schema.reminders.completedAt),
+				gte(schema.reminders.dueAt, now),
+				lte(schema.reminders.dueAt, in7d)
+			),
+			orderBy: (r, { asc }) => [asc(r.dueAt)],
+			with: { logger: { columns: { displayName: true } } }
+		}),
+		db.query.dailyEvents.findMany({
+			where: and(
+				inArray(schema.dailyEvents.companionId, ids),
+				gte(schema.dailyEvents.loggedAt, ago7d)
+			),
+			orderBy: (d, { desc }) => [desc(d.loggedAt)],
+			limit: RECENT_EVENT_LIMIT,
+			with: { logger: { columns: { displayName: true } } }
+		}),
+		db.query.healthEvents.findMany({
+			where: and(
+				inArray(schema.healthEvents.companionId, ids),
+				gte(schema.healthEvents.occurredAt, ago7d)
+			),
+			orderBy: (h, { desc }) => [desc(h.occurredAt)],
+			limit: RECENT_EVENT_LIMIT,
+			with: { logger: { columns: { displayName: true } } }
+		}),
+		db.query.journalEntries.findMany({
+			where: and(
+				inArray(schema.journalEntries.companionId, ids),
+				eq(schema.journalEntries.date, today)
+			),
+			with: { logger: { columns: { displayName: true } } }
+		})
+	]);
+
+	const todayJournalByCompanion = Object.fromEntries(todayJournal.map((j) => [j.companionId, j]));
+
+	return {
+		upcomingReminders,
+		recentDaily,
+		recentHealth,
+		todayJournalByCompanion
+	};
+};
+
+export const actions: Actions = {
+	complete: async ({ request, locals }) => {
+		if (!locals.user) return fail(401, { error: t(locals.locale, 'error.unauthorized') });
+
+		const data = await request.formData();
+		const id = String(data.get('id') ?? '');
+
+		const reminder = await db.query.reminders.findFirst({
+			where: eq(schema.reminders.id, id)
+		});
+		if (!reminder) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
+
+		const companion = await db.query.companions.findFirst({
+			where: eq(schema.companions.id, reminder.companionId)
+		});
+		if (!companion) return fail(404, { error: t(locals.locale, 'error.reminderNotFound') });
+
+		completeReminder(reminder, locals.user.id);
+
+		return { completeSuccess: true };
 	}
 };

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,0 +1,387 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { enhance } from '$app/forms';
+	import { t, getLocale } from '$lib/i18n';
+	import { Card, CardContent } from '$lib/components/ui/card/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import { CheckCheck, Pencil, Plus, Undo2 } from '@lucide/svelte';
+	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
+	import LocalTime from '$lib/components/LocalTime.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
+	import {
+		ACTIVITY_ICONS,
+		MOOD_ICONS,
+		REMINDER_ICONS,
+		activityLabel,
+		healthTypeLabel
+	} from '$lib/i18n/labels';
+	import { localDateISO } from '$lib/date';
+	import { createPendingDismissals } from '$lib/pendingDismiss.svelte';
+	import { registerDismissForm } from '$lib/actions/registerDismissForm';
+
+	let { data }: { data: PageData } = $props();
+	const locale = getLocale();
+
+	let companionsById = $derived(Object.fromEntries(data.companions.map((c) => [c.id, c])));
+
+	type Reminder = (typeof data.upcomingReminders)[number];
+	let remindersByDay = $derived.by(() => {
+		const out: Record<string, Reminder[]> = {};
+		for (const r of data.upcomingReminders) {
+			const day = localDateISO(new Date(r.dueAt));
+			(out[day] ??= []).push(r);
+		}
+		return out;
+	});
+	let reminderDays = $derived(Object.keys(remindersByDay).sort());
+
+	type DailyEvent = (typeof data.recentDaily)[number];
+	type HealthEvent = (typeof data.recentHealth)[number];
+	type MergedEvent =
+		| { kind: 'daily'; row: DailyEvent; at: Date }
+		| { kind: 'health'; row: HealthEvent; at: Date };
+
+	let recentTimeline = $derived.by<MergedEvent[]>(() => {
+		const merged: MergedEvent[] = [
+			...data.recentDaily.map((d) => ({
+				kind: 'daily' as const,
+				row: d,
+				at: new Date(d.loggedAt)
+			})),
+			...data.recentHealth.map((h) => ({
+				kind: 'health' as const,
+				row: h,
+				at: new Date(h.occurredAt)
+			}))
+		];
+		merged.sort((a, b) => b.at.getTime() - a.at.getTime());
+		return merged.slice(0, 20);
+	});
+
+	let undoDelayMs = $derived((data.reminderUndoSeconds ?? 0) * 1000);
+	const pendingDismiss = createPendingDismissals(
+		() => locale,
+		() => undoDelayMs
+	);
+	const dismissFormRegistry = new Map<string, HTMLFormElement>();
+	$effect(() => () => pendingDismiss.cleanup());
+
+	function handleWindowKey(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			pendingDismiss.undoLast((id) => data.upcomingReminders.find((r) => r.id === id)?.title);
+		}
+	}
+
+	function formatDayHeading(iso: string): string {
+		const today = localDateISO(new Date());
+		const tomorrow = localDateISO(new Date(Date.now() + 86400000));
+		if (iso === today) return t(locale, 'overview.day.today');
+		if (iso === tomorrow) return t(locale, 'overview.day.tomorrow');
+		const [y, m, d] = iso.split('-').map(Number);
+		return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+			weekday: 'short',
+			month: 'short',
+			day: 'numeric'
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>{t(locale, 'overview.title')} | EinVault</title>
+</svelte:head>
+
+<svelte:window onkeydown={handleWindowKey} />
+
+<div class="space-y-8 pb-20 md:pb-0">
+	<h1 class="sr-only">{t(locale, 'overview.title')}</h1>
+
+	<section class="space-y-3">
+		<h2 class="font-display text-xl font-bold text-foreground">
+			{t(locale, 'overview.heading.reminders')}
+		</h2>
+		{#if reminderDays.length === 0}
+			<Card>
+				<CardContent class="text-center py-8">
+					<p class="text-sm italic text-muted-foreground">
+						{t(locale, 'overview.empty.reminders')}
+					</p>
+				</CardContent>
+			</Card>
+		{:else}
+			<div class="space-y-4">
+				{#each reminderDays as day (day)}
+					<div class="space-y-2">
+						<h3
+							class="text-xs font-semibold uppercase tracking-wide text-muted-foreground sticky top-16 bg-background/95 backdrop-blur py-1 z-10"
+						>
+							{formatDayHeading(day)}
+						</h3>
+						<div class="space-y-2">
+							{#each remindersByDay[day] as r (r.id)}
+								{@const companion = companionsById[r.companionId]}
+								{@const isPending = pendingDismiss.isPending(r.id)}
+								<Card class="relative overflow-hidden {isPending ? 'bg-muted/40' : ''}">
+									<CardContent class="py-3">
+										<div class="flex items-start gap-3">
+											{#if companion}
+												<a href="/{companion.id}" aria-label={companion.name} class="shrink-0">
+													<CompanionAvatar
+														companionId={companion.id}
+														avatarPath={companion.avatarPath}
+														name={companion.name}
+														size="sm"
+													/>
+												</a>
+											{/if}
+											<div class="flex-1 min-w-0">
+												<div class="flex items-center gap-2 flex-wrap">
+													<span class="text-base" aria-hidden="true"
+														>{REMINDER_ICONS[r.type] ?? '📌'}</span
+													>
+													<span
+														class="font-medium {isPending
+															? 'line-through text-muted-foreground'
+															: 'text-foreground'}"
+													>
+														{r.title}
+													</span>
+												</div>
+												<p class="text-xs mt-0.5 text-muted-foreground">
+													{companion?.name ?? ''} ·
+													<LocalTime date={r.dueAt} format="time" />
+												</p>
+											</div>
+											<form
+												method="POST"
+												action="?/complete"
+												use:enhance
+												use:registerDismissForm={{
+													id: r.id,
+													registry: dismissFormRegistry
+												}}
+												class="shrink-0"
+											>
+												<input type="hidden" name="id" value={r.id} />
+												{#if isPending}
+													<div class="flex items-center gap-1">
+														<Button
+															type="button"
+															variant="ghost"
+															size="sm"
+															class="h-7 gap-1.5 px-2 text-xs text-primary"
+															onclick={() => pendingDismiss.undo(r.id, r.title)}
+															title={t(locale, 'common.reminder.undo')}
+															aria-label={t(locale, 'common.reminder.undo')}
+															onmouseenter={() => pendingDismiss.pause(r.id)}
+															onmouseleave={() => pendingDismiss.resume(r.id)}
+															onfocusin={() => pendingDismiss.pause(r.id)}
+															onfocusout={() => pendingDismiss.resume(r.id)}
+														>
+															<Undo2 class="h-3.5 w-3.5" />
+															<span class="hidden sm:inline"
+																>{t(locale, 'common.reminder.undo')}</span
+															>
+														</Button>
+														<Button
+															type="button"
+															variant="ghost"
+															size="sm"
+															class="h-7 gap-1.5 px-2 text-xs"
+															onclick={() => pendingDismiss.commit(r.id, r.title)}
+															title={t(locale, 'common.reminder.dismissNow')}
+															aria-label={t(locale, 'common.reminder.dismissNow')}
+														>
+															<CheckCheck class="h-3.5 w-3.5" />
+															<span class="hidden sm:inline"
+																>{t(locale, 'common.reminder.dismissNow')}</span
+															>
+														</Button>
+													</div>
+												{:else}
+													<Button
+														type="button"
+														variant="ghost"
+														size="sm"
+														class="h-7 gap-1.5 px-2 text-xs"
+														aria-label={t(locale, 'overview.markDone')}
+														onclick={() => {
+															const form = dismissFormRegistry.get(r.id);
+															if (form) pendingDismiss.queue(r.id, form, r.title);
+														}}
+													>
+														<CheckCheck class="h-3.5 w-3.5" />
+														<span class="hidden sm:inline">{t(locale, 'common.reminder.done')}</span
+														>
+													</Button>
+												{/if}
+											</form>
+										</div>
+									</CardContent>
+									{#if isPending}
+										<span
+											class="dismiss-countdown absolute bottom-0 left-0 h-0.5 bg-primary/70"
+											style="--dismiss-ms: {undoDelayMs}ms"
+											aria-hidden="true"
+										></span>
+									{/if}
+								</Card>
+							{/each}
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</section>
+
+	<Separator />
+
+	<section class="space-y-3">
+		<h2 class="font-display text-xl font-bold text-foreground">
+			{t(locale, 'overview.heading.todayJournal')}
+		</h2>
+		<div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
+			{#each data.companions as companion (companion.id)}
+				{@const entry = data.todayJournalByCompanion[companion.id]}
+				<Card>
+					<CardContent class="py-4">
+						<div class="flex items-center gap-2 mb-2">
+							<CompanionAvatar
+								companionId={companion.id}
+								avatarPath={companion.avatarPath}
+								name={companion.name}
+								size="sm"
+							/>
+							<span class="font-medium text-sm text-foreground truncate">{companion.name}</span>
+							{#if entry?.mood}
+								<span class="text-base ml-auto" aria-hidden="true">{MOOD_ICONS[entry.mood]}</span>
+							{/if}
+						</div>
+						{#if entry}
+							{#if entry.body}
+								<p class="text-sm text-muted-foreground line-clamp-3 mb-2 whitespace-pre-line">
+									{entry.body}
+								</p>
+							{:else}
+								<p class="text-xs italic text-muted-foreground mb-2">
+									{t(locale, 'overview.empty.journal')}
+								</p>
+							{/if}
+							<Button
+								href="/{companion.id}/journal/{entry.date}"
+								variant="ghost"
+								size="sm"
+								class="h-7 gap-1.5 px-2 text-xs"
+							>
+								<Pencil class="h-3.5 w-3.5" />
+								{t(locale, 'overview.journal.editToday')}
+							</Button>
+						{:else}
+							<p class="text-xs italic text-muted-foreground mb-2">
+								{t(locale, 'overview.empty.journal')}
+							</p>
+							<Button
+								href="/{companion.id}/journal/{localDateISO(new Date())}"
+								variant="ghost"
+								size="sm"
+								class="h-7 gap-1.5 px-2 text-xs"
+							>
+								<Plus class="h-3.5 w-3.5" />
+								{t(locale, 'overview.journal.addToday')}
+							</Button>
+						{/if}
+					</CardContent>
+				</Card>
+			{/each}
+		</div>
+	</section>
+
+	<Separator />
+
+	<section class="space-y-3">
+		<h2 class="font-display text-xl font-bold text-foreground">
+			{t(locale, 'overview.heading.recentActivity')}
+		</h2>
+		{#if recentTimeline.length === 0}
+			<Card>
+				<CardContent class="text-center py-8">
+					<p class="text-sm italic text-muted-foreground">
+						{t(locale, 'overview.empty.recent')}
+					</p>
+				</CardContent>
+			</Card>
+		{:else}
+			<div class="space-y-2">
+				{#each recentTimeline as event (event.kind + ':' + event.row.id)}
+					{@const companion = companionsById[event.row.companionId]}
+					<Card>
+						<CardContent class="py-3">
+							<div class="flex items-start gap-3">
+								{#if companion}
+									<a href="/{companion.id}" aria-label={companion.name} class="shrink-0">
+										<CompanionAvatar
+											companionId={companion.id}
+											avatarPath={companion.avatarPath}
+											name={companion.name}
+											size="sm"
+										/>
+									</a>
+								{/if}
+								<div class="flex-1 min-w-0">
+									<div class="flex items-center gap-2 flex-wrap">
+										{#if event.kind === 'daily'}
+											<span class="text-base" aria-hidden="true"
+												>{ACTIVITY_ICONS[event.row.type] ?? '📝'}</span
+											>
+											<span class="font-medium text-sm text-foreground"
+												>{activityLabel(locale, event.row.type)}</span
+											>
+											{#if event.row.durationMinutes}
+												<Badge variant="secondary">{event.row.durationMinutes}m</Badge>
+											{/if}
+										{:else}
+											<span class="text-base" aria-hidden="true">🏥</span>
+											<span class="font-medium text-sm text-foreground truncate"
+												>{event.row.title}</span
+											>
+											<Badge variant="secondary">{healthTypeLabel(locale, event.row.type)}</Badge>
+										{/if}
+									</div>
+									{#if event.kind === 'daily' && event.row.notes}
+										<p class="text-xs mt-0.5 text-muted-foreground line-clamp-2">
+											{event.row.notes}
+										</p>
+									{/if}
+									<p class="text-xs mt-0.5 text-muted-foreground">
+										{companion?.name ?? ''} ·
+										<LocalTime date={event.at} format="datetime" /><ByLine
+											user={event.row.logger}
+											variant="inline"
+										/>
+									</p>
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+				{/each}
+			</div>
+		{/if}
+	</section>
+</div>
+
+<div class="sr-only" role="status" aria-live="polite">{pendingDismiss.announcement}</div>
+
+<style>
+	.dismiss-countdown {
+		animation: dismiss-shrink var(--dismiss-ms) linear forwards;
+	}
+	@keyframes dismiss-shrink {
+		from {
+			width: 100%;
+		}
+		to {
+			width: 0;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds an Overview landing page at `/` for members and admins who have two or more active companions. Single-companion users still go straight to their companion's dashboard, and caretakers are still routed to `/care`. Closes #48 (Phase 1).

## What changed

### Routing

`src/routes/(app)/+page.server.ts` was a redirect-only loader. It now branches on the active-companion count loaded from the layout:

- 0 active: redirect to `/companions/new`.
- 1 active: redirect to `/{id}`. Same UX as before.
- 2+ active: load Overview data and render the new page.

### Overview UI (`src/routes/(app)/+page.svelte`)

Three sections, single column:

1. **Upcoming Reminders (Next 7 Days).** Grouped by day with sticky day headers ("Today", "Tomorrow", or weekday + date). Each row shows the companion avatar, reminder title, time, and the same Undo / Dismiss-now / Done button group used on the per-companion reminders page. Reuses `pendingDismiss` and `registerDismissForm` so the undo-toast UX is identical. Escape undoes the most recent dismiss.
2. **Today's Journal.** One card per companion in a responsive auto-fit grid. Cards either show the existing entry (mood, truncated body, Edit) or an "Add today's entry" CTA pointing at `/{id}/journal/{today}`.
3. **Recent Activity (Last 7 Days).** Daily and health events merged client-side, sorted desc, capped at 20. Each row shows companion, activity icon and label, time, and `<ByLine />`.

Each section has an empty state. There's an `aria-live="polite"` announcement region for dismissals.

### Data loading

Overview queries are aggregated via `inArray(companionId, ids)` in a single `Promise.all`:

- `upcomingReminders`: not completed, due in `[now, now+7d]`, asc by `dueAt`, with `logger`.
- `recentDaily` and `recentHealth`: last 7 days, desc, `limit: 30` each, with `logger`.
- `todayJournal`: keyed into `Record<companionId, JournalEntry>` for O(1) lookup in the page.

### `complete` form action

Mirrors the per-companion dashboard's `complete` action so Overview reminder rows can mark-done in place. It also includes a role and ownership gate that the per-companion equivalent currently lacks. Caretakers get a 403 (SvelteKit runs form actions before layout `load`, so the `(app)` layout's caretaker redirect doesn't fire in time), and the companion is required to be `isActive = true`. Falls through to the shared `completeReminder` helper for the actual transaction and recurring-reminder spawn.

### Switcher (`src/routes/(app)/+layout.svelte`)

- Adds an `OVERVIEW_VALUE` sentinel option to the existing native `<Select>`. Visible only when `companions.length > 1`.
- Removes the `?? data.companions[0]` fallback from `activeCompanion` so the switcher no longer pretends a companion is active while on Overview. All downstream uses are already guarded (`{#if activeCompanion}`, `navItems.length > 0`), so the sidebar and bottom nav correctly disappear on Overview.
- `switchCompanion` branches on the sentinel: `goto('/')` for Overview, otherwise the existing path-preserving logic.

### i18n

Adds `nav.overview` and an `overview.*` block (12 keys) across all six locales. Reuses existing locale-specific renderings of `nav.caretaker.overview` for `nav.overview` and `overview.title` (Übersicht / Resumen / Aperçu / Panoramica / Resumo). Other strings are best-effort translations matching the tone of nearby keys.

### Out of scope

Deferred to follow-up PRs:

- Multi-companion picker on activity and journal forms (Phase 2, schema-touching).
- Pinned companions, configurable timespan, caretaker overview, route rename.

## Test plan

- [ ] **0 companions**: archive all, visit `/`, redirected to `/companions/new`.
- [ ] **1 active companion**: visit `/`, redirected to `/{id}`. Switcher shows just the companion (no Overview entry, since `length > 1` gate). each companion. Sidebar and bottom nav absent on Overview. Logo links to `/`.
- [ ] Switcher to companion goes to `/{id}`, sidebar appears. Switcher to Overview goes to `/`, sidebar gone.
- [ ] From `/{id}/journal`, switching to another companion goes to `/{otherId}/journal`. Switching to Overview goes to `/` (does not append `/journal`).
- [ ] Mark-as-done on an Overview reminder triggers the undo modal; row disappears after the timer. Undo restores it; Dismiss-now commits immediately. Escape undoes the most recent.
- [ ] Today's Journal cards span the full container width with 2, 3, or more companions.
- [ ] Caretaker login still bounced to `/care` (regression).
- [ ] Caretaker POSTing directly to `/?/complete` (e.g., via curl) returns 403. Reminder remains uncompleted.
- [ ] POSTing `/?/complete` for a reminder belonging to an archived companion returns 404.
- [ ] `npm run check` clean (catches missing locale keys).
- [ ] `npm run lint` clean.