### PR TITLE
Harden supply chain, CI, and release pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary
+    groups:
+      svelte:
+        patterns:
+          - 'svelte'
+          - 'svelte-*'
+          - '@sveltejs/*'
+          - 'prettier-plugin-svelte'
+          - 'eslint-plugin-svelte'
+      eslint:
+        patterns:
+          - 'eslint'
+          - '@eslint/*'
+          - '@typescript-eslint/*'
+          - 'typescript-eslint'
+      tailwind:
+        patterns:
+          - 'tailwindcss'
+          - '@tailwindcss/*'
+      types:
+        patterns:
+          - '@types/*'
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns:
+          - '*'
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,8 @@ updates:
         patterns:
           - '@types/*'
       minor-and-patch:
+        patterns:
+          - '*'
         update-types:
           - minor
           - patch
@@ -38,6 +40,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 5
     groups:
       actions:
         patterns:
@@ -48,3 +51,4 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,14 +4,17 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -55,6 +57,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -64,3 +67,21 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/einvault
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+          vuln-type: 'os,library'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,27 +79,36 @@ jobs:
           provenance: mode=max
           sbom: true
 
-      - name: Scan image with Trivy (linux/amd64)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      - name: Set up Trivy
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6
         with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: '1'
-          vuln-type: 'os,library'
+          cache: true
+
+      - name: Scan image with Trivy (linux/amd64)
         env:
-          TRIVY_PLATFORM: linux/amd64
+          IMAGE: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
+        run: |
+          trivy image \
+            --platform linux/amd64 \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --exit-code 1 \
+            --vuln-type os,library \
+            --skip-db-update \
+            "$IMAGE"
 
       - name: Scan image with Trivy (linux/arm64)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: '1'
-          vuln-type: 'os,library'
         env:
-          TRIVY_PLATFORM: linux/arm64
+          IMAGE: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
+        run: |
+          trivy image \
+            --platform linux/arm64 \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --exit-code 1 \
+            --vuln-type os,library \
+            --skip-db-update \
+            "$IMAGE"
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -114,8 +123,7 @@ jobs:
           SOURCE: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.meta-release.outputs.tags }}
         run: |
-          while IFS= read -r tag; do
-            [ -z "$tag" ] && continue
-            echo "promoting $tag"
-            docker buildx imagetools create -t "$tag" "$SOURCE"
-          done <<< "$TAGS"
+          set -euo pipefail
+          printf '%s\n' "$TAGS" \
+            | grep -v '^$' \
+            | xargs -r -P4 -I{} sh -c 'echo "promoting $1"; docker buildx imagetools create -t "$1" "$2"' _ {} "$SOURCE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -25,6 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: lint
+    if: always() && needs.lint.result != 'failure' && needs.lint.result != 'cancelled'
     permissions:
       contents: read
       packages: write
@@ -45,14 +47,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Extract metadata
-        id: meta
+      - name: Extract sha tag metadata
+        id: meta-sha
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/einvault
+          tags: |
+            type=sha,prefix=sha-
+
+      - name: Extract release tag metadata
+        id: meta-release
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/einvault
           tags: |
             type=ref,event=branch
-            type=sha,prefix=sha-
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
@@ -62,13 +71,35 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-sha.outputs.tags }}
+          labels: ${{ steps.meta-sha.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max
           sbom: true
+
+      - name: Scan image with Trivy (linux/amd64)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+          vuln-type: 'os,library'
+        env:
+          TRIVY_PLATFORM: linux/amd64
+
+      - name: Scan image with Trivy (linux/arm64)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+          vuln-type: 'os,library'
+        env:
+          TRIVY_PLATFORM: linux/arm64
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -77,11 +108,14 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
-      - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: '1'
-          vuln-type: 'os,library'
+      - name: Promote release tags
+        if: steps.meta-release.outputs.tags != ''
+        env:
+          SOURCE: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta-release.outputs.tags }}
+        run: |
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "promoting $tag"
+            docker buildx imagetools create -t "$tag" "$SOURCE"
+          done <<< "$TAGS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,16 +7,19 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run lint
 
   build:
@@ -28,21 +31,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/einvault
           tags: |
@@ -52,7 +55,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ EinVault is a small homelab project. The goal is to keep it simple, self-contain
 
 Open an issue. Include what you were doing, what you expected, what actually happened, and steps to reproduce. Attach relevant logs (`docker logs einvault` or dev server output). The more specific, the better.
 
+For suspected security vulnerabilities, do not open a public issue. See [SECURITY.md](SECURITY.md) for the private disclosure path.
+
 ## Feature requests
 
 Before opening one, ask yourself: does this work without any external service? Can it run air-gapped? Does it fit a companion health/care tracker? Features that phone home, require third-party accounts, or pull in heavy new runtimes are unlikely to land.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1.7
 
+ARG NODE_IMAGE=node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+
 # deps
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS deps
+FROM ${NODE_IMAGE} AS deps
 
 WORKDIR /build
 
@@ -15,7 +17,7 @@ RUN npm ci --ignore-scripts \
 
 
 # builder
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
+FROM ${NODE_IMAGE} AS builder
 
 WORKDIR /build
 
@@ -26,11 +28,11 @@ ENV NODE_ENV=production
 RUN npm run build
 
 # Prune to production deps only (prune preserves compiled native modules)
-RUN npm prune --omit=dev --ignore-scripts
+RUN npm prune --omit=dev
 
 
 # runner
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS runner
+FROM ${NODE_IMAGE} AS runner
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # deps
-FROM node:24-alpine AS deps
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS deps
 
 WORKDIR /build
 
@@ -9,29 +9,28 @@ WORKDIR /build
 RUN apk add --no-cache python3 make g++
 
 COPY package.json package-lock.json ./
-RUN npm ci --ignore-scripts=false
+# Default-deny install scripts; rebuild only the two native modules that need them.
+RUN npm ci --ignore-scripts \
+    && npm rebuild better-sqlite3 sharp
 
 
 # builder
-FROM node:24-alpine AS builder
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
 
 WORKDIR /build
 
 COPY --from=deps /build/node_modules ./node_modules
 COPY . .
 
-# Generate Drizzle migrations before build
-RUN npm run db:generate
-
 ENV NODE_ENV=production
 RUN npm run build
 
 # Prune to production deps only (prune preserves compiled native modules)
-RUN npm prune --omit=dev
+RUN npm prune --omit=dev --ignore-scripts
 
 
 # runner
-FROM node:24-alpine AS runner
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS runner
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,23 @@ docker compose -f docker-compose.prod.yml start einvault
 
 ### Image tags
 
-| Tag            | Description                                          |
-| -------------- | ---------------------------------------------------- |
-| `latest`       | Latest stable release (published on version tags)    |
-| `x.y.z`        | Pinned release                                       |
-| `x.y`          | Latest patch of a minor release                      |
-| `main`         | Latest commit on `main` — unstable, for testing only |
-| `sha-<commit>` | Specific commit build, useful for rollback           |
+| Tag            | Description                                         |
+| -------------- | --------------------------------------------------- |
+| `latest`       | Latest stable release (published on version tags)   |
+| `x.y.z`        | Pinned release                                      |
+| `x.y`          | Latest patch of a minor release                     |
+| `main`         | Latest commit on `main`, unstable, for testing only |
+| `sha-<commit>` | Specific commit build, useful for rollback          |
+
+### Verifying releases
+
+Each release image carries a Sigstore-signed SLSA provenance attestation and a SPDX SBOM, and only ships after Trivy clears the OS and library packages on both `linux/amd64` and `linux/arm64`. See [SECURITY.md](SECURITY.md#verifying-releases) for the verification commands.
+
+For tag selection:
+
+- **`:latest`** is the lowest-friction default and what `docker-compose.prod.yml` uses. A `docker compose pull` will follow new releases automatically, so a hypothetical poisoned release would auto-deploy. Acceptable for casual homelab use, especially when paired with manual `gh attestation verify` before the pull.
+- **`:vX.Y.Z`** pins to a specific release. Auto-updaters like Watchtower will not move past it. Recommended for production deployments.
+- **`@sha256:<digest>`** pins to the exact bytes you verified. Immune to registry retags or future republishing. Recommended for hardened deployments.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ EinVault is a self-hosted application with a single supported release line: the 
 
 Please report suspected vulnerabilities privately via GitHub's "Report a vulnerability" form on the repository's Security tab (<https://github.com/davefatkin/EinVault/security/advisories/new>).
 
-If you cannot use GitHub Security Advisories, email the maintainer at <dave@einvault.com> with the subject prefix `[EinVault security]`.
+If you cannot use GitHub Security Advisories, email the maintainer at <security@einvault.com> with the subject prefix `[EinVault security]`.
 
 Please include:
 
@@ -34,3 +34,26 @@ Out of scope:
 - Vulnerabilities in self-hosted deployments caused by misconfiguration of the surrounding environment (reverse proxy, TLS, OS, container runtime)
 - Issues that require a pre-existing administrator account to exploit
 - Denial of service that depends on uncapped resource limits the operator is expected to set (`UPLOAD_MAX_MB`, `MAX_DAILY_PHOTOS`, request rate-limiting at the reverse proxy)
+
+## Verifying releases
+
+Published container images at `ghcr.io/davefatkin/einvault` carry both an SLSA build provenance attestation (signed via Sigstore) and an SPDX SBOM, generated automatically by the release workflow.
+
+To verify a release before pulling it into production:
+
+```bash
+# Verify SLSA provenance using the GitHub CLI:
+gh attestation verify oci://ghcr.io/davefatkin/einvault:vX.Y.Z \
+    --repo davefatkin/EinVault
+
+# Inspect the SBOM bundled with the image:
+docker buildx imagetools inspect \
+    ghcr.io/davefatkin/einvault:vX.Y.Z \
+    --format '{{ json .SBOM }}'
+```
+
+Pin deployments to a specific digest rather than a floating tag so that what you verified is what you run:
+
+```yaml
+image: ghcr.io/davefatkin/einvault@sha256:<digest from the verified manifest>
+```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security policy
+
+## Supported versions
+
+EinVault is a self-hosted application with a single supported release line: the latest tagged version on `main`. Older versions do not receive backported fixes.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately via GitHub's "Report a vulnerability" form on the repository's Security tab (<https://github.com/davefatkin/EinVault/security/advisories/new>).
+
+If you cannot use GitHub Security Advisories, email the maintainer at <dave@einvault.com> with the subject prefix `[EinVault security]`.
+
+Please include:
+
+- A description of the issue and its impact
+- Steps to reproduce, or a proof-of-concept
+- The affected version (commit SHA or release tag)
+- Any suggested remediation, if you have one
+
+You can expect an initial acknowledgement within 7 days. Please do not file public issues, pull requests, or discussions for unpatched vulnerabilities.
+
+## Scope
+
+In scope:
+
+- Authentication and session handling (local password, OIDC)
+- Authorization and role enforcement (admin, member, caretaker)
+- Data exposure between users and across companions
+- Server-side request handling, file upload, and image processing
+- Supply-chain integrity of published container images and dependencies
+
+Out of scope:
+
+- Vulnerabilities in self-hosted deployments caused by misconfiguration of the surrounding environment (reverse proxy, TLS, OS, container runtime)
+- Issues that require a pre-existing administrator account to exploit
+- Denial of service that depends on uncapped resource limits the operator is expected to set (`UPLOAD_MAX_MB`, `MAX_DAILY_PHOTOS`, request rate-limiting at the reverse proxy)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3062,9 +3062,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "einvault",
 			"version": "0.8.1",
 			"dependencies": {
+				"@fontsource-variable/fraunces": "5.2.9",
+				"@fontsource-variable/geist": "5.2.9",
+				"@fontsource-variable/geist-mono": "5.2.8",
 				"@lucide/svelte": "^1.0.1",
 				"@oslojs/crypto": "^1.0.1",
 				"@oslojs/encoding": "^1.1.0",
@@ -889,6 +892,33 @@
 				"@noble/hashes": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@fontsource-variable/fraunces": {
+			"version": "5.2.9",
+			"resolved": "https://registry.npmjs.org/@fontsource-variable/fraunces/-/fraunces-5.2.9.tgz",
+			"integrity": "sha512-Y6IjunlN9Ni723np+GIgAaKzCDBrPRrqNi01TZxHs5wtHYROWFM9W6yiT+/gGwSjWIRD18oX17kD/BRWekc/Lw==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
+		},
+		"node_modules/@fontsource-variable/geist": {
+			"version": "5.2.9",
+			"resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.9.tgz",
+			"integrity": "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
+		},
+		"node_modules/@fontsource-variable/geist-mono": {
+			"version": "5.2.8",
+			"resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.2.8.tgz",
+			"integrity": "sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA==",
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
 			}
 		},
 		"node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
 		"vite": "^8.0.5"
 	},
 	"dependencies": {
+		"@fontsource-variable/fraunces": "5.2.9",
+		"@fontsource-variable/geist": "5.2.9",
+		"@fontsource-variable/geist-mono": "5.2.8",
 		"@lucide/svelte": "^1.0.1",
 		"@oslojs/crypto": "^1.0.1",
 		"@oslojs/encoding": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",
-		"build": "NODE_ENV=production svelte-kit sync && vite build",
+		"build": "NODE_ENV=production npm run -s _build",
+		"_build": "svelte-kit sync && vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",
-		"build": "svelte-kit sync && vite build",
+		"build": "NODE_ENV=production svelte-kit sync && vite build",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap');
+@import '@fontsource-variable/fraunces';
+@import '@fontsource-variable/fraunces/wght-italic.css';
+@import '@fontsource-variable/geist';
+@import '@fontsource-variable/geist-mono';
 
 @import 'tailwindcss';
 @plugin "@tailwindcss/typography";
@@ -18,9 +20,9 @@
 	--container-2xl: 1400px;
 
 	/* Font families */
-	--font-sans: 'Geist', system-ui, sans-serif;
-	--font-mono: 'Geist Mono', monospace;
-	--font-display: 'Fraunces', Georgia, serif;
+	--font-sans: 'Geist Variable', system-ui, sans-serif;
+	--font-mono: 'Geist Mono Variable', monospace;
+	--font-display: 'Fraunces Variable', Georgia, serif;
 
 	/* Semantic colour tokens — wired to CSS variables so that
 	   light/dark overrides in :root / .dark still drive them.    */

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -14,18 +14,10 @@ const securityHeaders: Handle = async ({ event, resolve }) => {
 	response.headers.set('X-Content-Type-Options', 'nosniff');
 	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-	response.headers.set(
-		'Content-Security-Policy',
-		[
-			"default-src 'self'",
-			"script-src 'self' 'unsafe-inline'",
-			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-			"img-src 'self' data: blob:",
-			"font-src 'self' https://fonts.gstatic.com",
-			"connect-src 'self'",
-			"frame-ancestors 'none'"
-		].join('; ')
-	);
+
+	// CSP is emitted by SvelteKit (see svelte.config.js `kit.csp`) so that the
+	// per-render nonce flows through `%sveltekit.nonce%` and we can drop
+	// `unsafe-inline` from script-src.
 
 	if (env.NODE_ENV === 'production') {
 		response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -15,9 +15,17 @@ const securityHeaders: Handle = async ({ event, resolve }) => {
 	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
 
-	// CSP is emitted by SvelteKit (see svelte.config.js `kit.csp`) so that the
-	// per-render nonce flows through `%sveltekit.nonce%` and we can drop
-	// `unsafe-inline` from script-src.
+	// CSP is normally emitted by SvelteKit (see svelte.config.js `kit.csp`) so
+	// the per-render nonce flows through `%sveltekit.nonce%`. If a `+server.ts`
+	// returns HTML without going through SvelteKit's renderer, fall back to a
+	// strict no-inline baseline so it doesn't ship without any CSP at all.
+	const contentType = response.headers.get('content-type') ?? '';
+	if (contentType.startsWith('text/html') && !response.headers.has('content-security-policy')) {
+		response.headers.set(
+			'Content-Security-Policy',
+			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+		);
+	}
 
 	if (env.NODE_ENV === 'production') {
 		response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,6 +7,12 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 // also present, so production gets a strict nonce-only policy.
 const dev = process.env.NODE_ENV !== 'production';
 
+if (process.env.npm_lifecycle_event === 'build' && dev) {
+	throw new Error(
+		`svelte.config.js: NODE_ENV must be "production" during build, got: ${JSON.stringify(process.env.NODE_ENV)}`
+	);
+}
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	preprocess: vitePreprocess(),

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,6 +1,12 @@
 import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
+// Vite HMR injects inline scripts into the dev server response that bypass
+// SvelteKit's nonce machinery, so dev needs `'unsafe-inline'` to function.
+// CSP Level 3 (all modern browsers) ignores `'unsafe-inline'` when a nonce is
+// also present, so production gets a strict nonce-only policy.
+const dev = process.env.NODE_ENV !== 'production';
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	preprocess: vitePreprocess(),
@@ -12,9 +18,9 @@ const config = {
 			mode: 'nonce',
 			directives: {
 				'default-src': ['self'],
-				'script-src': ['self'],
-				'style-src': ['self', 'unsafe-inline', 'https://fonts.googleapis.com'],
-				'font-src': ['self', 'https://fonts.gstatic.com'],
+				'script-src': dev ? ['self', 'unsafe-inline'] : ['self'],
+				'style-src': ['self', 'unsafe-inline'],
+				'font-src': ['self'],
 				'img-src': ['self', 'data:', 'blob:'],
 				'connect-src': ['self'],
 				'frame-ancestors': ['none'],


### PR DESCRIPTION
## Why?

With the proliferation of supply chain attacks, I figured I'd take a stab at tightening things up around here. I'm no devops or security engineer, so Claude helped out with this one. Worth it? Who knows?

## Summary

Closes a set of supply-chain gaps surfaced by an audit covering dependencies, CI, the container build, runtime CSP, and the release pipeline. No application behaviour changes for end users. Operators of self-hosted instances should pin deployments to a published digest after the next release so the SLSA attestation can actually be verified.

## CI and dependency perimeter

`.github/dependabot.yml` is new. It groups npm bumps (svelte, eslint, tailwind, types, plus a `*` catch-all for minor/patch), adds the `github-actions` and `docker` ecosystems, and sets `open-pull-requests-limit` per ecosystem.

Every third-party action in `lint.yml` and `release.yml` is now pinned by 40-character commit SHA with the version recorded in a trailing comment. Both workflows have a top-level `permissions: contents: read` so `GITHUB_TOKEN` defaults to read-only.

`npm ci` in CI runs with `--ignore-scripts`. The duplicate lint job in `release.yml` is gated on `startsWith(github.ref, 'refs/tags/v')` so it stops re-running on every main push; the build job uses `if: always() && needs.lint.result != 'failure' && needs.lint.result != 'cancelled'` to handle the skipped case cleanly.

`SECURITY.md` documents the private disclosure path (GitHub Security Advisories or `security@einvault.com`) and the commands operators can run to verify a release.

## Container build

The Dockerfile pins `node:24-alpine` by digest, declared once via `ARG NODE_IMAGE` so Dependabot has a single line to bump and the three build stages stay in lockstep.

The deps stage runs `npm ci --ignore-scripts` and then `npm rebuild better-sqlite3 sharp`, which restricts install-script execution to the two known native modules instead of every transitive package. The `RUN npm run db:generate` step is removed; the migrations under `drizzle/` are the source of truth and the runtime calls `migrate()` on boot.

## Runtime CSP

`src/hooks.server.ts` no longer sets `Content-Security-Policy` itself. SvelteKit's `kit.csp` configuration in `svelte.config.js` emits the policy with a per-request nonce, so `'unsafe-inline'` is gone from `script-src` in production builds. Dev mode keeps `'unsafe-inline'` because Vite's HMR client injects inline scripts that bypass nonce machinery; CSP Level 3 browsers ignore `'unsafe-inline'` when a nonce is also present, so production posture is strict either way.

`hooks.server.ts` retains a defence-in-depth fallback that sets a strict no-inline CSP on any `text/html` response that reaches the handler without one. That covers a future `+server.ts` returning HTML outside SvelteKit's renderer.

`svelte.config.js` throws at config-load time if `npm_lifecycle_event === 'build'` while `NODE_ENV !== 'production'`, so a misconfigured build never silently ships dev CSP. The npm `build` script is now a thin wrapper that exports `NODE_ENV=production` and delegates to `_build`, satisfying the invariant symmetrically across `svelte-kit sync` and `vite build`.

## Self-hosted fonts

`@fontsource-variable/fraunces`, `@fontsource-variable/geist`, and `@fontsource-variable/geist-mono` replace the two `@import url('https://fonts.googleapis.com/...')` lines in `src/app.css`. The build now bundles 15 woff2 files locally; browsers fetch only matched unicode-range subsets at runtime. CSP drops `fonts.googleapis.com` from `style-src` and `fonts.gstatic.com` from `font-src`, and visitor IPs no longer leak to Google on every page load.

## Release pipeline

`release.yml` now publishes container images in stages:

1. `build-push-action` pushes the image only under the immutable `sha-<short>` tag.
2. `aquasecurity/setup-trivy` installs the CLI and caches the vulnerability DB. Two `trivy image` invocations scan `linux/amd64` and `linux/arm64` separately against the same manifest-list digest (the trivy-action default scans only one platform of a manifest list).
3. `actions/attest-build-provenance` publishes a Sigstore-signed SLSA provenance attestation against the digest. `build-push-action` is configured with `provenance: mode=max` and `sbom: true`, so an SPDX SBOM rides along in the image manifest.
4. Only after scans and attestation succeed does the workflow promote the release tags (`vX.Y.Z`, `vX.Y`, `latest`, and the branch ref) via `docker buildx imagetools create`. Promotion runs in parallel via `xargs -P 4` under `set -euo pipefail`.

Net effect: a vulnerable image cannot land on `:latest` or a semver tag, and every digest that does land carries verifiable provenance plus a machine-readable SBOM.

## Verifying a release

```bash
gh attestation verify oci://ghcr.io/davefatkin/einvault:vX.Y.Z \
  --repo davefatkin/EinVault

docker buildx imagetools inspect \
  ghcr.io/davefatkin/einvault:vX.Y.Z \
  --format '{{ json .SBOM }}'

Pin production deployments to a verified digest rather than a floating tag:

image: ghcr.io/davefatkin/einvault@sha256:<digest>

Test plan

- npm run lint passes
- npm run check reports 0 errors, 0 warnings
- npm run build succeeds; baked policy in build/server/chunks/internal-*.js shows "script-src": ["self"] only
- Push to a feature branch triggers lint.yml only, no release work
- Push to main triggers the release workflow: skipped lint, build under sha-<short> only, Trivy passes both arches, provenance attested, main tag promoted
- Tag push (vX.Y.Z): full pipeline including :latest, :vX.Y, :vX.Y.Z promotion
- gh attestation verify oci://ghcr.io/davefatkin/einvault@sha256:<digest> --repo davefatkin/EinVault reports success
- Manual browser check: DevTools Network panel shows no fonts.googleapis.com / fonts.gstatic.com requests on any route
- Manual browser check: no CSP violations in the console on /auth/login, /setup, journal, care, and admin pages