### PR TITLE
feat: external image storage (S3 & Immich)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,47 @@ ORIGIN=https://einvault.yourdomain.com
 # Defaults to /data/einvault.db, which maps to EINVAULT_DATA on the host.
 # DATABASE_URL=/data/einvault.db
 
+# Optional: external image storage (S3-compatible)
+#
+# By default, avatars and journal photos are written to DATA_DIR/uploads on
+# disk. Set STORAGE_BACKEND=s3 to write new images to an S3-compatible bucket
+# instead (AWS S3, Garage, MinIO, Backblaze B2, Cloudflare R2, etc.).
+#
+# Existing rows keep using whichever backend they were written to — switching
+# STORAGE_BACKEND only affects future uploads. To move existing data, copy the
+# objects manually and update the provider/storage_key columns.
+#
+# When STORAGE_BACKEND=s3, downloads are served via short-lived presigned URLs
+# (the app issues a 302 redirect). EinVault enforces access control before
+# issuing the URL; once issued, the URL is valid for S3_PRESIGN_TTL_SECONDS
+# regardless of subsequent permission changes (e.g. a caretaker going off
+# shift). Keep the TTL short.
+#
+# STORAGE_BACKEND=local
+
+# S3 endpoint. For AWS, leave default (https://s3.<region>.amazonaws.com) and
+# set S3_REGION. For self-hosted (Garage/MinIO), use the full URL.
+# S3_ENDPOINT=https://s3.garage.example.com
+
+# Bucket name. EinVault assumes the bucket already exists and is private.
+# S3_BUCKET=einvault
+
+# Region. For non-AWS providers, 'auto' usually works.
+# S3_REGION=auto
+
+# Access key ID and secret. Scope this credential to the single EinVault
+# bucket only.
+# S3_ACCESS_KEY_ID=
+# S3_SECRET_ACCESS_KEY=
+
+# Set to true for path-style endpoints (Garage, MinIO, older S3 deployments).
+# Leave unset (false) for AWS S3 and Cloudflare R2.
+# S3_FORCE_PATH_STYLE=false
+
+# Lifetime in seconds of a presigned download URL (default: 300).
+# Lower = stricter access, higher = better browser cache reuse on reload.
+# S3_PRESIGN_TTL_SECONDS=300
+
 # Optional: OIDC authentication
 #
 # Enable single sign-on via any OpenID Connect provider (Authelia, Authentik,

--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,33 @@ ORIGIN=https://einvault.yourdomain.com
 # Lower = stricter access, higher = better browser cache reuse on reload.
 # S3_PRESIGN_TTL_SECONDS=300
 
+# Optional: Immich integration (reference mode)
+#
+# When configured, users can attach existing Immich assets to journal entries
+# and companion avatars by picking them from the user's Immich library. The
+# reference is stored in EinVault (no copy is made), and EinVault proxies
+# reads through the server using the API key.
+#
+# EinVault never uploads to Immich and never deletes Immich assets. Removing
+# an EinVault row only removes the reference. Caretakers cannot use the
+# picker (the underlying endpoints reject them).
+#
+# Both IMMICH_URL and IMMICH_API_KEY must be set together. If either is set
+# without the other, the app refuses to start.
+
+# Base URL of your Immich server (no trailing slash).
+# IMMICH_URL=http://immich.your-lan:2283
+
+# API key. Generate in Immich under Account Settings → API Keys. Required
+# permissions: asset.read (list assets), asset.view (fetch thumbnails and
+# image bytes), and album.read (only if IMMICH_ALBUM_ID is set below).
+# IMMICH_API_KEY=
+
+# Optional: restrict the picker to a single album. When set, the picker only
+# shows assets in this album. When unset, the picker shows the user's most
+# recent assets across the whole library.
+# IMMICH_ALBUM_ID=
+
 # Optional: OIDC authentication
 #
 # Enable single sign-on via any OpenID Connect provider (Authelia, Authentik,

--- a/.env.example
+++ b/.env.example
@@ -106,8 +106,9 @@ ORIGIN=https://einvault.yourdomain.com
 # an EinVault row only removes the reference. Caretakers cannot use the
 # picker (the underlying endpoints reject them).
 #
-# Both IMMICH_URL and IMMICH_API_KEY must be set together. If either is set
-# without the other, the app refuses to start.
+# Both IMMICH_URL and IMMICH_API_KEY must be set together to enable the
+# integration. If only one is set, the integration is disabled and a warning
+# is logged at startup; the app still boots.
 
 # Base URL of your Immich server (no trailing slash).
 # IMMICH_URL=http://immich.your-lan:2283

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ By default, avatars and journal photos are written to `./data/uploads`. You can 
 
 Downloads use short-lived presigned URLs (the app issues a 302 redirect). Access control is checked before the URL is issued; once issued, the URL stays valid for the full TTL even if permissions later change. Keep the TTL short.
 
+### Immich integration (optional)
+
+When `IMMICH_URL` and `IMMICH_API_KEY` are set, members and admins get a "Pick from Immich" option on the journal photo and companion avatar flows. The chosen asset stays in Immich; EinVault stores only a reference and proxies reads through the server using the API key. EinVault never uploads to Immich and never deletes assets from it. Caretakers cannot use the picker.
+
+|                   | Default | Description                                                                                                                                                                                  |
+| ----------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `IMMICH_URL`      | —       | Base URL of your Immich server, e.g. `http://immich.local:2283`. No trailing slash. Required if `IMMICH_API_KEY` is set.                                                                     |
+| `IMMICH_API_KEY`  | —       | API key. Required permissions: `asset.read`, `asset.view`, plus `album.read` if `IMMICH_ALBUM_ID` is set. Generate in Immich → Account Settings → API Keys. Required if `IMMICH_URL` is set. |
+| `IMMICH_ALBUM_ID` | —       | If set, the picker only shows assets in this album. If unset, the picker shows the user's most recent assets across the whole library.                                                       |
+
 ### Data and backup
 
 Data lives in `./data` next to the compose file. Stop the container first so SQLite isn't mid-write, then copy the directory:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ Everything else in the compose file can be edited directly:
 | `./data` volume         | `./data`            | Where the database and uploads are stored on the host.                                                                            |
 | `DATABASE_URL`          | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                    |
 
+### External image storage (optional)
+
+By default, avatars and journal photos are written to `./data/uploads`. You can instead route new uploads to an S3-compatible bucket (AWS S3, Garage, MinIO, Backblaze B2, Cloudflare R2). Existing photos remain on disk; only new writes go to S3.
+
+|                          | Default | Description                                                                                                                                                               |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STORAGE_BACKEND`        | `local` | `local` writes to `./data/uploads`. `s3` writes new uploads to the configured bucket. Reads always honor the per-row provider, so switching does not invalidate old rows. |
+| `S3_ENDPOINT`            | —       | Full endpoint URL, e.g. `https://s3.garage.example.com` or `https://s3.us-east-1.amazonaws.com`.                                                                          |
+| `S3_BUCKET`              | —       | Bucket name. Must already exist and should be private.                                                                                                                    |
+| `S3_REGION`              | `auto`  | Region. For non-AWS providers, `auto` usually works.                                                                                                                      |
+| `S3_ACCESS_KEY_ID`       | —       | Access key. Scope it to this bucket only.                                                                                                                                 |
+| `S3_SECRET_ACCESS_KEY`   | —       | Secret key.                                                                                                                                                               |
+| `S3_FORCE_PATH_STYLE`    | `false` | Set to `true` for Garage, MinIO, and older S3 deployments. Leave `false` for AWS and R2.                                                                                  |
+| `S3_PRESIGN_TTL_SECONDS` | `300`   | Lifetime of presigned download URLs. Shorter is stricter, longer improves browser cache reuse on reload.                                                                  |
+
+Downloads use short-lived presigned URLs (the app issues a 302 redirect). Access control is checked before the URL is issued; once issued, the URL stays valid for the full TTL even if permissions later change. Keep the TTL short.
+
 ### Data and backup
 
 Data lives in `./data` next to the compose file. Stop the container first so SQLite isn't mid-write, then copy the directory:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,18 @@ services:
       # Defaults to UTC if omitted. Example: America/New_York, Europe/London
       # TZ: ${TZ:-America/New_York}
 
+      # Optional: external image storage (S3-compatible).
+      # Set STORAGE_BACKEND=s3 + the S3_* vars to route new uploads to a
+      # bucket. Existing photos stay on disk; reads honor per-row provider.
+      STORAGE_BACKEND: ${STORAGE_BACKEND:-local}
+      S3_ENDPOINT: ${S3_ENDPOINT:-}
+      S3_BUCKET: ${S3_BUCKET:-}
+      S3_REGION: ${S3_REGION:-auto}
+      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
+      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
+      S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-false}
+      S3_PRESIGN_TTL_SECONDS: ${S3_PRESIGN_TTL_SECONDS:-300}
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,12 @@ services:
       S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-false}
       S3_PRESIGN_TTL_SECONDS: ${S3_PRESIGN_TTL_SECONDS:-300}
 
+      # Optional: Immich integration (reference mode). Both URL and API key
+      # must be set together for the picker to activate.
+      IMMICH_URL: ${IMMICH_URL:-}
+      IMMICH_API_KEY: ${IMMICH_API_KEY:-}
+      IMMICH_ALBUM_ID: ${IMMICH_ALBUM_ID:-}
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,6 +38,23 @@ services:
       # Defaults to UTC if omitted. Example: America/New_York, Europe/London
       # TZ: America/New_York
 
+      # Optional: external image storage (S3-compatible)
+      # By default avatars and journal photos are written to /data/uploads.
+      # Set STORAGE_BACKEND=s3 to route NEW uploads to an S3-compatible bucket
+      # (AWS S3, Garage, MinIO, Backblaze B2, Cloudflare R2). Existing photos
+      # remain on disk; per-row provider tracking keeps reads consistent.
+      # Downloads use short-lived presigned URLs (302 redirect from the app).
+      # STORAGE_BACKEND: s3
+      # S3_ENDPOINT: https://s3.garage.example.com
+      # S3_BUCKET: einvault
+      # S3_REGION: auto
+      # S3_ACCESS_KEY_ID:
+      # S3_SECRET_ACCESS_KEY:
+      # Set true for path-style endpoints (Garage, MinIO). Leave unset for AWS/R2.
+      # S3_FORCE_PATH_STYLE: 'true'
+      # Lifetime of a presigned download URL. Lower = stricter access.
+      # S3_PRESIGN_TTL_SECONDS: 300
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,6 +55,15 @@ services:
       # Lifetime of a presigned download URL. Lower = stricter access.
       # S3_PRESIGN_TTL_SECONDS: 300
 
+      # Optional: Immich integration (reference mode)
+      # When set, users can attach existing Immich assets to journal entries
+      # and avatars. EinVault stores a reference and proxies reads through
+      # the API key; it never uploads or deletes from Immich.
+      # IMMICH_URL: http://immich.local:2283
+      # IMMICH_API_KEY:
+      # Optional: restrict picker to a single Immich album.
+      # IMMICH_ALBUM_ID:
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/drizzle/0012_curved_baron_zemo.sql
+++ b/drizzle/0012_curved_baron_zemo.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `companions` ADD `avatar_provider` text DEFAULT 'local' NOT NULL;--> statement-breakpoint
+ALTER TABLE `companions` ADD `avatar_storage_key` text;--> statement-breakpoint
+ALTER TABLE `journal_photos` ADD `provider` text DEFAULT 'local' NOT NULL;--> statement-breakpoint
+ALTER TABLE `journal_photos` ADD `storage_key` text;

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1318 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4a23eb88-a800-4096-800b-d3da707bd9fd",
+  "prevId": "fd8072e4-6c93-404e-8dae-6b5ede17beb5",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778544024638,
       "tag": "0011_smiling_enchantress",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1779721030065,
+      "tag": "0012_curved_baron_zemo",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@oslojs/crypto": "^1.0.1",
 				"@oslojs/encoding": "^1.1.0",
 				"@tailwindcss/typography": "^0.5.0-alpha.3",
+				"aws4fetch": "^1.0.20",
 				"bcryptjs": "^3.0.3",
 				"better-sqlite3": "^12.8.0",
 				"class-variance-authority": "^0.7.1",
@@ -3059,6 +3060,12 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/aws4fetch": {
+			"version": "1.0.20",
+			"resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+			"integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+			"license": "MIT"
 		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"@oslojs/crypto": "^1.0.1",
 		"@oslojs/encoding": "^1.1.0",
 		"@tailwindcss/typography": "^0.5.0-alpha.3",
+		"aws4fetch": "^1.0.20",
 		"bcryptjs": "^3.0.3",
 		"better-sqlite3": "^12.8.0",
 		"class-variance-authority": "^0.7.1",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,9 +4,11 @@ import { validateAuth } from '$server/auth';
 import { env } from '$env/dynamic/private';
 import { resolveLocale, parseAcceptLanguage } from '$lib/i18n';
 import { logOidcBootStatus } from '$lib/server/auth/oidc';
-import { S3_CONFIG } from '$lib/server/env';
+import { S3_CONFIG, logImmichBootStatus, logStorageBootStatus } from '$lib/server/env';
 
 logOidcBootStatus();
+logStorageBootStatus();
+logImmichBootStatus();
 
 // When S3 storage is configured, /api/photos and /api/avatars 302 to the S3
 // host. CSP is enforced on the final navigation target after redirects, so

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -25,9 +25,11 @@ const S3_IMG_ORIGIN: string | null = (() => {
 })();
 
 function injectImgSrcOrigin(csp: string, origin: string): string {
-	// Append the origin inside the existing img-src directive.
+	// Append the origin inside every img-src directive. Callback form so
+	// arbitrary characters in `origin` are not interpreted as $1 backrefs.
+	// `gi` so multiple directives all pick up the origin.
 	if (/(^|;)\s*img-src\b/i.test(csp)) {
-		return csp.replace(/(img-src\b[^;]*)/i, `$1 ${origin}`);
+		return csp.replace(/(img-src\b[^;]*)/gi, (_m, captured) => `${captured} ${origin}`);
 	}
 	// No img-src directive present; add one.
 	return `${csp.replace(/;?\s*$/, '')}; img-src 'self' data: blob: ${origin}`;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,8 +4,32 @@ import { validateAuth } from '$server/auth';
 import { env } from '$env/dynamic/private';
 import { resolveLocale, parseAcceptLanguage } from '$lib/i18n';
 import { logOidcBootStatus } from '$lib/server/auth/oidc';
+import { S3_CONFIG } from '$lib/server/env';
 
 logOidcBootStatus();
+
+// When S3 storage is configured, /api/photos and /api/avatars 302 to the S3
+// host. CSP is enforced on the final navigation target after redirects, so
+// the S3 origin has to appear in img-src or the browser blocks the load.
+// Computed once at boot from runtime env so swapping S3_ENDPOINT only needs a
+// container restart, not a rebuild.
+const S3_IMG_ORIGIN: string | null = (() => {
+	if (!S3_CONFIG) return null;
+	try {
+		return new URL(S3_CONFIG.endpoint).origin;
+	} catch {
+		return null;
+	}
+})();
+
+function injectImgSrcOrigin(csp: string, origin: string): string {
+	// Append the origin inside the existing img-src directive.
+	if (/(^|;)\s*img-src\b/i.test(csp)) {
+		return csp.replace(/(img-src\b[^;]*)/i, `$1 ${origin}`);
+	}
+	// No img-src directive present; add one.
+	return `${csp.replace(/;?\s*$/, '')}; img-src 'self' data: blob: ${origin}`;
+}
 
 const securityHeaders: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);
@@ -25,6 +49,13 @@ const securityHeaders: Handle = async ({ event, resolve }) => {
 			'Content-Security-Policy',
 			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 		);
+	}
+
+	if (S3_IMG_ORIGIN) {
+		const csp = response.headers.get('content-security-policy');
+		if (csp) {
+			response.headers.set('content-security-policy', injectImgSrcOrigin(csp, S3_IMG_ORIGIN));
+		}
 	}
 
 	if (env.NODE_ENV === 'production') {

--- a/src/lib/components/CompanionAvatar.svelte
+++ b/src/lib/components/CompanionAvatar.svelte
@@ -12,6 +12,8 @@
 		archived?: boolean;
 		class?: string;
 		onlightbox?: () => void;
+		immichEnabled?: boolean;
+		onpickImmich?: () => void;
 	}
 
 	let {
@@ -22,7 +24,9 @@
 		editable = false,
 		archived = false,
 		class: className = '',
-		onlightbox
+		onlightbox,
+		immichEnabled = false,
+		onpickImmich
 	}: Props = $props();
 
 	const sizes = {
@@ -100,7 +104,7 @@
 	}
 </script>
 
-<div class="relative inline-block {className}">
+<div class="relative inline-flex items-center gap-1.5 {className}">
 	{#if onlightbox && imgSrc}
 		<button
 			type="button"
@@ -150,29 +154,47 @@
 				{uploadError}
 			</div>
 		{/if}
-		<button
-			bind:this={buttonEl}
-			type="button"
-			class="absolute bottom-0 right-0 h-6 w-6 rounded-full bg-white text-bark-700 flex items-center justify-center
-				cursor-pointer hover:bg-bark-50 transition-colors shadow-sm text-xs"
-			title={uploadError ?? t(locale, 'component.avatar.changePhoto')}
-			aria-label={uploadError
-				? t(locale, 'component.avatar.uploadError', { error: uploadError })
-				: t(locale, 'component.avatar.changePhotoFor', { name })}
-			onclick={(e) => {
-				e.stopPropagation();
-				fileInputEl?.click();
-			}}
-			disabled={uploading}
-		>
-			{#if uploading}
-				⏳
-			{:else if uploadError}
-				⚠️
-			{:else}
-				📷
+		<div class="flex flex-col gap-1">
+			<button
+				bind:this={buttonEl}
+				type="button"
+				class="h-7 w-7 rounded-full bg-white text-bark-700 flex items-center justify-center
+					cursor-pointer hover:bg-bark-50 transition-colors shadow-sm text-xs"
+				title={uploadError ?? t(locale, 'component.avatar.changePhoto')}
+				aria-label={uploadError
+					? t(locale, 'component.avatar.uploadError', { error: uploadError })
+					: t(locale, 'component.avatar.changePhotoFor', { name })}
+				onclick={(e) => {
+					e.stopPropagation();
+					fileInputEl?.click();
+				}}
+				disabled={uploading}
+			>
+				{#if uploading}
+					⏳
+				{:else if uploadError}
+					⚠️
+				{:else}
+					📷
+				{/if}
+			</button>
+			{#if immichEnabled && onpickImmich}
+				<button
+					type="button"
+					class="h-7 w-7 rounded-full bg-white text-bark-700 flex items-center justify-center
+						cursor-pointer hover:bg-bark-50 transition-colors shadow-sm text-xs"
+					title={t(locale, 'immich.picker.button')}
+					aria-label={t(locale, 'immich.picker.button')}
+					onclick={(e) => {
+						e.stopPropagation();
+						onpickImmich();
+					}}
+					disabled={uploading}
+				>
+					🖼️
+				</button>
 			{/if}
-		</button>
+		</div>
 		<input
 			bind:this={fileInputEl}
 			type="file"

--- a/src/lib/components/ImmichPicker.svelte
+++ b/src/lib/components/ImmichPicker.svelte
@@ -68,6 +68,9 @@
 		}
 	}
 
+	// Opening the picker always starts from page 1: simpler than persisting
+	// scroll/state across opens, and homelab Immich responds fast enough that
+	// re-fetching the first page is unnoticeable.
 	$effect(() => {
 		if (open) {
 			triggerEl = document.activeElement as HTMLElement | null;

--- a/src/lib/components/ImmichPicker.svelte
+++ b/src/lib/components/ImmichPicker.svelte
@@ -15,7 +15,7 @@
 
 	interface Props {
 		open: boolean;
-		onpick: (assetId: string) => void;
+		onpick: (assetId: string) => void | Promise<void>;
 		onclose: () => void;
 	}
 
@@ -97,9 +97,17 @@
 		}
 	}
 
-	function pick(assetId: string) {
+	async function pick(assetId: string) {
+		if (selecting) return;
 		selecting = assetId;
-		onpick(assetId);
+		try {
+			await onpick(assetId);
+		} finally {
+			// If parent closed the picker, $effect on `open` already resets
+			// `selecting` on next open. If parent kept the picker open (e.g.
+			// after a failed pick), clear here so the user can try another.
+			selecting = null;
+		}
 	}
 </script>
 
@@ -170,7 +178,7 @@
 								type="button"
 								class="relative aspect-square overflow-hidden rounded-md bg-stone-100 dark:bg-stone-800 transition-opacity hover:opacity-80 disabled:opacity-50 disabled:cursor-wait"
 								onclick={() => pick(asset.id)}
-								disabled={selecting !== null}
+								disabled={selecting === asset.id}
 								title={asset.originalFileName}
 							>
 								<img

--- a/src/lib/components/ImmichPicker.svelte
+++ b/src/lib/components/ImmichPicker.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { tick } from 'svelte';
+	import { t, getLocale } from '$lib/i18n';
+	import { X, ImageIcon, Loader2 } from '@lucide/svelte';
+
+	interface ImmichAsset {
+		id: string;
+		originalFileName: string;
+		originalMimeType: string;
+		fileSizeInByte: number | null;
+		createdAt: string | null;
+		type: string;
+	}
+
+	interface Props {
+		open: boolean;
+		onpick: (assetId: string) => void;
+		onclose: () => void;
+	}
+
+	let { open, onpick, onclose }: Props = $props();
+	const locale = getLocale();
+
+	let dialogEl = $state<HTMLElement | null>(null);
+	let triggerEl = $state<HTMLElement | null>(null);
+
+	let assets = $state<ImmichAsset[]>([]);
+	let loading = $state(false);
+	let loadingMore = $state(false);
+	let error = $state('');
+	let page = $state(1);
+	let hasNextPage = $state(false);
+	let albumScoped = $state(false);
+	let selecting = $state<string | null>(null);
+
+	const PAGE_SIZE = 60;
+
+	async function loadPage(nextPage: number, append = false) {
+		const flag = append ? 'loadingMore' : 'loading';
+		if (flag === 'loading') loading = true;
+		else loadingMore = true;
+		error = '';
+		try {
+			const res = await fetch(`/api/immich/assets?page=${nextPage}&pageSize=${PAGE_SIZE}`);
+			if (!res.ok) {
+				error = t(locale, 'immich.picker.loadError');
+				return;
+			}
+			const data = (await res.json()) as {
+				items: ImmichAsset[];
+				hasNextPage: boolean;
+				albumScoped: boolean;
+			};
+			if (append) {
+				assets = [...assets, ...data.items];
+			} else {
+				assets = data.items;
+			}
+			hasNextPage = data.hasNextPage;
+			albumScoped = data.albumScoped;
+			page = nextPage;
+		} catch {
+			error = t(locale, 'immich.picker.loadError');
+		} finally {
+			loading = false;
+			loadingMore = false;
+		}
+	}
+
+	$effect(() => {
+		if (open) {
+			triggerEl = document.activeElement as HTMLElement | null;
+			assets = [];
+			page = 1;
+			hasNextPage = false;
+			error = '';
+			selecting = null;
+			loadPage(1, false);
+			tick().then(() => dialogEl?.focus());
+		} else {
+			tick().then(() => triggerEl?.focus());
+		}
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			onclose();
+		}
+	}
+
+	async function handleScroll(e: Event) {
+		const el = e.currentTarget as HTMLElement;
+		if (loadingMore || !hasNextPage) return;
+		if (el.scrollHeight - el.scrollTop - el.clientHeight < 200) {
+			await loadPage(page + 1, true);
+		}
+	}
+
+	function pick(assetId: string) {
+		selecting = assetId;
+		onpick(assetId);
+	}
+</script>
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center p-4"
+		role="presentation"
+		onkeydown={handleKeydown}
+	>
+		<div
+			role="presentation"
+			class="absolute inset-0 bg-black/50"
+			onclick={onclose}
+			onkeydown={() => {}}
+		></div>
+
+		<div
+			bind:this={dialogEl}
+			role="dialog"
+			aria-modal="true"
+			aria-label={t(locale, 'immich.picker.title')}
+			tabindex="-1"
+			class="relative z-10 w-full max-w-3xl max-h-[85vh] rounded-lg border border-border bg-card shadow-lg flex flex-col"
+		>
+			<div class="flex items-center justify-between px-5 py-3 border-b border-border">
+				<div>
+					<h2 class="font-semibold text-foreground">
+						{t(locale, 'immich.picker.title')}
+					</h2>
+					{#if albumScoped}
+						<p class="text-xs text-muted-foreground mt-0.5">
+							{t(locale, 'immich.picker.albumScoped')}
+						</p>
+					{/if}
+				</div>
+				<button
+					type="button"
+					class="rounded-md p-1 hover:bg-accent text-muted-foreground"
+					aria-label={t(locale, 'immich.picker.close')}
+					onclick={onclose}
+				>
+					<X class="h-4 w-4" />
+				</button>
+			</div>
+
+			<div class="flex-1 overflow-y-auto p-4" onscroll={handleScroll}>
+				{#if error}
+					<div
+						class="rounded-lg bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive mb-3"
+					>
+						{error}
+					</div>
+				{/if}
+
+				{#if loading}
+					<div class="flex items-center justify-center py-16 text-muted-foreground">
+						<Loader2 class="h-6 w-6 animate-spin" />
+					</div>
+				{:else if assets.length === 0}
+					<div class="flex flex-col items-center justify-center py-16 text-muted-foreground">
+						<ImageIcon class="h-10 w-10 mb-3" />
+						<p class="text-sm">{t(locale, 'immich.picker.empty')}</p>
+					</div>
+				{:else}
+					<div class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2">
+						{#each assets as asset (asset.id)}
+							<button
+								type="button"
+								class="relative aspect-square overflow-hidden rounded-md bg-stone-100 dark:bg-stone-800 transition-opacity hover:opacity-80 disabled:opacity-50 disabled:cursor-wait"
+								onclick={() => pick(asset.id)}
+								disabled={selecting !== null}
+								title={asset.originalFileName}
+							>
+								<img
+									src={`/api/immich/thumbnail/${asset.id}?size=thumbnail`}
+									alt={asset.originalFileName}
+									class="w-full h-full object-cover"
+									loading="lazy"
+								/>
+								{#if selecting === asset.id}
+									<div class="absolute inset-0 flex items-center justify-center bg-black/40">
+										<Loader2 class="h-5 w-5 animate-spin text-white" />
+									</div>
+								{/if}
+							</button>
+						{/each}
+					</div>
+
+					{#if loadingMore}
+						<div class="flex items-center justify-center py-4 text-muted-foreground">
+							<Loader2 class="h-4 w-4 animate-spin" />
+						</div>
+					{/if}
+				{/if}
+			</div>
+
+			<div class="flex justify-end gap-2 px-5 py-3 border-t border-border">
+				<Button variant="outline" size="sm" onclick={onclose}>
+					{t(locale, 'immich.picker.cancel')}
+				</Button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -722,6 +722,16 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPhoto': 'Nächstes Foto',
 	'aria.viewPhoto': '{name}s Foto anzeigen',
 
+	// Immich picker
+	'immich.picker.title': 'Aus Immich auswählen',
+	'immich.picker.albumScoped': 'Es werden Inhalte aus dem konfigurierten Album angezeigt.',
+	'immich.picker.empty': 'Keine Inhalte in Immich gefunden.',
+	'immich.picker.cancel': 'Abbrechen',
+	'immich.picker.close': 'Auswahl schließen',
+	'immich.picker.loadError': 'Immich-Bibliothek konnte nicht geladen werden.',
+	'immich.picker.button': 'Aus Immich auswählen',
+	'immich.picker.pickFailed': 'Immich-Inhalt konnte nicht angehängt werden.',
+
 	// Meta
 	'meta.description': 'EinVault: privates Gesundheits- und Pflegetagebuch für Hunde'
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -712,6 +712,16 @@ const messages = {
 	'aria.nextPhoto': 'Next photo',
 	'aria.viewPhoto': "View {name}'s photo",
 
+	// Immich picker
+	'immich.picker.title': 'Pick from Immich',
+	'immich.picker.albumScoped': 'Showing assets from the configured album.',
+	'immich.picker.empty': 'No assets found in Immich.',
+	'immich.picker.cancel': 'Cancel',
+	'immich.picker.close': 'Close picker',
+	'immich.picker.loadError': 'Could not load Immich library.',
+	'immich.picker.button': 'Pick from Immich',
+	'immich.picker.pickFailed': 'Could not attach Immich asset.',
+
 	// Meta
 	'meta.description': 'EinVault: private dog health & care tracker'
 } as const;

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -720,6 +720,16 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPhoto': 'Foto siguiente',
 	'aria.viewPhoto': 'Ver foto de {name}',
 
+	// Immich picker
+	'immich.picker.title': 'Elegir desde Immich',
+	'immich.picker.albumScoped': 'Mostrando elementos del álbum configurado.',
+	'immich.picker.empty': 'No se encontraron elementos en Immich.',
+	'immich.picker.cancel': 'Cancelar',
+	'immich.picker.close': 'Cerrar selector',
+	'immich.picker.loadError': 'No se pudo cargar la biblioteca de Immich.',
+	'immich.picker.button': 'Elegir desde Immich',
+	'immich.picker.pickFailed': 'No se pudo adjuntar el elemento de Immich.',
+
 	// Meta
 	'meta.description': 'EinVault: diario privado de salud y cuidado canino'
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -721,6 +721,16 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPhoto': 'Photo suivante',
 	'aria.viewPhoto': 'Voir la photo de {name}',
 
+	// Immich picker
+	'immich.picker.title': 'Choisir depuis Immich',
+	'immich.picker.albumScoped': "Affichage des éléments de l'album configuré.",
+	'immich.picker.empty': 'Aucun élément trouvé dans Immich.',
+	'immich.picker.cancel': 'Annuler',
+	'immich.picker.close': 'Fermer le sélecteur',
+	'immich.picker.loadError': 'Impossible de charger la bibliothèque Immich.',
+	'immich.picker.button': 'Choisir depuis Immich',
+	'immich.picker.pickFailed': "Impossible d'attacher l'élément Immich.",
+
 	// Meta
 	'meta.description': 'EinVault : journal privé de santé et soins canins'
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -716,6 +716,16 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPhoto': 'Foto successiva',
 	'aria.viewPhoto': 'Vedi la foto di {name}',
 
+	// Immich picker
+	'immich.picker.title': 'Scegli da Immich',
+	'immich.picker.albumScoped': "Mostrando elementi dall'album configurato.",
+	'immich.picker.empty': 'Nessun elemento trovato in Immich.',
+	'immich.picker.cancel': 'Annulla',
+	'immich.picker.close': 'Chiudi selettore',
+	'immich.picker.loadError': 'Impossibile caricare la libreria Immich.',
+	'immich.picker.button': 'Scegli da Immich',
+	'immich.picker.pickFailed': "Impossibile allegare l'elemento Immich.",
+
 	// Meta
 	'meta.description': 'EinVault: diario privato per la salute e la cura del cane'
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -717,6 +717,16 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPhoto': 'Próxima foto',
 	'aria.viewPhoto': 'Ver foto de {name}',
 
+	// Immich picker
+	'immich.picker.title': 'Escolher do Immich',
+	'immich.picker.albumScoped': 'Mostrando itens do álbum configurado.',
+	'immich.picker.empty': 'Nenhum item encontrado no Immich.',
+	'immich.picker.cancel': 'Cancelar',
+	'immich.picker.close': 'Fechar seletor',
+	'immich.picker.loadError': 'Não foi possível carregar a biblioteca do Immich.',
+	'immich.picker.button': 'Escolher do Immich',
+	'immich.picker.pickFailed': 'Não foi possível anexar o item do Immich.',
+
 	// Meta
 	'meta.description': 'EinVault: diário privado de saúde e cuidados caninos'
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -78,7 +78,7 @@ export const companions = sqliteTable(
 			.default('lbs'),
 		microchip: text('microchip'),
 		avatarPath: text('avatar_path'),
-		avatarProvider: text('avatar_provider', { enum: ['local', 's3'] })
+		avatarProvider: text('avatar_provider', { enum: ['local', 's3', 'immich'] })
 			.notNull()
 			.default('local'),
 		avatarStorageKey: text('avatar_storage_key'),
@@ -134,7 +134,7 @@ export const journalPhotos = sqliteTable(
 			.notNull()
 			.references(() => journalEntries.id, { onDelete: 'cascade' }),
 		filename: text('filename').notNull(),
-		provider: text('provider', { enum: ['local', 's3'] })
+		provider: text('provider', { enum: ['local', 's3', 'immich'] })
 			.notNull()
 			.default('local'),
 		storageKey: text('storage_key'),

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -78,6 +78,10 @@ export const companions = sqliteTable(
 			.default('lbs'),
 		microchip: text('microchip'),
 		avatarPath: text('avatar_path'),
+		avatarProvider: text('avatar_provider', { enum: ['local', 's3'] })
+			.notNull()
+			.default('local'),
+		avatarStorageKey: text('avatar_storage_key'),
 		bio: text('bio'),
 		feedingSchedule: text('feeding_schedule'),
 		walkSchedule: text('walk_schedule'),
@@ -130,6 +134,10 @@ export const journalPhotos = sqliteTable(
 			.notNull()
 			.references(() => journalEntries.id, { onDelete: 'cascade' }),
 		filename: text('filename').notNull(),
+		provider: text('provider', { enum: ['local', 's3'] })
+			.notNull()
+			.default('local'),
+		storageKey: text('storage_key'),
 		originalName: text('original_name'),
 		mimeType: text('mime_type').notNull(),
 		sizeBytes: integer('size_bytes').notNull(),

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -50,41 +50,100 @@ export interface S3Config {
 	presignTtlSeconds: number;
 }
 
-function readS3Config(): S3Config | null {
-	const fields: Array<[keyof S3Config, string | undefined]> = [
-		['endpoint', env.S3_ENDPOINT],
-		['bucket', env.S3_BUCKET],
-		['accessKeyId', env.S3_ACCESS_KEY_ID],
-		['secretAccessKey', env.S3_SECRET_ACCESS_KEY]
-	];
-	const envNames: Record<string, string> = {
-		endpoint: 'S3_ENDPOINT',
-		bucket: 'S3_BUCKET',
-		accessKeyId: 'S3_ACCESS_KEY_ID',
-		secretAccessKey: 'S3_SECRET_ACCESS_KEY'
-	};
-	const missing = fields.filter(([, v]) => !v).map(([k]) => envNames[k as string]);
-	if (missing.length === fields.length) return null;
-	if (missing.length > 0) {
-		throw new Error(`S3 config incomplete. Missing: ${missing.join(', ')}.`);
-	}
+const S3_REQUIRED_VARS = [
+	'S3_ENDPOINT',
+	'S3_BUCKET',
+	'S3_ACCESS_KEY_ID',
+	'S3_SECRET_ACCESS_KEY'
+] as const;
+
+function readS3Config(): { config: S3Config | null; missing: string[] } {
+	const missing = S3_REQUIRED_VARS.filter((name) => !env[name]);
+	if (missing.length === S3_REQUIRED_VARS.length) return { config: null, missing };
+	if (missing.length > 0) return { config: null, missing };
 	return {
-		endpoint: env.S3_ENDPOINT!.replace(/\/$/, ''),
-		bucket: env.S3_BUCKET!,
-		region: env.S3_REGION ?? 'auto',
-		accessKeyId: env.S3_ACCESS_KEY_ID!,
-		secretAccessKey: env.S3_SECRET_ACCESS_KEY!,
-		forcePathStyle: env.S3_FORCE_PATH_STYLE === 'true',
-		presignTtlSeconds: envInt(env.S3_PRESIGN_TTL_SECONDS, 300)
+		config: {
+			endpoint: env.S3_ENDPOINT!.replace(/\/$/, ''),
+			bucket: env.S3_BUCKET!,
+			region: env.S3_REGION ?? 'auto',
+			accessKeyId: env.S3_ACCESS_KEY_ID!,
+			secretAccessKey: env.S3_SECRET_ACCESS_KEY!,
+			forcePathStyle: env.S3_FORCE_PATH_STYLE === 'true',
+			presignTtlSeconds: envInt(env.S3_PRESIGN_TTL_SECONDS, 300)
+		},
+		missing: []
 	};
 }
 
-export const S3_CONFIG = readS3Config();
+const s3Result = readS3Config();
+export const S3_CONFIG = s3Result.config;
 
-if (STORAGE_BACKEND === 's3' && !S3_CONFIG) {
-	throw new Error(
-		'STORAGE_BACKEND=s3 but S3 config missing. Set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY.'
-	);
+export function logStorageBootStatus(): void {
+	if (STORAGE_BACKEND === 's3' && !S3_CONFIG) {
+		// This will be caught at first use; surface it clearly at boot too.
+		console.error(
+			`[storage] STORAGE_BACKEND=s3 but S3 config incomplete. Missing: ${s3Result.missing.join(', ')}. The app will fail when a write is attempted.`
+		);
+	} else if (s3Result.missing.length > 0 && s3Result.missing.length < S3_REQUIRED_VARS.length) {
+		console.warn(
+			`[storage] Partial S3 config detected (missing: ${s3Result.missing.join(', ')}). S3 backend disabled. Set STORAGE_BACKEND=s3 and complete the config to enable.`
+		);
+	} else if (S3_CONFIG) {
+		console.info(
+			`[storage] S3 backend ${STORAGE_BACKEND === 's3' ? 'active' : 'available'} endpoint=${S3_CONFIG.endpoint} bucket=${S3_CONFIG.bucket}`
+		);
+	}
+}
+
+// Immich integration is a read-only reference layer, NOT a write destination.
+// When configured, users can pick existing assets from their Immich library to
+// attach to journal entries or as a companion avatar. EinVault stores a
+// reference (provider='immich', storage_key='immich:{assetId}') and proxies
+// reads through the server using the API key. EinVault never uploads to
+// Immich and never deletes Immich assets.
+export interface ImmichConfig {
+	url: string;
+	apiKey: string;
+	albumId: string | null;
+}
+
+const IMMICH_REQUIRED_VARS = ['IMMICH_URL', 'IMMICH_API_KEY'] as const;
+
+function readImmichConfig(): { config: ImmichConfig | null; missing: string[] } {
+	const url = env.IMMICH_URL?.trim();
+	const apiKey = env.IMMICH_API_KEY?.trim();
+	const albumId = env.IMMICH_ALBUM_ID?.trim() || null;
+	const missing = IMMICH_REQUIRED_VARS.filter((name) => !env[name]?.trim());
+	if (missing.length === IMMICH_REQUIRED_VARS.length) return { config: null, missing };
+	if (missing.length > 0) return { config: null, missing };
+	return {
+		config: {
+			url: url!.replace(/\/$/, ''),
+			apiKey: apiKey!,
+			albumId
+		},
+		missing: []
+	};
+}
+
+const immichResult = readImmichConfig();
+export const IMMICH_CONFIG = immichResult.config;
+
+export function logImmichBootStatus(): void {
+	if (
+		immichResult.missing.length > 0 &&
+		immichResult.missing.length < IMMICH_REQUIRED_VARS.length
+	) {
+		console.warn(
+			`[immich] Partial config detected (missing: ${immichResult.missing.join(', ')}). Integration disabled. Set both IMMICH_URL and IMMICH_API_KEY to enable.`
+		);
+		return;
+	}
+	if (IMMICH_CONFIG) {
+		console.info(
+			`[immich] enabled url=${IMMICH_CONFIG.url}${IMMICH_CONFIG.albumId ? ` album=${IMMICH_CONFIG.albumId}` : ''}`
+		);
+	}
 }
 
 // 0 = no undo window (instant commit). >0 = seconds before dismissal commits.

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -30,6 +30,63 @@ function envNonNegativeInt(value: string | undefined, defaultValue: number): num
 export const UPLOAD_MAX_MB = envInt(env.UPLOAD_MAX_MB, 10);
 export const MAX_DAILY_PHOTOS = envInt(env.MAX_DAILY_PHOTOS, 5);
 
+// Storage backend selection. 'local' writes to DATA_DIR/uploads; 's3' uses an
+// S3-compatible bucket (AWS, Garage, MinIO, Backblaze B2, R2, ...). Reads
+// always honor the per-row provider column, so switching here only affects
+// new writes — existing 'local' rows keep streaming from disk.
+const rawStorageBackend = (env.STORAGE_BACKEND ?? 'local').toLowerCase();
+if (rawStorageBackend !== 'local' && rawStorageBackend !== 's3') {
+	throw new Error(`Invalid STORAGE_BACKEND '${env.STORAGE_BACKEND}'. Allowed: local, s3.`);
+}
+export const STORAGE_BACKEND: 'local' | 's3' = rawStorageBackend;
+
+export interface S3Config {
+	endpoint: string;
+	bucket: string;
+	region: string;
+	accessKeyId: string;
+	secretAccessKey: string;
+	forcePathStyle: boolean;
+	presignTtlSeconds: number;
+}
+
+function readS3Config(): S3Config | null {
+	const fields: Array<[keyof S3Config, string | undefined]> = [
+		['endpoint', env.S3_ENDPOINT],
+		['bucket', env.S3_BUCKET],
+		['accessKeyId', env.S3_ACCESS_KEY_ID],
+		['secretAccessKey', env.S3_SECRET_ACCESS_KEY]
+	];
+	const envNames: Record<string, string> = {
+		endpoint: 'S3_ENDPOINT',
+		bucket: 'S3_BUCKET',
+		accessKeyId: 'S3_ACCESS_KEY_ID',
+		secretAccessKey: 'S3_SECRET_ACCESS_KEY'
+	};
+	const missing = fields.filter(([, v]) => !v).map(([k]) => envNames[k as string]);
+	if (missing.length === fields.length) return null;
+	if (missing.length > 0) {
+		throw new Error(`S3 config incomplete. Missing: ${missing.join(', ')}.`);
+	}
+	return {
+		endpoint: env.S3_ENDPOINT!.replace(/\/$/, ''),
+		bucket: env.S3_BUCKET!,
+		region: env.S3_REGION ?? 'auto',
+		accessKeyId: env.S3_ACCESS_KEY_ID!,
+		secretAccessKey: env.S3_SECRET_ACCESS_KEY!,
+		forcePathStyle: env.S3_FORCE_PATH_STYLE === 'true',
+		presignTtlSeconds: envInt(env.S3_PRESIGN_TTL_SECONDS, 300)
+	};
+}
+
+export const S3_CONFIG = readS3Config();
+
+if (STORAGE_BACKEND === 's3' && !S3_CONFIG) {
+	throw new Error(
+		'STORAGE_BACKEND=s3 but S3 config missing. Set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY.'
+	);
+}
+
 // 0 = no undo window (instant commit). >0 = seconds before dismissal commits.
 export const REMINDER_UNDO_SECONDS_DEFAULT = Math.min(
 	envNonNegativeInt(env.REMINDER_UNDO_SECONDS, 7),

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -1,5 +1,6 @@
 import { env } from '$env/dynamic/private';
 import { REMINDER_UNDO_MAX_SECONDS } from '$lib/reminderUndo';
+import type { StorageProvider } from '$lib/server/storage/types';
 
 export {
 	REMINDER_UNDO_MAX_SECONDS,
@@ -34,11 +35,20 @@ export const MAX_DAILY_PHOTOS = envInt(env.MAX_DAILY_PHOTOS, 5);
 // S3-compatible bucket (AWS, Garage, MinIO, Backblaze B2, R2, ...). Reads
 // always honor the per-row provider column, so switching here only affects
 // new writes — existing 'local' rows keep streaming from disk.
+//
+// Immich is intentionally excluded from this set: it's a read-only reference
+// layer, never a write destination. The type derives from StorageProvider so
+// adding a provider to the union forces an update here.
+export type StorageBackendName = Exclude<StorageProvider, 'immich'>;
+const ALLOWED_BACKENDS: readonly StorageBackendName[] = ['local', 's3'];
+
 const rawStorageBackend = (env.STORAGE_BACKEND ?? 'local').toLowerCase();
-if (rawStorageBackend !== 'local' && rawStorageBackend !== 's3') {
-	throw new Error(`Invalid STORAGE_BACKEND '${env.STORAGE_BACKEND}'. Allowed: local, s3.`);
+if (!(ALLOWED_BACKENDS as readonly string[]).includes(rawStorageBackend)) {
+	throw new Error(
+		`Invalid STORAGE_BACKEND '${env.STORAGE_BACKEND}'. Allowed: ${ALLOWED_BACKENDS.join(', ')}.`
+	);
 }
-export const STORAGE_BACKEND: 'local' | 's3' = rawStorageBackend;
+export const STORAGE_BACKEND: StorageBackendName = rawStorageBackend as StorageBackendName;
 
 export interface S3Config {
 	endpoint: string;

--- a/src/lib/server/permissions.ts
+++ b/src/lib/server/permissions.ts
@@ -1,0 +1,22 @@
+import { error, type RequestEvent } from '@sveltejs/kit';
+import { and, eq } from 'drizzle-orm';
+import { t } from '$lib/i18n';
+import { db, schema } from '$lib/server/db';
+
+// Members and admins can always edit a companion. Caretakers may only edit
+// when they are assigned to that companion. Throws via SvelteKit's error()
+// helper on failure; returns void on success.
+export async function assertCanEditCompanion(
+	locals: RequestEvent['locals'],
+	companionId: string
+): Promise<void> {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role !== 'caretaker') return;
+	const assigned = await db.query.companionCaretakers.findFirst({
+		where: and(
+			eq(schema.companionCaretakers.userId, locals.user.id),
+			eq(schema.companionCaretakers.companionId, companionId)
+		)
+	});
+	if (!assigned) error(403, t(locals.locale, 'error.forbidden'));
+}

--- a/src/lib/server/storage/avatarKeys.ts
+++ b/src/lib/server/storage/avatarKeys.ts
@@ -1,0 +1,19 @@
+import type { StorageProvider } from './types';
+
+export const AVATAR_LEGACY_EXTS = ['jpg', 'png', 'webp'] as const;
+
+export function avatarLegacyKey(companionId: string, ext: string): string {
+	return `avatars/${companionId}.${ext}`;
+}
+
+// Map a companion row's avatar columns to the storage key currently in use.
+// Returns null when the companion has no avatar set.
+export function resolveExistingAvatarKey(
+	provider: StorageProvider,
+	storedKey: string | null,
+	avatarPath: string | null
+): string | null {
+	if (storedKey) return storedKey;
+	if (provider === 'local' && avatarPath) return `avatars/${avatarPath}`;
+	return null;
+}

--- a/src/lib/server/storage/immich.ts
+++ b/src/lib/server/storage/immich.ts
@@ -2,6 +2,17 @@ import type { ImmichConfig } from '$lib/server/env';
 import type { GetResult, StorageBackend } from './types';
 
 const KEY_PREFIX = 'immich:';
+// Immich asset ids are UUIDs. Pin the format so a stored row referencing
+// `../../etc/passwd` can never sneak through parseKey.
+export const ASSET_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Default timeout for any single Immich HTTP call. Homelab Immich on LAN
+// should reply in well under a second; a hung Immich must not stall workers.
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+// Soft cap for album-mode listAssets. Immich's /albums/{id} returns every
+// asset in one shot, so a very large album would blow up memory.
+const ALBUM_ASSET_CAP = 5_000;
 
 export function immichKey(assetId: string): string {
 	return `${KEY_PREFIX}${assetId}`;
@@ -9,13 +20,26 @@ export function immichKey(assetId: string): string {
 
 function parseKey(key: string): string {
 	if (!key.startsWith(KEY_PREFIX)) {
-		throw new Error(`Immich storage key must start with '${KEY_PREFIX}': ${key}`);
+		throw new Error(`Immich storage key must start with '${KEY_PREFIX}'`);
 	}
 	const id = key.slice(KEY_PREFIX.length);
-	if (!/^[a-zA-Z0-9-]+$/.test(id)) {
-		throw new Error(`Invalid Immich asset id in key: ${key}`);
+	if (!ASSET_ID_RE.test(id)) {
+		throw new Error('Invalid Immich asset id in key');
 	}
 	return id;
+}
+
+function timeoutSignal(ms = DEFAULT_TIMEOUT_MS): AbortSignal {
+	return AbortSignal.timeout(ms);
+}
+
+// Log full upstream context server-side; return a short generic message so
+// callers (and any error.message that bubbles into a response) cannot leak
+// API keys, request ids, or bucket names.
+async function logAndSanitize(label: string, res: Response, hint: string): Promise<Error> {
+	const body = await res.text().catch(() => '');
+	console.error(`[immich] ${label} status=${res.status} body=${body.slice(0, 500)}`);
+	return new Error(`${hint} (${res.status})`);
 }
 
 export function createImmichBackend(config: ImmichConfig): StorageBackend {
@@ -27,13 +51,13 @@ export function createImmichBackend(config: ImmichConfig): StorageBackend {
 			size === 'original'
 				? `/api/assets/${assetId}/original`
 				: `/api/assets/${assetId}/thumbnail?size=${size}`;
-		const res = await fetch(`${config.url}${path}`, {
+		return fetch(`${config.url}${path}`, {
 			headers: {
 				'x-api-key': config.apiKey,
 				Accept: 'image/*'
-			}
+			},
+			signal: timeoutSignal()
 		});
-		return res;
 	}
 
 	return {
@@ -54,8 +78,7 @@ export function createImmichBackend(config: ImmichConfig): StorageBackend {
 			const res = await fetchAsset(assetId, 'preview');
 			if (res.status === 404) return null;
 			if (!res.ok || !res.body) {
-				const text = await res.text().catch(() => '');
-				throw new Error(`Immich asset ${assetId} fetch failed: ${res.status} ${text}`);
+				throw await logAndSanitize(`get asset=${assetId}`, res, 'Immich asset fetch failed');
 			}
 			const length = Number(res.headers.get('content-length') ?? 0);
 			const etag = res.headers.get('etag') ?? `"immich-${assetId}"`;
@@ -140,14 +163,27 @@ export function createImmichClient(config: ImmichConfig): ImmichClient {
 		async listAssets({ page, pageSize, albumId }) {
 			// Album mode: fetch the album once, then page client-side. Immich's
 			// /albums/{id} endpoint returns all assets in one response, which is
-			// fine for typical homelab album sizes.
+			// fine for typical homelab album sizes but capped here as a guard
+			// against giant albums.
 			if (albumId) {
-				const res = await fetch(`${config.url}/api/albums/${albumId}`, { headers: headers() });
+				const res = await fetch(`${config.url}/api/albums/${albumId}`, {
+					headers: headers(),
+					signal: timeoutSignal()
+				});
 				if (!res.ok) {
-					throw new Error(`Immich album ${albumId} fetch failed: ${res.status}`);
+					throw await logAndSanitize(`album=${albumId}`, res, 'Immich album fetch failed');
 				}
 				const body = (await res.json()) as ImmichAlbumResponse;
-				const all = (body.assets ?? []).filter((a) => a.type !== 'VIDEO').map(summarize);
+				const raw = body.assets ?? [];
+				if (raw.length > ALBUM_ASSET_CAP) {
+					console.warn(
+						`[immich] album ${albumId} has ${raw.length} assets; capping picker to first ${ALBUM_ASSET_CAP}`
+					);
+				}
+				const all = raw
+					.slice(0, ALBUM_ASSET_CAP)
+					.filter((a) => a.type !== 'VIDEO')
+					.map(summarize);
 				const start = (page - 1) * pageSize;
 				const items = all.slice(start, start + pageSize);
 				return { items, hasNextPage: start + pageSize < all.length };
@@ -163,10 +199,11 @@ export function createImmichClient(config: ImmichConfig): ImmichClient {
 					size: pageSize,
 					type: 'IMAGE',
 					order: 'desc'
-				})
+				}),
+				signal: timeoutSignal()
 			});
 			if (!res.ok) {
-				throw new Error(`Immich search failed: ${res.status}`);
+				throw await logAndSanitize('search', res, 'Immich search failed');
 			}
 			const body = (await res.json()) as ImmichSearchResponse;
 			const items = (body.assets?.items ?? []).map(summarize);
@@ -175,10 +212,13 @@ export function createImmichClient(config: ImmichConfig): ImmichClient {
 		},
 
 		async getAsset(assetId: string) {
-			const res = await fetch(`${config.url}/api/assets/${assetId}`, { headers: headers() });
+			const res = await fetch(`${config.url}/api/assets/${assetId}`, {
+				headers: headers(),
+				signal: timeoutSignal()
+			});
 			if (res.status === 404) return null;
 			if (!res.ok) {
-				throw new Error(`Immich asset ${assetId} fetch failed: ${res.status}`);
+				throw await logAndSanitize(`getAsset=${assetId}`, res, 'Immich asset fetch failed');
 			}
 			const body = (await res.json()) as ImmichAssetResponse;
 			return summarize(body);
@@ -186,7 +226,8 @@ export function createImmichClient(config: ImmichConfig): ImmichClient {
 
 		async fetchThumbnail(assetId: string, size: 'preview' | 'thumbnail') {
 			return fetch(`${config.url}/api/assets/${assetId}/thumbnail?size=${size}`, {
-				headers: { 'x-api-key': config.apiKey, Accept: 'image/*' }
+				headers: { 'x-api-key': config.apiKey, Accept: 'image/*' },
+				signal: timeoutSignal()
 			});
 		}
 	};

--- a/src/lib/server/storage/immich.ts
+++ b/src/lib/server/storage/immich.ts
@@ -1,0 +1,193 @@
+import type { ImmichConfig } from '$lib/server/env';
+import type { GetResult, StorageBackend } from './types';
+
+const KEY_PREFIX = 'immich:';
+
+export function immichKey(assetId: string): string {
+	return `${KEY_PREFIX}${assetId}`;
+}
+
+function parseKey(key: string): string {
+	if (!key.startsWith(KEY_PREFIX)) {
+		throw new Error(`Immich storage key must start with '${KEY_PREFIX}': ${key}`);
+	}
+	const id = key.slice(KEY_PREFIX.length);
+	if (!/^[a-zA-Z0-9-]+$/.test(id)) {
+		throw new Error(`Invalid Immich asset id in key: ${key}`);
+	}
+	return id;
+}
+
+export function createImmichBackend(config: ImmichConfig): StorageBackend {
+	async function fetchAsset(
+		assetId: string,
+		size: 'preview' | 'thumbnail' | 'original'
+	): Promise<Response> {
+		const path =
+			size === 'original'
+				? `/api/assets/${assetId}/original`
+				: `/api/assets/${assetId}/thumbnail?size=${size}`;
+		const res = await fetch(`${config.url}${path}`, {
+			headers: {
+				'x-api-key': config.apiKey,
+				Accept: 'image/*'
+			}
+		});
+		return res;
+	}
+
+	return {
+		provider: 'immich',
+
+		async put() {
+			throw new Error(
+				'Immich backend is read-only: use the from-immich endpoints to reference an existing asset.'
+			);
+		},
+
+		async get(key: string): Promise<GetResult | null> {
+			const assetId = parseKey(key);
+			// Serve Immich's 'preview' derivative rather than the original.
+			// Preview is typically ~1920px and quality-matches the cap EinVault
+			// applies to local/S3 uploads. Avoids streaming multi-MB originals
+			// for in-app journal views.
+			const res = await fetchAsset(assetId, 'preview');
+			if (res.status === 404) return null;
+			if (!res.ok || !res.body) {
+				const text = await res.text().catch(() => '');
+				throw new Error(`Immich asset ${assetId} fetch failed: ${res.status} ${text}`);
+			}
+			const length = Number(res.headers.get('content-length') ?? 0);
+			const etag = res.headers.get('etag') ?? `"immich-${assetId}"`;
+			const lastModified = res.headers.get('last-modified');
+			return {
+				kind: 'stream',
+				stream: res.body,
+				stat: {
+					size: length,
+					etag,
+					mtime: lastModified ? new Date(lastModified) : new Date(0)
+				}
+			};
+		},
+
+		async delete() {
+			// Intentional no-op. EinVault stores a reference to an Immich asset;
+			// removing the reference must not delete the user's photo from
+			// their Immich library.
+		}
+	};
+}
+
+export interface ImmichAssetSummary {
+	id: string;
+	originalFileName: string;
+	originalMimeType: string;
+	fileSizeInByte: number | null;
+	thumbhash: string | null;
+	createdAt: string | null;
+	type: string;
+}
+
+export interface ImmichClient {
+	listAssets(opts: { page: number; pageSize: number; albumId?: string | null }): Promise<{
+		items: ImmichAssetSummary[];
+		hasNextPage: boolean;
+	}>;
+	getAsset(assetId: string): Promise<ImmichAssetSummary | null>;
+	fetchThumbnail(assetId: string, size: 'preview' | 'thumbnail'): Promise<Response>;
+}
+
+interface ImmichAssetResponse {
+	id: string;
+	originalFileName?: string;
+	originalMimeType?: string;
+	fileSizeInByte?: number;
+	thumbhash?: string;
+	fileCreatedAt?: string;
+	type?: string;
+}
+
+interface ImmichSearchResponse {
+	assets?: {
+		items?: ImmichAssetResponse[];
+		nextPage?: string | null;
+	};
+}
+
+interface ImmichAlbumResponse {
+	assets?: ImmichAssetResponse[];
+}
+
+function summarize(a: ImmichAssetResponse): ImmichAssetSummary {
+	return {
+		id: a.id,
+		originalFileName: a.originalFileName ?? '',
+		originalMimeType: a.originalMimeType ?? 'application/octet-stream',
+		fileSizeInByte: typeof a.fileSizeInByte === 'number' ? a.fileSizeInByte : null,
+		thumbhash: a.thumbhash ?? null,
+		createdAt: a.fileCreatedAt ?? null,
+		type: a.type ?? 'IMAGE'
+	};
+}
+
+export function createImmichClient(config: ImmichConfig): ImmichClient {
+	function headers(): Record<string, string> {
+		return { 'x-api-key': config.apiKey, Accept: 'application/json' };
+	}
+
+	return {
+		async listAssets({ page, pageSize, albumId }) {
+			// Album mode: fetch the album once, then page client-side. Immich's
+			// /albums/{id} endpoint returns all assets in one response, which is
+			// fine for typical homelab album sizes.
+			if (albumId) {
+				const res = await fetch(`${config.url}/api/albums/${albumId}`, { headers: headers() });
+				if (!res.ok) {
+					throw new Error(`Immich album ${albumId} fetch failed: ${res.status}`);
+				}
+				const body = (await res.json()) as ImmichAlbumResponse;
+				const all = (body.assets ?? []).filter((a) => a.type !== 'VIDEO').map(summarize);
+				const start = (page - 1) * pageSize;
+				const items = all.slice(start, start + pageSize);
+				return { items, hasNextPage: start + pageSize < all.length };
+			}
+
+			// No album: use the search endpoint, newest first. Pagination is
+			// handled by Immich.
+			const res = await fetch(`${config.url}/api/search/metadata`, {
+				method: 'POST',
+				headers: { ...headers(), 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					page,
+					size: pageSize,
+					type: 'IMAGE',
+					order: 'desc'
+				})
+			});
+			if (!res.ok) {
+				throw new Error(`Immich search failed: ${res.status}`);
+			}
+			const body = (await res.json()) as ImmichSearchResponse;
+			const items = (body.assets?.items ?? []).map(summarize);
+			const hasNextPage = !!body.assets?.nextPage;
+			return { items, hasNextPage };
+		},
+
+		async getAsset(assetId: string) {
+			const res = await fetch(`${config.url}/api/assets/${assetId}`, { headers: headers() });
+			if (res.status === 404) return null;
+			if (!res.ok) {
+				throw new Error(`Immich asset ${assetId} fetch failed: ${res.status}`);
+			}
+			const body = (await res.json()) as ImmichAssetResponse;
+			return summarize(body);
+		},
+
+		async fetchThumbnail(assetId: string, size: 'preview' | 'thumbnail') {
+			return fetch(`${config.url}/api/assets/${assetId}/thumbnail?size=${size}`, {
+				headers: { 'x-api-key': config.apiKey, Accept: 'image/*' }
+			});
+		}
+	};
+}

--- a/src/lib/server/storage/index.ts
+++ b/src/lib/server/storage/index.ts
@@ -1,0 +1,10 @@
+import { LocalBackend } from './local';
+import type { StorageBackend } from './types';
+
+export type { BlobStat, GetResult, PutInput, StorageBackend, StorageProvider } from './types';
+
+let backend: StorageBackend = LocalBackend;
+
+export function getStorage(): StorageBackend {
+	return backend;
+}

--- a/src/lib/server/storage/index.ts
+++ b/src/lib/server/storage/index.ts
@@ -1,10 +1,39 @@
+import { S3_CONFIG, STORAGE_BACKEND } from '$lib/server/env';
 import { LocalBackend } from './local';
-import type { StorageBackend } from './types';
+import { createS3Backend } from './s3';
+import type { StorageBackend, StorageProvider } from './types';
 
-export type { BlobStat, GetResult, PutInput, StorageBackend, StorageProvider } from './types';
+export type {
+	BlobStat,
+	GetOptions,
+	GetResult,
+	PutInput,
+	StorageBackend,
+	StorageProvider
+} from './types';
 
-let backend: StorageBackend = LocalBackend;
+const backends: Partial<Record<StorageProvider, StorageBackend>> = {
+	local: LocalBackend
+};
 
-export function getStorage(): StorageBackend {
-	return backend;
+if (S3_CONFIG) {
+	backends.s3 = createS3Backend(S3_CONFIG);
 }
+
+/**
+ * Returns the backend for the given provider. With no argument, returns the
+ * write backend configured via STORAGE_BACKEND. Reads should pass the row's
+ * `provider` column so that existing local-stored rows continue to work after
+ * switching the write backend.
+ */
+export function getStorage(provider: StorageProvider = STORAGE_BACKEND): StorageBackend {
+	const b = backends[provider];
+	if (!b) {
+		throw new Error(
+			`Storage provider '${provider}' is not configured. Existing rows reference this provider — set the matching env vars.`
+		);
+	}
+	return b;
+}
+
+export { STORAGE_BACKEND };

--- a/src/lib/server/storage/index.ts
+++ b/src/lib/server/storage/index.ts
@@ -13,7 +13,7 @@ export type {
 	StorageProvider
 } from './types';
 
-export { immichKey } from './immich';
+export { immichKey, ASSET_ID_RE as IMMICH_ASSET_ID_RE } from './immich';
 export type { ImmichAssetSummary, ImmichClient } from './immich';
 
 const backends: Partial<Record<StorageProvider, StorageBackend>> = {

--- a/src/lib/server/storage/index.ts
+++ b/src/lib/server/storage/index.ts
@@ -1,6 +1,7 @@
-import { S3_CONFIG, STORAGE_BACKEND } from '$lib/server/env';
+import { IMMICH_CONFIG, S3_CONFIG, STORAGE_BACKEND } from '$lib/server/env';
 import { LocalBackend } from './local';
 import { createS3Backend } from './s3';
+import { createImmichBackend, createImmichClient, type ImmichClient } from './immich';
 import type { StorageBackend, StorageProvider } from './types';
 
 export type {
@@ -12,12 +13,21 @@ export type {
 	StorageProvider
 } from './types';
 
+export { immichKey } from './immich';
+export type { ImmichAssetSummary, ImmichClient } from './immich';
+
 const backends: Partial<Record<StorageProvider, StorageBackend>> = {
 	local: LocalBackend
 };
 
 if (S3_CONFIG) {
 	backends.s3 = createS3Backend(S3_CONFIG);
+}
+
+let immichClient: ImmichClient | null = null;
+if (IMMICH_CONFIG) {
+	backends.immich = createImmichBackend(IMMICH_CONFIG);
+	immichClient = createImmichClient(IMMICH_CONFIG);
 }
 
 /**
@@ -34,6 +44,14 @@ export function getStorage(provider: StorageProvider = STORAGE_BACKEND): Storage
 		);
 	}
 	return b;
+}
+
+export function getImmichClient(): ImmichClient | null {
+	return immichClient;
+}
+
+export function isImmichEnabled(): boolean {
+	return immichClient !== null;
 }
 
 export { STORAGE_BACKEND };

--- a/src/lib/server/storage/local.ts
+++ b/src/lib/server/storage/local.ts
@@ -3,7 +3,7 @@ import { mkdir, stat, unlink, writeFile } from 'fs/promises';
 import { dirname, join, normalize, resolve } from 'path';
 import { Readable } from 'stream';
 import { DATA_DIR } from '$lib/server/paths';
-import type { BlobStat, GetResult, PutInput, StorageBackend } from './types';
+import type { BlobStat, GetOptions, GetResult, PutInput, StorageBackend } from './types';
 
 const ROOT = join(DATA_DIR, 'uploads');
 const SAFE_BASE = resolve(ROOT);
@@ -34,7 +34,7 @@ export const LocalBackend: StorageBackend = {
 		return { key };
 	},
 
-	async get(key: string): Promise<GetResult | null> {
+	async get(key: string, opts?: GetOptions): Promise<GetResult | null> {
 		const full = resolveKey(key);
 		let s: Awaited<ReturnType<typeof stat>>;
 		try {
@@ -42,20 +42,15 @@ export const LocalBackend: StorageBackend = {
 		} catch {
 			return null;
 		}
-		return {
-			stream: Readable.toWeb(createReadStream(full)) as ReadableStream,
-			stat: makeStat(s.size, s.mtimeMs, s.mtime)
-		};
-	},
-
-	async stat(key: string): Promise<BlobStat | null> {
-		const full = resolveKey(key);
-		try {
-			const s = await stat(full);
-			return makeStat(s.size, s.mtimeMs, s.mtime);
-		} catch {
-			return null;
+		const blobStat = makeStat(s.size, s.mtimeMs, s.mtime);
+		if (opts?.ifNoneMatch && opts.ifNoneMatch === blobStat.etag) {
+			return { kind: 'notModified', etag: blobStat.etag };
 		}
+		return {
+			kind: 'stream',
+			stream: Readable.toWeb(createReadStream(full)) as ReadableStream,
+			stat: blobStat
+		};
 	},
 
 	async delete(key: string): Promise<void> {

--- a/src/lib/server/storage/local.ts
+++ b/src/lib/server/storage/local.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from 'fs';
 import { mkdir, stat, unlink, writeFile } from 'fs/promises';
-import { dirname, join, normalize, resolve } from 'path';
+import { dirname, join, normalize, resolve, sep } from 'path';
 import { Readable } from 'stream';
 import { DATA_DIR } from '$lib/server/paths';
 import type { BlobStat, GetOptions, GetResult, PutInput, StorageBackend } from './types';
@@ -10,7 +10,7 @@ const SAFE_BASE = resolve(ROOT);
 
 function resolveKey(key: string): string {
 	const full = resolve(join(ROOT, normalize(key)));
-	if (!full.startsWith(SAFE_BASE + '/') && full !== SAFE_BASE) {
+	if (full !== SAFE_BASE && !full.startsWith(SAFE_BASE + sep)) {
 		throw new Error('storage: key escapes upload root');
 	}
 	return full;

--- a/src/lib/server/storage/local.ts
+++ b/src/lib/server/storage/local.ts
@@ -1,0 +1,69 @@
+import { createReadStream } from 'fs';
+import { mkdir, stat, unlink, writeFile } from 'fs/promises';
+import { dirname, join, normalize, resolve } from 'path';
+import { Readable } from 'stream';
+import { DATA_DIR } from '$lib/server/paths';
+import type { BlobStat, GetResult, PutInput, StorageBackend } from './types';
+
+const ROOT = join(DATA_DIR, 'uploads');
+const SAFE_BASE = resolve(ROOT);
+
+function resolveKey(key: string): string {
+	const full = resolve(join(ROOT, normalize(key)));
+	if (!full.startsWith(SAFE_BASE + '/') && full !== SAFE_BASE) {
+		throw new Error('storage: key escapes upload root');
+	}
+	return full;
+}
+
+function makeStat(size: number, mtimeMs: number, mtime: Date): BlobStat {
+	return {
+		size,
+		mtime,
+		etag: `"${mtimeMs.toString(36)}-${size.toString(36)}"`
+	};
+}
+
+export const LocalBackend: StorageBackend = {
+	provider: 'local',
+
+	async put({ key, body }: PutInput) {
+		const full = resolveKey(key);
+		await mkdir(dirname(full), { recursive: true });
+		await writeFile(full, body);
+		return { key };
+	},
+
+	async get(key: string): Promise<GetResult | null> {
+		const full = resolveKey(key);
+		let s: Awaited<ReturnType<typeof stat>>;
+		try {
+			s = await stat(full);
+		} catch {
+			return null;
+		}
+		return {
+			stream: Readable.toWeb(createReadStream(full)) as ReadableStream,
+			stat: makeStat(s.size, s.mtimeMs, s.mtime)
+		};
+	},
+
+	async stat(key: string): Promise<BlobStat | null> {
+		const full = resolveKey(key);
+		try {
+			const s = await stat(full);
+			return makeStat(s.size, s.mtimeMs, s.mtime);
+		} catch {
+			return null;
+		}
+	},
+
+	async delete(key: string): Promise<void> {
+		const full = resolveKey(key);
+		try {
+			await unlink(full);
+		} catch {
+			// already gone
+		}
+	}
+};

--- a/src/lib/server/storage/mime.ts
+++ b/src/lib/server/storage/mime.ts
@@ -1,0 +1,34 @@
+// Mime types EinVault will accept for journal photos and avatars.
+// Conservative on purpose: SVG and ICO can carry active content; HEIC may
+// require sharp's libheif which is not always present.
+export const ALLOWED_PHOTO_MIME = [
+	'image/jpeg',
+	'image/png',
+	'image/webp',
+	'image/gif',
+	'image/heic'
+] as const;
+
+export const ALLOWED_AVATAR_MIME = ['image/jpeg', 'image/png', 'image/webp'] as const;
+
+export function isAllowedPhotoMime(mime: string | null | undefined): boolean {
+	return !!mime && (ALLOWED_PHOTO_MIME as readonly string[]).includes(mime);
+}
+
+export function isAllowedAvatarMime(mime: string | null | undefined): boolean {
+	return !!mime && (ALLOWED_AVATAR_MIME as readonly string[]).includes(mime);
+}
+
+// Derive a safe lowercase file extension from a mime type, falling back to
+// an extension hinted by the original filename only if it passes a strict
+// allowlist regex. Defaults to 'jpg' when nothing is usable.
+export function safeExtFromMime(mime: string, originalFileName: string | null | undefined): string {
+	const hinted = originalFileName?.split('.').pop()?.toLowerCase();
+	if (hinted && /^[a-z0-9]{1,5}$/.test(hinted)) return hinted;
+	if (mime === 'image/jpeg') return 'jpg';
+	if (mime === 'image/png') return 'png';
+	if (mime === 'image/webp') return 'webp';
+	if (mime === 'image/gif') return 'gif';
+	if (mime === 'image/heic') return 'heic';
+	return 'jpg';
+}

--- a/src/lib/server/storage/s3.ts
+++ b/src/lib/server/storage/s3.ts
@@ -49,7 +49,8 @@ export function createS3Backend(config: S3Config): StorageBackend {
 			});
 			if (!res.ok) {
 				const text = await res.text().catch(() => '');
-				throw new Error(`S3 PUT ${key} failed: ${res.status} ${text}`);
+				console.error(`[s3] PUT key=${key} status=${res.status} body=${text.slice(0, 500)}`);
+				throw new Error(`S3 PUT failed (${res.status})`);
 			}
 			return { key };
 		},
@@ -73,7 +74,8 @@ export function createS3Backend(config: S3Config): StorageBackend {
 			const res = await aws.fetch(objectUrl(key), { method: 'DELETE' });
 			if (!res.ok && res.status !== 404) {
 				const text = await res.text().catch(() => '');
-				throw new Error(`S3 DELETE ${key} failed: ${res.status} ${text}`);
+				console.error(`[s3] DELETE key=${key} status=${res.status} body=${text.slice(0, 500)}`);
+				throw new Error(`S3 DELETE failed (${res.status})`);
 			}
 		}
 	};

--- a/src/lib/server/storage/s3.ts
+++ b/src/lib/server/storage/s3.ts
@@ -1,0 +1,80 @@
+import { AwsClient } from 'aws4fetch';
+import type { S3Config } from '$lib/server/env';
+import type { GetResult, PutInput, StorageBackend } from './types';
+
+function encodeKey(key: string): string {
+	// S3 keys can contain `/` as a literal character. Encode each segment so
+	// special characters in filenames are safe, but preserve segment boundaries.
+	return key
+		.split('/')
+		.map((seg) => encodeURIComponent(seg))
+		.join('/');
+}
+
+export function createS3Backend(config: S3Config): StorageBackend {
+	const aws = new AwsClient({
+		accessKeyId: config.accessKeyId,
+		secretAccessKey: config.secretAccessKey,
+		region: config.region,
+		service: 's3'
+	});
+
+	const endpoint = new URL(config.endpoint);
+
+	function objectUrl(key: string): string {
+		const encoded = encodeKey(key);
+		if (config.forcePathStyle) {
+			return `${config.endpoint}/${encodeURIComponent(config.bucket)}/${encoded}`;
+		}
+		// virtual-hosted style: bucket as subdomain
+		return `${endpoint.protocol}//${encodeURIComponent(config.bucket)}.${endpoint.host}/${encoded}`;
+	}
+
+	return {
+		provider: 's3',
+
+		async put({ key, body, contentType }: PutInput) {
+			// Copy into a fresh ArrayBuffer so the resulting Blob/BodyInit types
+			// resolve cleanly across Node/DOM lib variations.
+			const ab = new ArrayBuffer(body.byteLength);
+			new Uint8Array(ab).set(body);
+			const blob = new Blob([ab], { type: contentType });
+			const res = await aws.fetch(objectUrl(key), {
+				method: 'PUT',
+				body: blob,
+				headers: {
+					'Content-Type': contentType,
+					'Content-Length': String(blob.size)
+				}
+			});
+			if (!res.ok) {
+				const text = await res.text().catch(() => '');
+				throw new Error(`S3 PUT ${key} failed: ${res.status} ${text}`);
+			}
+			return { key };
+		},
+
+		async get(key: string): Promise<GetResult | null> {
+			// Issue a presigned GET URL. Caller redirects browser to it.
+			// We do not HEAD first — if the object is missing the eventual fetch
+			// will 404, which is acceptable for a homelab.
+			const url = `${objectUrl(key)}?X-Amz-Expires=${config.presignTtlSeconds}`;
+			const signed = await aws.sign(new Request(url, { method: 'GET' }), {
+				aws: { signQuery: true }
+			});
+			return {
+				kind: 'redirect',
+				url: signed.url,
+				cacheSeconds: Math.min(60, Math.max(0, config.presignTtlSeconds - 30))
+			};
+		},
+
+		async delete(key: string): Promise<void> {
+			const res = await aws.fetch(objectUrl(key), { method: 'DELETE' });
+			if (!res.ok && res.status !== 404) {
+				const text = await res.text().catch(() => '');
+				throw new Error(`S3 DELETE ${key} failed: ${res.status} ${text}`);
+			}
+		}
+	};
+}

--- a/src/lib/server/storage/types.ts
+++ b/src/lib/server/storage/types.ts
@@ -1,0 +1,26 @@
+export type StorageProvider = 'local';
+
+export interface PutInput {
+	key: string;
+	body: Buffer;
+	contentType: string;
+}
+
+export interface BlobStat {
+	size: number;
+	etag: string;
+	mtime: Date;
+}
+
+export interface GetResult {
+	stream: ReadableStream;
+	stat: BlobStat;
+}
+
+export interface StorageBackend {
+	readonly provider: StorageProvider;
+	put(input: PutInput): Promise<{ key: string }>;
+	get(key: string): Promise<GetResult | null>;
+	stat(key: string): Promise<BlobStat | null>;
+	delete(key: string): Promise<void>;
+}

--- a/src/lib/server/storage/types.ts
+++ b/src/lib/server/storage/types.ts
@@ -1,4 +1,4 @@
-export type StorageProvider = 'local' | 's3';
+export type StorageProvider = 'local' | 's3' | 'immich';
 
 export interface PutInput {
 	key: string;

--- a/src/lib/server/storage/types.ts
+++ b/src/lib/server/storage/types.ts
@@ -1,4 +1,4 @@
-export type StorageProvider = 'local';
+export type StorageProvider = 'local' | 's3';
 
 export interface PutInput {
 	key: string;
@@ -12,15 +12,18 @@ export interface BlobStat {
 	mtime: Date;
 }
 
-export interface GetResult {
-	stream: ReadableStream;
-	stat: BlobStat;
+export type GetResult =
+	| { kind: 'stream'; stream: ReadableStream; stat: BlobStat }
+	| { kind: 'redirect'; url: string; cacheSeconds: number }
+	| { kind: 'notModified'; etag: string };
+
+export interface GetOptions {
+	ifNoneMatch?: string | null;
 }
 
 export interface StorageBackend {
 	readonly provider: StorageProvider;
 	put(input: PutInput): Promise<{ key: string }>;
-	get(key: string): Promise<GetResult | null>;
-	stat(key: string): Promise<BlobStat | null>;
+	get(key: string, opts?: GetOptions): Promise<GetResult | null>;
 	delete(key: string): Promise<void>;
 }

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -3,6 +3,7 @@
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import ImmichPicker from '$lib/components/ImmichPicker.svelte';
 	import { bustAvatarCache } from '$lib/avatarCache.svelte';
+	import { invalidateAll } from '$app/navigation';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
 	import { localDateISO } from '$lib/date';
@@ -107,11 +108,15 @@
 			}
 			bustAvatarCache(companion.id);
 			immichAvatarPickerOpen = false;
-			window.location.reload();
+			// Refresh the loader so the new avatar metadata flows in without a
+			// full page reload (which would drop any unsaved form state).
+			await invalidateAll();
 		} catch {
 			setImmichAvatarError(t(locale, 'immich.picker.pickFailed'));
 		}
 	}
+
+	$effect(() => () => clearTimeout(immichAvatarErrorTimer));
 
 	// Pending reminder dismissals
 	const undoDelayMs = $derived((data.reminderUndoSeconds ?? 0) * 1000);

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
+	import ImmichPicker from '$lib/components/ImmichPicker.svelte';
+	import { bustAvatarCache } from '$lib/avatarCache.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
 	import { localDateISO } from '$lib/date';
@@ -76,6 +78,39 @@
 	function closeAvatarLightbox() {
 		avatarLightboxOpen = false;
 		(document.activeElement as HTMLElement)?.blur();
+	}
+
+	// Immich avatar picker
+	let immichAvatarPickerOpen = $state(false);
+	let immichAvatarError = $state('');
+	let immichAvatarErrorTimer: ReturnType<typeof setTimeout>;
+
+	function setImmichAvatarError(msg: string) {
+		immichAvatarError = msg;
+		clearTimeout(immichAvatarErrorTimer);
+		immichAvatarErrorTimer = setTimeout(() => (immichAvatarError = ''), 5000);
+	}
+
+	async function pickAvatarFromImmich(assetId: string) {
+		try {
+			const res = await fetch(`/api/companions/${companion.id}/avatar/from-immich`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ assetId })
+			});
+			if (!res.ok) {
+				const err = await res
+					.json()
+					.catch(() => ({ message: t(locale, 'immich.picker.pickFailed') }));
+				setImmichAvatarError(err.message ?? t(locale, 'immich.picker.pickFailed'));
+				return;
+			}
+			bustAvatarCache(companion.id);
+			immichAvatarPickerOpen = false;
+			window.location.reload();
+		} catch {
+			setImmichAvatarError(t(locale, 'immich.picker.pickFailed'));
+		}
 	}
 
 	// Pending reminder dismissals
@@ -468,6 +503,8 @@
 						size="lg"
 						editable={companion.isActive}
 						onlightbox={avatarUrl ? () => (avatarLightboxOpen = true) : undefined}
+						immichEnabled={data.immichEnabled}
+						onpickImmich={() => (immichAvatarPickerOpen = true)}
 					/>
 					<div>
 						<h1 class="font-display text-2xl font-bold">{companion.name}</h1>
@@ -820,3 +857,20 @@
 		</CardContent>
 	</Card>
 </div>
+
+{#if data.immichEnabled}
+	<ImmichPicker
+		open={immichAvatarPickerOpen}
+		onpick={pickAvatarFromImmich}
+		onclose={() => (immichAvatarPickerOpen = false)}
+	/>
+{/if}
+
+{#if immichAvatarError}
+	<div
+		role="alert"
+		class="fixed bottom-4 right-4 z-50 max-w-sm rounded-lg bg-destructive text-destructive-foreground px-4 py-2 text-sm shadow-lg"
+	>
+		{immichAvatarError}
+	</div>
+{/if}

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -133,12 +133,14 @@
 				setUploadError(err.message ?? 'Upload failed');
 				return;
 			}
-			const { id, filename, loggedBy, logger } = await res.json();
+			const { id, filename, provider, storageKey, loggedBy, logger } = await res.json();
 			photos = [
 				...photos,
 				{
 					id,
 					filename,
+					provider,
+					storageKey,
 					entryId: data.entry?.id ?? '',
 					originalName: file.name,
 					mimeType: file.type,

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -11,6 +11,7 @@
 
 	const serverTimezone = getContext<string | undefined>('serverTimezone');
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import ImmichPicker from '$lib/components/ImmichPicker.svelte';
 	import {
 		Trash2,
 		ChevronLeft,
@@ -198,6 +199,33 @@
 			if (photos.length < data.maxDailyPhotos) uploadPhoto(file);
 		}
 		if (fileInputEl) fileInputEl.value = '';
+	}
+
+	let immichPickerOpen = $state(false);
+
+	async function pickFromImmich(assetId: string) {
+		try {
+			const res = await fetch(
+				`/api/companions/${data.companion.id}/journal/${data.date}/photos/from-immich`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ assetId })
+				}
+			);
+			if (!res.ok) {
+				const err = await res
+					.json()
+					.catch(() => ({ message: t(locale, 'immich.picker.pickFailed') }));
+				setUploadError(err.message ?? t(locale, 'immich.picker.pickFailed'));
+				return;
+			}
+			const photo = await res.json();
+			photos = [...photos, photo];
+			immichPickerOpen = false;
+		} catch {
+			setUploadError(t(locale, 'immich.picker.pickFailed'));
+		}
 	}
 
 	function photoUrl(photo: (typeof photos)[0]) {
@@ -621,24 +649,36 @@
 				>
 			</h2>
 			{#if photos.length < data.maxDailyPhotos}
-				<label
-					class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent cursor-pointer"
-				>
-					{#if uploading}{t(locale, 'page.journal.day.uploading')}{:else}<Plus
-							class="h-3.5 w-3.5"
+				<div class="flex items-center gap-2">
+					{#if data.immichEnabled}
+						<button
+							type="button"
+							class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
+							onclick={() => (immichPickerOpen = true)}
+						>
+							<ImageIcon class="h-3.5 w-3.5" />
+							{t(locale, 'immich.picker.button')}
+						</button>
+					{/if}
+					<label
+						class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent cursor-pointer"
+					>
+						{#if uploading}{t(locale, 'page.journal.day.uploading')}{:else}<Plus
+								class="h-3.5 w-3.5"
+							/>
+							{t(locale, 'page.journal.day.addPhoto')}{/if}
+						<input
+							bind:this={fileInputEl}
+							type="file"
+							name="photos"
+							accept="image/jpeg,image/png,image/webp,image/gif"
+							multiple
+							class="sr-only"
+							onchange={handleFileInput}
+							disabled={uploading}
 						/>
-						{t(locale, 'page.journal.day.addPhoto')}{/if}
-					<input
-						bind:this={fileInputEl}
-						type="file"
-						name="photos"
-						accept="image/jpeg,image/png,image/webp,image/gif"
-						multiple
-						class="sr-only"
-						onchange={handleFileInput}
-						disabled={uploading}
-					/>
-				</label>
+					</label>
+				</div>
 			{/if}
 		</div>
 
@@ -1120,3 +1160,11 @@
 	}}
 	oncancel={() => (confirmOpen = false)}
 />
+
+{#if data.immichEnabled}
+	<ImmichPicker
+		open={immichPickerOpen}
+		onpick={pickFromImmich}
+		onclose={() => (immichPickerOpen = false)}
+	/>
+{/if}

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -84,12 +84,14 @@
 				setUploadError(err.message ?? 'Upload failed');
 				return;
 			}
-			const { id, filename, loggedBy, logger } = await res.json();
+			const { id, filename, provider, storageKey, loggedBy, logger } = await res.json();
 			photos = [
 				...photos,
 				{
 					id,
 					filename,
+					provider,
+					storageKey,
 					entryId: data.todayEntry?.id ?? '',
 					originalName: file.name,
 					mimeType: file.type,

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -4,6 +4,7 @@ import { db, schema } from '$lib/server/db';
 import { version } from '../../package.json';
 import { t } from '$lib/i18n';
 import { resolveReminderUndoSeconds } from '$lib/server/env';
+import { isImmichEnabled } from '$lib/server/storage';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
 	const isApiRoute = url.pathname.startsWith('/api');
@@ -37,6 +38,8 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 		serverTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 		version,
 		year: new Date().getFullYear(),
-		reminderUndoSeconds: resolveReminderUndoSeconds(locals.user?.reminderUndoSeconds ?? null)
+		reminderUndoSeconds: resolveReminderUndoSeconds(locals.user?.reminderUndoSeconds ?? null),
+		// Caretakers don't get the picker — the underlying endpoints reject them.
+		immichEnabled: isImmichEnabled() && locals.user?.role !== 'caretaker'
 	};
 };

--- a/src/routes/api/avatars/[companionId]/+server.ts
+++ b/src/routes/api/avatars/[companionId]/+server.ts
@@ -13,14 +13,30 @@ export const GET: RequestHandler = async ({ params, locals, request, url }) => {
 	});
 	if (!companion?.avatarPath) error(404, t(locals.locale, 'error.noAvatar'));
 
-	const key = `avatars/${companion.avatarPath}`;
-	const storage = getStorage();
+	const key = companion.avatarStorageKey ?? `avatars/${companion.avatarPath}`;
+	const ifNoneMatch = request.headers.get('if-none-match');
 
-	const stat = await storage.stat(key);
-	if (!stat) error(404, t(locals.locale, 'error.fileNotFound'));
+	let res: Awaited<ReturnType<ReturnType<typeof getStorage>['get']>>;
+	try {
+		res = await getStorage(companion.avatarProvider).get(key, { ifNoneMatch });
+	} catch {
+		error(403, t(locals.locale, 'error.forbidden'));
+	}
+	if (!res) error(404, t(locals.locale, 'error.fileNotFound'));
 
-	if (request.headers.get('if-none-match') === stat.etag) {
-		return new Response(null, { status: 304 });
+	if (res.kind === 'notModified') {
+		return new Response(null, { status: 304, headers: { ETag: res.etag } });
+	}
+
+	if (res.kind === 'redirect') {
+		return new Response(null, {
+			status: 302,
+			headers: {
+				Location: res.url,
+				'Cache-Control': `private, max-age=${res.cacheSeconds}`,
+				'Referrer-Policy': 'no-referrer'
+			}
+		});
 	}
 
 	const ext = companion.avatarPath.split('.').pop() ?? 'jpg';
@@ -31,16 +47,13 @@ export const GET: RequestHandler = async ({ params, locals, request, url }) => {
 		? 'private, max-age=31536000, immutable'
 		: 'private, no-cache';
 
-	const result = await storage.get(key);
-	if (!result) error(404, t(locals.locale, 'error.fileNotFound'));
-
-	return new Response(result.stream, {
+	return new Response(res.stream, {
 		headers: {
 			'Content-Type': mimeType,
-			'Content-Length': String(result.stat.size),
+			'Content-Length': String(res.stat.size),
 			'Cache-Control': cacheControl,
-			ETag: result.stat.etag,
-			'Last-Modified': result.stat.mtime.toUTCString(),
+			ETag: res.stat.etag,
+			'Last-Modified': res.stat.mtime.toUTCString(),
 			'X-Content-Type-Options': 'nosniff'
 		}
 	});

--- a/src/routes/api/avatars/[companionId]/+server.ts
+++ b/src/routes/api/avatars/[companionId]/+server.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
-import { getStorage } from '$lib/server/storage';
+import { getStorage, type GetResult } from '$lib/server/storage';
 
 export const GET: RequestHandler = async ({ params, locals, request, url }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
@@ -16,11 +16,15 @@ export const GET: RequestHandler = async ({ params, locals, request, url }) => {
 	const key = companion.avatarStorageKey ?? `avatars/${companion.avatarPath}`;
 	const ifNoneMatch = request.headers.get('if-none-match');
 
-	let res: Awaited<ReturnType<ReturnType<typeof getStorage>['get']>>;
+	let res: GetResult | null;
 	try {
 		res = await getStorage(companion.avatarProvider).get(key, { ifNoneMatch });
-	} catch {
-		error(403, t(locals.locale, 'error.forbidden'));
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('escapes upload root')) {
+			error(403, t(locals.locale, 'error.forbidden'));
+		}
+		console.error(`[avatars] storage error provider=${companion.avatarProvider} key=${key}:`, err);
+		error(502, t(locals.locale, 'error.fileNotFound'));
 	}
 	if (!res) error(404, t(locals.locale, 'error.fileNotFound'));
 
@@ -43,9 +47,14 @@ export const GET: RequestHandler = async ({ params, locals, request, url }) => {
 	const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : 'image/jpeg';
 
 	const hasCacheBuster = url.searchParams.has('t');
-	const cacheControl = hasCacheBuster
-		? 'private, max-age=31536000, immutable'
-		: 'private, no-cache';
+	// Immich-backed avatars can regenerate previews server-side, so we don't
+	// mark them immutable even with a cache buster — fall back to revalidate.
+	const cacheControl =
+		companion.avatarProvider === 'immich'
+			? 'private, max-age=300'
+			: hasCacheBuster
+				? 'private, max-age=31536000, immutable'
+				: 'private, no-cache';
 
 	return new Response(res.stream, {
 		headers: {

--- a/src/routes/api/avatars/[companionId]/+server.ts
+++ b/src/routes/api/avatars/[companionId]/+server.ts
@@ -3,11 +3,7 @@ import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
-import { createReadStream } from 'fs';
-import { Readable } from 'stream';
-import { stat } from 'fs/promises';
-import { join, resolve } from 'path';
-import { DATA_DIR } from '$lib/server/paths';
+import { getStorage } from '$lib/server/storage';
 
 export const GET: RequestHandler = async ({ params, locals, request, url }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
@@ -17,42 +13,34 @@ export const GET: RequestHandler = async ({ params, locals, request, url }) => {
 	});
 	if (!companion?.avatarPath) error(404, t(locals.locale, 'error.noAvatar'));
 
-	const fullPath = join(DATA_DIR, 'uploads', 'avatars', companion.avatarPath);
+	const key = `avatars/${companion.avatarPath}`;
+	const storage = getStorage();
 
-	// Path traversal guard
-	const safeBase = resolve(join(DATA_DIR, 'uploads', 'avatars'));
-	if (!resolve(fullPath).startsWith(safeBase)) error(403, t(locals.locale, 'error.forbidden'));
+	const stat = await storage.stat(key);
+	if (!stat) error(404, t(locals.locale, 'error.fileNotFound'));
 
-	let fileStat: Awaited<ReturnType<typeof stat>>;
-	try {
-		fileStat = await stat(fullPath);
-	} catch {
-		error(404, t(locals.locale, 'error.fileNotFound'));
-	}
-
-	const etag = `"${fileStat.mtimeMs.toString(36)}-${fileStat.size.toString(36)}"`;
-
-	// Return 304 if client already has this version
-	if (request.headers.get('if-none-match') === etag) {
+	if (request.headers.get('if-none-match') === stat.etag) {
 		return new Response(null, { status: 304 });
 	}
 
 	const ext = companion.avatarPath.split('.').pop() ?? 'jpg';
 	const mimeType = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : 'image/jpeg';
 
-	// Cache indefinitely when URL has a cache-buster (?t=...), otherwise rely on ETag revalidation
 	const hasCacheBuster = url.searchParams.has('t');
 	const cacheControl = hasCacheBuster
 		? 'private, max-age=31536000, immutable'
 		: 'private, no-cache';
 
-	return new Response(Readable.toWeb(createReadStream(fullPath)) as ReadableStream, {
+	const result = await storage.get(key);
+	if (!result) error(404, t(locals.locale, 'error.fileNotFound'));
+
+	return new Response(result.stream, {
 		headers: {
 			'Content-Type': mimeType,
-			'Content-Length': String(fileStat.size),
+			'Content-Length': String(result.stat.size),
 			'Cache-Control': cacheControl,
-			ETag: etag,
-			'Last-Modified': fileStat.mtime.toUTCString(),
+			ETag: result.stat.etag,
+			'Last-Modified': result.stat.mtime.toUTCString(),
 			'X-Content-Type-Options': 'nosniff'
 		}
 	});

--- a/src/routes/api/companions/[companionId]/avatar/+server.ts
+++ b/src/routes/api/companions/[companionId]/avatar/+server.ts
@@ -3,15 +3,17 @@ import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq, and } from 'drizzle-orm';
-import { writeFile, mkdir, unlink } from 'fs/promises';
-import { join } from 'path';
-import { existsSync } from 'fs';
 import sharp from 'sharp';
-import { DATA_DIR } from '$lib/server/paths';
+import { getStorage } from '$lib/server/storage';
 import { UPLOAD_MAX_MB } from '$lib/server/env';
 
 const MAX_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const LEGACY_EXTS = ['jpg', 'png', 'webp'];
+
+function avatarKey(companionId: string, ext: string): string {
+	return `avatars/${companionId}.${ext}`;
+}
 
 async function assertCanEditAvatar(
 	locals: import('@sveltejs/kit').RequestEvent['locals'],
@@ -46,13 +48,11 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	if (!ALLOWED_TYPES.includes(file.type))
 		error(400, t(locals.locale, 'error.invalidFileTypeAvatar'));
 
-	const avatarDir = join(DATA_DIR, 'uploads', 'avatars');
-	await mkdir(avatarDir, { recursive: true });
+	const storage = getStorage();
 
-	// Remove old avatar regardless of extension
-	for (const oldExt of ['jpg', 'png', 'webp']) {
-		const old = join(avatarDir, `${params.companionId}.${oldExt}`);
-		if (existsSync(old)) await unlink(old).catch(() => {});
+	// Remove any prior avatar regardless of legacy extension
+	for (const ext of LEGACY_EXTS) {
+		await storage.delete(avatarKey(params.companionId, ext));
 	}
 
 	const raw = Buffer.from(await file.arrayBuffer());
@@ -62,7 +62,11 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		.toBuffer();
 
 	const filename = `${params.companionId}.jpg`;
-	await writeFile(join(avatarDir, filename), processed);
+	await storage.put({
+		key: avatarKey(params.companionId, 'jpg'),
+		body: processed,
+		contentType: 'image/jpeg'
+	});
 
 	await db
 		.update(schema.companions)
@@ -75,10 +79,9 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 export const DELETE: RequestHandler = async ({ params, locals }) => {
 	await assertCanEditAvatar(locals, params.companionId);
 
-	const avatarDir = join(DATA_DIR, 'uploads', 'avatars');
-	for (const ext of ['jpg', 'png', 'webp']) {
-		const p = join(avatarDir, `${params.companionId}.${ext}`);
-		if (existsSync(p)) await unlink(p).catch(() => {});
+	const storage = getStorage();
+	for (const ext of LEGACY_EXTS) {
+		await storage.delete(avatarKey(params.companionId, ext));
 	}
 
 	await db

--- a/src/routes/api/companions/[companionId]/avatar/+server.ts
+++ b/src/routes/api/companions/[companionId]/avatar/+server.ts
@@ -4,7 +4,8 @@ import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq, and } from 'drizzle-orm';
 import sharp from 'sharp';
-import { getStorage } from '$lib/server/storage';
+import { getStorage, STORAGE_BACKEND } from '$lib/server/storage';
+import type { StorageProvider } from '$lib/server/storage';
 import { UPLOAD_MAX_MB } from '$lib/server/env';
 
 const MAX_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
@@ -13,6 +14,18 @@ const LEGACY_EXTS = ['jpg', 'png', 'webp'];
 
 function avatarKey(companionId: string, ext: string): string {
 	return `avatars/${companionId}.${ext}`;
+}
+
+function resolveExistingKey(
+	companionId: string,
+	provider: StorageProvider,
+	storedKey: string | null,
+	avatarPath: string | null
+): string | null {
+	if (storedKey) return storedKey;
+	// Legacy local row: derive key from avatarPath (filename).
+	if (provider === 'local' && avatarPath) return `avatars/${avatarPath}`;
+	return null;
 }
 
 async function assertCanEditAvatar(
@@ -48,11 +61,23 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	if (!ALLOWED_TYPES.includes(file.type))
 		error(400, t(locals.locale, 'error.invalidFileTypeAvatar'));
 
-	const storage = getStorage();
-
-	// Remove any prior avatar regardless of legacy extension
-	for (const ext of LEGACY_EXTS) {
-		await storage.delete(avatarKey(params.companionId, ext));
+	// Remove previous avatar from wherever it currently lives.
+	const existingKey = resolveExistingKey(
+		params.companionId,
+		companion.avatarProvider,
+		companion.avatarStorageKey,
+		companion.avatarPath
+	);
+	if (existingKey) {
+		await getStorage(companion.avatarProvider).delete(existingKey);
+	}
+	// Local-only legacy cleanup: wipe sibling .png/.webp from disk in case
+	// they survived a prior failed delete.
+	if (companion.avatarProvider === 'local') {
+		const local = getStorage('local');
+		for (const ext of LEGACY_EXTS) {
+			await local.delete(avatarKey(params.companionId, ext));
+		}
 	}
 
 	const raw = Buffer.from(await file.arrayBuffer());
@@ -62,15 +87,20 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		.toBuffer();
 
 	const filename = `${params.companionId}.jpg`;
-	await storage.put({
-		key: avatarKey(params.companionId, 'jpg'),
+	const key = avatarKey(params.companionId, 'jpg');
+	await getStorage().put({
+		key,
 		body: processed,
 		contentType: 'image/jpeg'
 	});
 
 	await db
 		.update(schema.companions)
-		.set({ avatarPath: filename })
+		.set({
+			avatarPath: filename,
+			avatarProvider: STORAGE_BACKEND,
+			avatarStorageKey: key
+		})
 		.where(eq(schema.companions.id, params.companionId));
 
 	return json({ avatarPath: filename, url: `/api/avatars/${params.companionId}` });
@@ -79,14 +109,30 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 export const DELETE: RequestHandler = async ({ params, locals }) => {
 	await assertCanEditAvatar(locals, params.companionId);
 
-	const storage = getStorage();
-	for (const ext of LEGACY_EXTS) {
-		await storage.delete(avatarKey(params.companionId, ext));
+	const companion = await db.query.companions.findFirst({
+		where: eq(schema.companions.id, params.companionId)
+	});
+	if (!companion) error(404, t(locals.locale, 'error.notFound'));
+
+	const existingKey = resolveExistingKey(
+		params.companionId,
+		companion.avatarProvider,
+		companion.avatarStorageKey,
+		companion.avatarPath
+	);
+	if (existingKey) {
+		await getStorage(companion.avatarProvider).delete(existingKey);
+	}
+	if (companion.avatarProvider === 'local') {
+		const local = getStorage('local');
+		for (const ext of LEGACY_EXTS) {
+			await local.delete(avatarKey(params.companionId, ext));
+		}
 	}
 
 	await db
 		.update(schema.companions)
-		.set({ avatarPath: null })
+		.set({ avatarPath: null, avatarStorageKey: null, avatarProvider: 'local' })
 		.where(eq(schema.companions.id, params.companionId));
 
 	return json({ success: true });

--- a/src/routes/api/companions/[companionId]/avatar/+server.ts
+++ b/src/routes/api/companions/[companionId]/avatar/+server.ts
@@ -51,11 +51,16 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	);
 	const previousProvider = companion.avatarProvider;
 
-	await getStorage().put({
-		key,
-		body: processed,
-		contentType: 'image/jpeg'
-	});
+	try {
+		await getStorage().put({
+			key,
+			body: processed,
+			contentType: 'image/jpeg'
+		});
+	} catch (err) {
+		console.error('[avatar] storage put failed:', err);
+		error(502, t(locals.locale, 'error.fileNotFound'));
+	}
 
 	await db
 		.update(schema.companions)

--- a/src/routes/api/companions/[companionId]/avatar/+server.ts
+++ b/src/routes/api/companions/[companionId]/avatar/+server.ts
@@ -2,50 +2,22 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
-import { eq, and } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import sharp from 'sharp';
 import { getStorage, STORAGE_BACKEND } from '$lib/server/storage';
-import type { StorageProvider } from '$lib/server/storage';
+import {
+	AVATAR_LEGACY_EXTS,
+	avatarLegacyKey,
+	resolveExistingAvatarKey
+} from '$lib/server/storage/avatarKeys';
+import { isAllowedAvatarMime } from '$lib/server/storage/mime';
+import { assertCanEditCompanion } from '$lib/server/permissions';
 import { UPLOAD_MAX_MB } from '$lib/server/env';
 
 const MAX_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
-const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-const LEGACY_EXTS = ['jpg', 'png', 'webp'];
-
-function avatarKey(companionId: string, ext: string): string {
-	return `avatars/${companionId}.${ext}`;
-}
-
-function resolveExistingKey(
-	companionId: string,
-	provider: StorageProvider,
-	storedKey: string | null,
-	avatarPath: string | null
-): string | null {
-	if (storedKey) return storedKey;
-	// Legacy local row: derive key from avatarPath (filename).
-	if (provider === 'local' && avatarPath) return `avatars/${avatarPath}`;
-	return null;
-}
-
-async function assertCanEditAvatar(
-	locals: import('@sveltejs/kit').RequestEvent['locals'],
-	companionId: string
-): Promise<void> {
-	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
-	if (locals.user.role === 'caretaker') {
-		const assigned = await db.query.companionCaretakers.findFirst({
-			where: and(
-				eq(schema.companionCaretakers.userId, locals.user.id),
-				eq(schema.companionCaretakers.companionId, companionId)
-			)
-		});
-		if (!assigned) error(403, t(locals.locale, 'error.forbidden'));
-	}
-}
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
-	await assertCanEditAvatar(locals, params.companionId);
+	await assertCanEditCompanion(locals, params.companionId);
 
 	const companion = await db.query.companions.findFirst({
 		where: eq(schema.companions.id, params.companionId)
@@ -58,27 +30,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	if (!file || file.size === 0) error(400, t(locals.locale, 'error.noFileProvided'));
 	if (file.size > MAX_SIZE)
 		error(400, t(locals.locale, 'error.fileTooLarge', { max: UPLOAD_MAX_MB }));
-	if (!ALLOWED_TYPES.includes(file.type))
-		error(400, t(locals.locale, 'error.invalidFileTypeAvatar'));
-
-	// Remove previous avatar from wherever it currently lives.
-	const existingKey = resolveExistingKey(
-		params.companionId,
-		companion.avatarProvider,
-		companion.avatarStorageKey,
-		companion.avatarPath
-	);
-	if (existingKey) {
-		await getStorage(companion.avatarProvider).delete(existingKey);
-	}
-	// Local-only legacy cleanup: wipe sibling .png/.webp from disk in case
-	// they survived a prior failed delete.
-	if (companion.avatarProvider === 'local') {
-		const local = getStorage('local');
-		for (const ext of LEGACY_EXTS) {
-			await local.delete(avatarKey(params.companionId, ext));
-		}
-	}
+	if (!isAllowedAvatarMime(file.type)) error(400, t(locals.locale, 'error.invalidFileTypeAvatar'));
 
 	const raw = Buffer.from(await file.arrayBuffer());
 	const processed = await sharp(raw)
@@ -87,7 +39,18 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		.toBuffer();
 
 	const filename = `${params.companionId}.jpg`;
-	const key = avatarKey(params.companionId, 'jpg');
+	const key = avatarLegacyKey(params.companionId, 'jpg');
+
+	// Snapshot the prior avatar before any writes. We write the new blob and
+	// update the DB first; only then do we delete what was there, so a
+	// mid-flight failure leaves the old avatar live instead of broken.
+	const previousKey = resolveExistingAvatarKey(
+		companion.avatarProvider,
+		companion.avatarStorageKey,
+		companion.avatarPath
+	);
+	const previousProvider = companion.avatarProvider;
+
 	await getStorage().put({
 		key,
 		body: processed,
@@ -103,37 +66,71 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		})
 		.where(eq(schema.companions.id, params.companionId));
 
+	// Best-effort cleanup of the prior avatar. Skip when the previous key is
+	// identical to the new one (same backend writing avatars/{cid}.jpg again —
+	// the put above just overwrote it). Never deletes from Immich.
+	if (previousKey && previousKey !== key && previousProvider !== 'immich') {
+		try {
+			await getStorage(previousProvider).delete(previousKey);
+		} catch (err) {
+			console.warn('[avatar] failed to delete previous avatar:', err);
+		}
+	}
+	if (previousProvider === 'local') {
+		const local = getStorage('local');
+		for (const ext of AVATAR_LEGACY_EXTS) {
+			const legacy = avatarLegacyKey(params.companionId, ext);
+			if (legacy === key) continue;
+			try {
+				await local.delete(legacy);
+			} catch {
+				// ignore — best effort sweep
+			}
+		}
+	}
+
 	return json({ avatarPath: filename, url: `/api/avatars/${params.companionId}` });
 };
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	await assertCanEditAvatar(locals, params.companionId);
+	await assertCanEditCompanion(locals, params.companionId);
 
 	const companion = await db.query.companions.findFirst({
 		where: eq(schema.companions.id, params.companionId)
 	});
 	if (!companion) error(404, t(locals.locale, 'error.notFound'));
 
-	const existingKey = resolveExistingKey(
-		params.companionId,
+	const previousKey = resolveExistingAvatarKey(
 		companion.avatarProvider,
 		companion.avatarStorageKey,
 		companion.avatarPath
 	);
-	if (existingKey) {
-		await getStorage(companion.avatarProvider).delete(existingKey);
-	}
-	if (companion.avatarProvider === 'local') {
-		const local = getStorage('local');
-		for (const ext of LEGACY_EXTS) {
-			await local.delete(avatarKey(params.companionId, ext));
-		}
-	}
+	const previousProvider = companion.avatarProvider;
 
+	// DB first so a delete failure leaves the user with the old avatar still
+	// referenced (which they can re-delete) rather than orphaned bytes.
 	await db
 		.update(schema.companions)
 		.set({ avatarPath: null, avatarStorageKey: null, avatarProvider: 'local' })
 		.where(eq(schema.companions.id, params.companionId));
+
+	if (previousKey && previousProvider !== 'immich') {
+		try {
+			await getStorage(previousProvider).delete(previousKey);
+		} catch (err) {
+			console.warn('[avatar] failed to delete avatar bytes:', err);
+		}
+	}
+	if (previousProvider === 'local') {
+		const local = getStorage('local');
+		for (const ext of AVATAR_LEGACY_EXTS) {
+			try {
+				await local.delete(avatarLegacyKey(params.companionId, ext));
+			} catch {
+				// ignore
+			}
+		}
+	}
 
 	return json({ success: true });
 };

--- a/src/routes/api/companions/[companionId]/avatar/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/avatar/from-immich/+server.ts
@@ -10,10 +10,11 @@ import {
 	resolveExistingAvatarKey
 } from '$lib/server/storage/avatarKeys';
 import { isAllowedAvatarMime, safeExtFromMime } from '$lib/server/storage/mime';
-import { assertCanEditCompanion } from '$lib/server/permissions';
-
 export const POST: RequestHandler = async ({ request, params, locals }) => {
-	await assertCanEditCompanion(locals, params.companionId);
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	// Caretakers cannot browse Immich; matches photos/from-immich and keeps
+	// the integration scoped to family members/admins only.
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
 
 	const client = getImmichClient();
 	if (!client) error(404, t(locals.locale, 'error.notFound'));

--- a/src/routes/api/companions/[companionId]/avatar/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/avatar/from-immich/+server.ts
@@ -1,0 +1,88 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { db, schema } from '$lib/server/db';
+import { eq, and } from 'drizzle-orm';
+import { getImmichClient, getStorage, immichKey } from '$lib/server/storage';
+import type { StorageProvider } from '$lib/server/storage';
+
+const ALLOWED_MIME_PREFIXES = ['image/'];
+const ASSET_ID_RE = /^[a-zA-Z0-9-]+$/;
+const LEGACY_EXTS = ['jpg', 'png', 'webp'];
+
+function avatarLegacyKey(companionId: string, ext: string): string {
+	return `avatars/${companionId}.${ext}`;
+}
+
+function resolveExistingKey(
+	provider: StorageProvider,
+	storedKey: string | null,
+	avatarPath: string | null
+): string | null {
+	if (storedKey) return storedKey;
+	if (provider === 'local' && avatarPath) return `avatars/${avatarPath}`;
+	return null;
+}
+
+export const POST: RequestHandler = async ({ request, params, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') {
+		const assigned = await db.query.companionCaretakers.findFirst({
+			where: and(
+				eq(schema.companionCaretakers.userId, locals.user.id),
+				eq(schema.companionCaretakers.companionId, params.companionId)
+			)
+		});
+		if (!assigned) error(403, t(locals.locale, 'error.forbidden'));
+	}
+
+	const client = getImmichClient();
+	if (!client) error(404, t(locals.locale, 'error.notFound'));
+
+	const body = (await request.json().catch(() => null)) as { assetId?: string } | null;
+	const assetId = body?.assetId?.trim();
+	if (!assetId || !ASSET_ID_RE.test(assetId)) error(400, 'Invalid asset id');
+
+	const companion = await db.query.companions.findFirst({
+		where: eq(schema.companions.id, params.companionId)
+	});
+	if (!companion) error(404, t(locals.locale, 'error.notFound'));
+
+	const asset = await client.getAsset(assetId);
+	if (!asset) error(404, t(locals.locale, 'error.notFound'));
+	if (!ALLOWED_MIME_PREFIXES.some((p) => asset.originalMimeType.startsWith(p))) {
+		error(400, t(locals.locale, 'error.invalidFileTypeAvatar'));
+	}
+
+	// Remove the previous avatar from wherever it lives. Skip if previous was
+	// also Immich-referenced — we never delete from Immich.
+	const existingKey = resolveExistingKey(
+		companion.avatarProvider,
+		companion.avatarStorageKey,
+		companion.avatarPath
+	);
+	if (existingKey && companion.avatarProvider !== 'immich') {
+		await getStorage(companion.avatarProvider).delete(existingKey);
+	}
+	if (companion.avatarProvider === 'local') {
+		const local = getStorage('local');
+		for (const ext of LEGACY_EXTS) {
+			await local.delete(avatarLegacyKey(params.companionId, ext));
+		}
+	}
+
+	const ext = asset.originalFileName.split('.').pop()?.toLowerCase() || 'jpg';
+	const filename = `${assetId}.${ext}`;
+	const key = immichKey(assetId);
+
+	await db
+		.update(schema.companions)
+		.set({
+			avatarPath: filename,
+			avatarProvider: 'immich',
+			avatarStorageKey: key
+		})
+		.where(eq(schema.companions.id, params.companionId));
+
+	return json({ avatarPath: filename, url: `/api/avatars/${params.companionId}` });
+};

--- a/src/routes/api/companions/[companionId]/avatar/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/avatar/from-immich/+server.ts
@@ -2,46 +2,29 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
-import { eq, and } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { getImmichClient, getStorage, immichKey } from '$lib/server/storage';
-import type { StorageProvider } from '$lib/server/storage';
+import {
+	AVATAR_LEGACY_EXTS,
+	avatarLegacyKey,
+	resolveExistingAvatarKey
+} from '$lib/server/storage/avatarKeys';
+import { isAllowedAvatarMime, safeExtFromMime } from '$lib/server/storage/mime';
+import { assertCanEditCompanion } from '$lib/server/permissions';
 
-const ALLOWED_MIME_PREFIXES = ['image/'];
 const ASSET_ID_RE = /^[a-zA-Z0-9-]+$/;
-const LEGACY_EXTS = ['jpg', 'png', 'webp'];
-
-function avatarLegacyKey(companionId: string, ext: string): string {
-	return `avatars/${companionId}.${ext}`;
-}
-
-function resolveExistingKey(
-	provider: StorageProvider,
-	storedKey: string | null,
-	avatarPath: string | null
-): string | null {
-	if (storedKey) return storedKey;
-	if (provider === 'local' && avatarPath) return `avatars/${avatarPath}`;
-	return null;
-}
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
-	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
-	if (locals.user.role === 'caretaker') {
-		const assigned = await db.query.companionCaretakers.findFirst({
-			where: and(
-				eq(schema.companionCaretakers.userId, locals.user.id),
-				eq(schema.companionCaretakers.companionId, params.companionId)
-			)
-		});
-		if (!assigned) error(403, t(locals.locale, 'error.forbidden'));
-	}
+	await assertCanEditCompanion(locals, params.companionId);
 
 	const client = getImmichClient();
 	if (!client) error(404, t(locals.locale, 'error.notFound'));
 
 	const body = (await request.json().catch(() => null)) as { assetId?: string } | null;
 	const assetId = body?.assetId?.trim();
-	if (!assetId || !ASSET_ID_RE.test(assetId)) error(400, 'Invalid asset id');
+	if (!assetId || !ASSET_ID_RE.test(assetId)) {
+		error(400, t(locals.locale, 'error.invalidFileTypeAvatar'));
+	}
 
 	const companion = await db.query.companions.findFirst({
 		where: eq(schema.companions.id, params.companionId)
@@ -50,30 +33,23 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	const asset = await client.getAsset(assetId);
 	if (!asset) error(404, t(locals.locale, 'error.notFound'));
-	if (!ALLOWED_MIME_PREFIXES.some((p) => asset.originalMimeType.startsWith(p))) {
+	if (!isAllowedAvatarMime(asset.originalMimeType)) {
 		error(400, t(locals.locale, 'error.invalidFileTypeAvatar'));
 	}
 
-	// Remove the previous avatar from wherever it lives. Skip if previous was
-	// also Immich-referenced — we never delete from Immich.
-	const existingKey = resolveExistingKey(
+	const ext = safeExtFromMime(asset.originalMimeType, asset.originalFileName);
+	const filename = `${assetId}.${ext}`;
+	const key = immichKey(assetId);
+
+	// Snapshot the previous avatar BEFORE updating the DB so that on success we
+	// can clean it up. If we deleted first and the DB update failed, the user
+	// would be left with no avatar but a dangling row.
+	const previousKey = resolveExistingAvatarKey(
 		companion.avatarProvider,
 		companion.avatarStorageKey,
 		companion.avatarPath
 	);
-	if (existingKey && companion.avatarProvider !== 'immich') {
-		await getStorage(companion.avatarProvider).delete(existingKey);
-	}
-	if (companion.avatarProvider === 'local') {
-		const local = getStorage('local');
-		for (const ext of LEGACY_EXTS) {
-			await local.delete(avatarLegacyKey(params.companionId, ext));
-		}
-	}
-
-	const ext = asset.originalFileName.split('.').pop()?.toLowerCase() || 'jpg';
-	const filename = `${assetId}.${ext}`;
-	const key = immichKey(assetId);
+	const previousProvider = companion.avatarProvider;
 
 	await db
 		.update(schema.companions)
@@ -83,6 +59,26 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 			avatarStorageKey: key
 		})
 		.where(eq(schema.companions.id, params.companionId));
+
+	// Clean up the prior avatar after the DB now points at the new one. Best
+	// effort: never throw if cleanup fails — the new avatar is already live.
+	if (previousKey && previousProvider !== 'immich') {
+		try {
+			await getStorage(previousProvider).delete(previousKey);
+		} catch (err) {
+			console.warn('[avatar/from-immich] failed to delete previous avatar:', err);
+		}
+	}
+	if (previousProvider === 'local') {
+		const local = getStorage('local');
+		for (const legacyExt of AVATAR_LEGACY_EXTS) {
+			try {
+				await local.delete(avatarLegacyKey(params.companionId, legacyExt));
+			} catch {
+				// ignore — best effort sweep
+			}
+		}
+	}
 
 	return json({ avatarPath: filename, url: `/api/avatars/${params.companionId}` });
 };

--- a/src/routes/api/companions/[companionId]/avatar/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/avatar/from-immich/+server.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
-import { getImmichClient, getStorage, immichKey } from '$lib/server/storage';
+import { getImmichClient, getStorage, immichKey, IMMICH_ASSET_ID_RE } from '$lib/server/storage';
 import {
 	AVATAR_LEGACY_EXTS,
 	avatarLegacyKey,
@@ -11,8 +11,6 @@ import {
 } from '$lib/server/storage/avatarKeys';
 import { isAllowedAvatarMime, safeExtFromMime } from '$lib/server/storage/mime';
 import { assertCanEditCompanion } from '$lib/server/permissions';
-
-const ASSET_ID_RE = /^[a-zA-Z0-9-]+$/;
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
 	await assertCanEditCompanion(locals, params.companionId);
@@ -22,7 +20,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	const body = (await request.json().catch(() => null)) as { assetId?: string } | null;
 	const assetId = body?.assetId?.trim();
-	if (!assetId || !ASSET_ID_RE.test(assetId)) {
+	if (!assetId || !IMMICH_ASSET_ID_RE.test(assetId)) {
 		error(400, t(locals.locale, 'error.invalidFileTypeAvatar'));
 	}
 

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -4,16 +4,18 @@ import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq, and, count } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
-import { writeFile, mkdir } from 'fs/promises';
-import { join } from 'path';
 import sharp from 'sharp';
-import { DATA_DIR } from '$lib/server/paths';
+import { getStorage } from '$lib/server/storage';
 import { MAX_DAILY_PHOTOS, UPLOAD_MAX_MB } from '$lib/server/env';
 import { canModifyPhoto } from '$lib/permissions';
 import { isValidDate } from '$lib/server/validation';
 
 const MAX_FILE_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+
+function journalKey(companionId: string, date: string, filename: string): string {
+	return `journal/${companionId}/${date}/${filename}`;
+}
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
@@ -93,9 +95,11 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	}
 
 	const filename = `${photoId}.${ext}`;
-	const uploadDir = join(DATA_DIR, 'uploads', 'journal', companionId, date);
-	await mkdir(uploadDir, { recursive: true });
-	await writeFile(join(uploadDir, filename), processed);
+	await getStorage().put({
+		key: journalKey(companionId, date, filename),
+		body: processed,
+		contentType: mimeType
+	});
 
 	await db.insert(schema.journalPhotos).values({
 		id: photoId,
@@ -170,20 +174,7 @@ export const DELETE: RequestHandler = async ({ url, params, locals }) => {
 
 	if (!canModifyPhoto(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
 
-	const { unlink } = await import('fs/promises');
-	const filePath = join(
-		DATA_DIR,
-		'uploads',
-		'journal',
-		params.companionId,
-		params.date,
-		photo.filename
-	);
-	try {
-		await unlink(filePath);
-	} catch {
-		// File already gone; still delete the DB record
-	}
+	await getStorage().delete(journalKey(params.companionId, params.date, photo.filename));
 
 	await db.delete(schema.journalPhotos).where(eq(schema.journalPhotos.id, photoId));
 

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -5,7 +5,7 @@ import { db, schema } from '$lib/server/db';
 import { eq, and, count } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 import sharp from 'sharp';
-import { getStorage } from '$lib/server/storage';
+import { getStorage, STORAGE_BACKEND } from '$lib/server/storage';
 import { MAX_DAILY_PHOTOS, UPLOAD_MAX_MB } from '$lib/server/env';
 import { canModifyPhoto } from '$lib/permissions';
 import { isValidDate } from '$lib/server/validation';
@@ -95,8 +95,9 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	}
 
 	const filename = `${photoId}.${ext}`;
+	const key = journalKey(companionId, date, filename);
 	await getStorage().put({
-		key: journalKey(companionId, date, filename),
+		key,
 		body: processed,
 		contentType: mimeType
 	});
@@ -105,6 +106,8 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		id: photoId,
 		entryId: entry.id,
 		filename,
+		provider: STORAGE_BACKEND,
+		storageKey: key,
 		originalName: file.name,
 		mimeType,
 		sizeBytes: processed.length,
@@ -174,7 +177,8 @@ export const DELETE: RequestHandler = async ({ url, params, locals }) => {
 
 	if (!canModifyPhoto(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
 
-	await getStorage().delete(journalKey(params.companionId, params.date, photo.filename));
+	const key = photo.storageKey ?? journalKey(params.companionId, params.date, photo.filename);
+	await getStorage(photo.provider).delete(key);
 
 	await db.delete(schema.journalPhotos).where(eq(schema.journalPhotos.id, photoId));
 

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -96,11 +96,16 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	const filename = `${photoId}.${ext}`;
 	const key = journalKey(companionId, date, filename);
-	await getStorage().put({
-		key,
-		body: processed,
-		contentType: mimeType
-	});
+	try {
+		await getStorage().put({
+			key,
+			body: processed,
+			contentType: mimeType
+		});
+	} catch (err) {
+		console.error('[journal-photo] storage put failed:', err);
+		error(502, t(locals.locale, 'error.fileNotFound'));
+	}
 
 	await db.insert(schema.journalPhotos).values({
 		id: photoId,

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
@@ -1,0 +1,104 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { db, schema } from '$lib/server/db';
+import { eq, and, count } from 'drizzle-orm';
+import { generateId } from '$lib/server/utils';
+import { getImmichClient, immichKey } from '$lib/server/storage';
+import { MAX_DAILY_PHOTOS } from '$lib/server/env';
+import { isValidDate } from '$lib/server/validation';
+
+const ALLOWED_MIME_PREFIXES = ['image/'];
+const ASSET_ID_RE = /^[a-zA-Z0-9-]+$/;
+
+function extFromMime(mime: string, originalFileName: string): string {
+	const fromName = originalFileName.split('.').pop()?.toLowerCase();
+	if (fromName && /^[a-z0-9]{1,5}$/.test(fromName)) return fromName;
+	if (mime === 'image/jpeg') return 'jpg';
+	if (mime === 'image/png') return 'png';
+	if (mime === 'image/webp') return 'webp';
+	if (mime === 'image/gif') return 'gif';
+	if (mime === 'image/heic') return 'heic';
+	return 'bin';
+}
+
+export const POST: RequestHandler = async ({ request, params, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const client = getImmichClient();
+	if (!client) error(404, t(locals.locale, 'error.notFound'));
+
+	const { companionId, date } = params;
+	if (!isValidDate(date)) error(400, t(locals.locale, 'error.invalidDate'));
+
+	const body = (await request.json().catch(() => null)) as { assetId?: string } | null;
+	const assetId = body?.assetId?.trim();
+	if (!assetId || !ASSET_ID_RE.test(assetId)) error(400, 'Invalid asset id');
+
+	const companion = await db.query.companions.findFirst({
+		where: eq(schema.companions.id, companionId)
+	});
+	if (!companion) error(404, t(locals.locale, 'error.companionNotFound'));
+
+	const asset = await client.getAsset(assetId);
+	if (!asset) error(404, t(locals.locale, 'error.notFound'));
+	if (!ALLOWED_MIME_PREFIXES.some((p) => asset.originalMimeType.startsWith(p))) {
+		error(400, t(locals.locale, 'error.invalidFileType'));
+	}
+
+	let entry = await db.query.journalEntries.findFirst({
+		where: and(
+			eq(schema.journalEntries.companionId, companionId),
+			eq(schema.journalEntries.date, date)
+		)
+	});
+
+	if (!entry) {
+		const [created] = await db
+			.insert(schema.journalEntries)
+			.values({
+				id: generateId(15),
+				companionId,
+				date,
+				body: '',
+				loggedBy: locals.user?.id ?? null
+			})
+			.returning();
+		entry = created;
+	}
+
+	const [{ value: photoCount }] = await db
+		.select({ value: count() })
+		.from(schema.journalPhotos)
+		.where(eq(schema.journalPhotos.entryId, entry.id));
+	if (photoCount >= MAX_DAILY_PHOTOS) {
+		error(400, t(locals.locale, 'error.maxPhotosExceeded', { max: MAX_DAILY_PHOTOS }));
+	}
+
+	const photoId = generateId(15);
+	const ext = extFromMime(asset.originalMimeType, asset.originalFileName);
+	const filename = `${photoId}.${ext}`;
+
+	await db.insert(schema.journalPhotos).values({
+		id: photoId,
+		entryId: entry.id,
+		filename,
+		provider: 'immich',
+		storageKey: immichKey(assetId),
+		originalName: asset.originalFileName || null,
+		mimeType: asset.originalMimeType,
+		sizeBytes: asset.fileSizeInByte ?? 0,
+		loggedBy: locals.user.id
+	});
+
+	const created = await db.query.journalPhotos.findFirst({
+		where: eq(schema.journalPhotos.id, photoId),
+		with: { logger: { columns: { displayName: true } } }
+	});
+
+	return json({
+		...created,
+		url: `/api/photos/journal/${companionId}/${date}/${filename}`
+	});
+};

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
@@ -4,12 +4,10 @@ import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq, and, count } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
-import { getImmichClient, immichKey } from '$lib/server/storage';
+import { getImmichClient, immichKey, IMMICH_ASSET_ID_RE } from '$lib/server/storage';
 import { isAllowedPhotoMime, safeExtFromMime } from '$lib/server/storage/mime';
 import { MAX_DAILY_PHOTOS } from '$lib/server/env';
 import { isValidDate } from '$lib/server/validation';
-
-const ASSET_ID_RE = /^[a-zA-Z0-9-]+$/;
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
@@ -23,7 +21,9 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	const body = (await request.json().catch(() => null)) as { assetId?: string } | null;
 	const assetId = body?.assetId?.trim();
-	if (!assetId || !ASSET_ID_RE.test(assetId)) error(400, t(locals.locale, 'error.invalidFileType'));
+	if (!assetId || !IMMICH_ASSET_ID_RE.test(assetId)) {
+		error(400, t(locals.locale, 'error.invalidFileType'));
+	}
 
 	const companion = await db.query.companions.findFirst({
 		where: eq(schema.companions.id, companionId)

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
@@ -64,33 +64,39 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	const loggedBy = locals.user.id;
 
 	// Wrap count + insert in a transaction so two concurrent picks cannot
-	// both observe a count under the cap and then both insert. The local
-	// upload path has the same TOCTOU pre-existing; not addressed here.
-	const result = db.transaction((tx) => {
-		const rows = tx
-			.select({ value: count() })
-			.from(schema.journalPhotos)
-			.where(eq(schema.journalPhotos.entryId, entryId))
-			.all();
-		const photoCount = rows[0]?.value ?? 0;
-		if (photoCount >= MAX_DAILY_PHOTOS) {
-			return { ok: false as const };
-		}
-		tx.insert(schema.journalPhotos)
-			.values({
-				id: photoId,
-				entryId,
-				filename,
-				provider: 'immich',
-				storageKey: immichKey(assetId),
-				originalName: asset.originalFileName || null,
-				mimeType: asset.originalMimeType,
-				sizeBytes: asset.fileSizeInByte ?? 0,
-				loggedBy
-			})
-			.run();
-		return { ok: true as const };
-	});
+	// both observe a count under the cap and then both insert. `immediate`
+	// takes the write lock at BEGIN so concurrent transactions serialize
+	// cleanly under WAL instead of one hitting SQLITE_BUSY_SNAPSHOT and
+	// surfacing as a 500. The local upload path has the same TOCTOU
+	// pre-existing; not addressed here.
+	const result = db.transaction(
+		(tx) => {
+			const rows = tx
+				.select({ value: count() })
+				.from(schema.journalPhotos)
+				.where(eq(schema.journalPhotos.entryId, entryId))
+				.all();
+			const photoCount = rows[0]?.value ?? 0;
+			if (photoCount >= MAX_DAILY_PHOTOS) {
+				return { ok: false as const };
+			}
+			tx.insert(schema.journalPhotos)
+				.values({
+					id: photoId,
+					entryId,
+					filename,
+					provider: 'immich',
+					storageKey: immichKey(assetId),
+					originalName: asset.originalFileName || null,
+					mimeType: asset.originalMimeType,
+					sizeBytes: asset.fileSizeInByte ?? 0,
+					loggedBy
+				})
+				.run();
+			return { ok: true as const };
+		},
+		{ behavior: 'immediate' }
+	);
 
 	if (!result.ok) {
 		error(400, t(locals.locale, 'error.maxPhotosExceeded', { max: MAX_DAILY_PHOTOS }));

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
@@ -5,22 +5,11 @@ import { db, schema } from '$lib/server/db';
 import { eq, and, count } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 import { getImmichClient, immichKey } from '$lib/server/storage';
+import { isAllowedPhotoMime, safeExtFromMime } from '$lib/server/storage/mime';
 import { MAX_DAILY_PHOTOS } from '$lib/server/env';
 import { isValidDate } from '$lib/server/validation';
 
-const ALLOWED_MIME_PREFIXES = ['image/'];
 const ASSET_ID_RE = /^[a-zA-Z0-9-]+$/;
-
-function extFromMime(mime: string, originalFileName: string): string {
-	const fromName = originalFileName.split('.').pop()?.toLowerCase();
-	if (fromName && /^[a-z0-9]{1,5}$/.test(fromName)) return fromName;
-	if (mime === 'image/jpeg') return 'jpg';
-	if (mime === 'image/png') return 'png';
-	if (mime === 'image/webp') return 'webp';
-	if (mime === 'image/gif') return 'gif';
-	if (mime === 'image/heic') return 'heic';
-	return 'bin';
-}
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
@@ -34,7 +23,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	const body = (await request.json().catch(() => null)) as { assetId?: string } | null;
 	const assetId = body?.assetId?.trim();
-	if (!assetId || !ASSET_ID_RE.test(assetId)) error(400, 'Invalid asset id');
+	if (!assetId || !ASSET_ID_RE.test(assetId)) error(400, t(locals.locale, 'error.invalidFileType'));
 
 	const companion = await db.query.companions.findFirst({
 		where: eq(schema.companions.id, companionId)
@@ -43,7 +32,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	const asset = await client.getAsset(assetId);
 	if (!asset) error(404, t(locals.locale, 'error.notFound'));
-	if (!ALLOWED_MIME_PREFIXES.some((p) => asset.originalMimeType.startsWith(p))) {
+	if (!isAllowedPhotoMime(asset.originalMimeType)) {
 		error(400, t(locals.locale, 'error.invalidFileType'));
 	}
 
@@ -68,29 +57,44 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		entry = created;
 	}
 
-	const [{ value: photoCount }] = await db
-		.select({ value: count() })
-		.from(schema.journalPhotos)
-		.where(eq(schema.journalPhotos.entryId, entry.id));
-	if (photoCount >= MAX_DAILY_PHOTOS) {
+	const photoId = generateId(15);
+	const ext = safeExtFromMime(asset.originalMimeType, asset.originalFileName);
+	const filename = `${photoId}.${ext}`;
+	const entryId = entry.id;
+	const loggedBy = locals.user.id;
+
+	// Wrap count + insert in a transaction so two concurrent picks cannot
+	// both observe a count under the cap and then both insert. The local
+	// upload path has the same TOCTOU pre-existing; not addressed here.
+	const result = db.transaction((tx) => {
+		const rows = tx
+			.select({ value: count() })
+			.from(schema.journalPhotos)
+			.where(eq(schema.journalPhotos.entryId, entryId))
+			.all();
+		const photoCount = rows[0]?.value ?? 0;
+		if (photoCount >= MAX_DAILY_PHOTOS) {
+			return { ok: false as const };
+		}
+		tx.insert(schema.journalPhotos)
+			.values({
+				id: photoId,
+				entryId,
+				filename,
+				provider: 'immich',
+				storageKey: immichKey(assetId),
+				originalName: asset.originalFileName || null,
+				mimeType: asset.originalMimeType,
+				sizeBytes: asset.fileSizeInByte ?? 0,
+				loggedBy
+			})
+			.run();
+		return { ok: true as const };
+	});
+
+	if (!result.ok) {
 		error(400, t(locals.locale, 'error.maxPhotosExceeded', { max: MAX_DAILY_PHOTOS }));
 	}
-
-	const photoId = generateId(15);
-	const ext = extFromMime(asset.originalMimeType, asset.originalFileName);
-	const filename = `${photoId}.${ext}`;
-
-	await db.insert(schema.journalPhotos).values({
-		id: photoId,
-		entryId: entry.id,
-		filename,
-		provider: 'immich',
-		storageKey: immichKey(assetId),
-		originalName: asset.originalFileName || null,
-		mimeType: asset.originalMimeType,
-		sizeBytes: asset.fileSizeInByte ?? 0,
-		loggedBy: locals.user.id
-	});
 
 	const created = await db.query.journalPhotos.findFirst({
 		where: eq(schema.journalPhotos.id, photoId),

--- a/src/routes/api/immich/assets/+server.ts
+++ b/src/routes/api/immich/assets/+server.ts
@@ -1,0 +1,34 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { IMMICH_CONFIG } from '$lib/server/env';
+import { getImmichClient } from '$lib/server/storage';
+
+const DEFAULT_PAGE_SIZE = 60;
+const MAX_PAGE_SIZE = 200;
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const client = getImmichClient();
+	if (!client || !IMMICH_CONFIG) error(404, t(locals.locale, 'error.notFound'));
+
+	const page = Math.max(1, Number(url.searchParams.get('page')) || 1);
+	const pageSizeRaw = Number(url.searchParams.get('pageSize')) || DEFAULT_PAGE_SIZE;
+	const pageSize = Math.min(MAX_PAGE_SIZE, Math.max(1, pageSizeRaw));
+
+	const result = await client.listAssets({
+		page,
+		pageSize,
+		albumId: IMMICH_CONFIG.albumId
+	});
+
+	return json({
+		items: result.items,
+		hasNextPage: result.hasNextPage,
+		page,
+		pageSize,
+		albumScoped: !!IMMICH_CONFIG.albumId
+	});
+};

--- a/src/routes/api/immich/thumbnail/[assetId]/+server.ts
+++ b/src/routes/api/immich/thumbnail/[assetId]/+server.ts
@@ -1,9 +1,7 @@
 import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
-import { getImmichClient } from '$lib/server/storage';
-
-const ASSET_ID_RE = /^[a-zA-Z0-9-]+$/;
+import { getImmichClient, IMMICH_ASSET_ID_RE } from '$lib/server/storage';
 
 export const GET: RequestHandler = async ({ params, url, locals }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
@@ -13,7 +11,7 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 	if (!client) error(404, t(locals.locale, 'error.notFound'));
 
 	const assetId = params.assetId;
-	if (!ASSET_ID_RE.test(assetId)) error(400, 'Invalid asset id');
+	if (!IMMICH_ASSET_ID_RE.test(assetId)) error(400, t(locals.locale, 'error.invalidFileType'));
 
 	const sizeParam = url.searchParams.get('size');
 	const size: 'preview' | 'thumbnail' = sizeParam === 'preview' ? 'preview' : 'thumbnail';
@@ -21,11 +19,8 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 	const res = await client.fetchThumbnail(assetId, size);
 	if (res.status === 404) error(404, t(locals.locale, 'error.notFound'));
 	if (!res.ok || !res.body) {
-		const bodyText = await res.text().catch(() => '');
-		console.error(
-			`[immich-thumbnail] upstream ${res.status} for asset ${assetId} size=${size}: ${bodyText.slice(0, 500)}`
-		);
-		error(502, `Immich upstream error (${res.status})`);
+		console.error(`[immich-thumbnail] upstream status=${res.status} asset=${assetId} size=${size}`);
+		error(502, t(locals.locale, 'error.fileNotFound'));
 	}
 
 	const contentType = res.headers.get('content-type') ?? 'image/jpeg';

--- a/src/routes/api/immich/thumbnail/[assetId]/+server.ts
+++ b/src/routes/api/immich/thumbnail/[assetId]/+server.ts
@@ -1,0 +1,42 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { getImmichClient } from '$lib/server/storage';
+
+const ASSET_ID_RE = /^[a-zA-Z0-9-]+$/;
+
+export const GET: RequestHandler = async ({ params, url, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const client = getImmichClient();
+	if (!client) error(404, t(locals.locale, 'error.notFound'));
+
+	const assetId = params.assetId;
+	if (!ASSET_ID_RE.test(assetId)) error(400, 'Invalid asset id');
+
+	const sizeParam = url.searchParams.get('size');
+	const size: 'preview' | 'thumbnail' = sizeParam === 'preview' ? 'preview' : 'thumbnail';
+
+	const res = await client.fetchThumbnail(assetId, size);
+	if (res.status === 404) error(404, t(locals.locale, 'error.notFound'));
+	if (!res.ok || !res.body) {
+		const bodyText = await res.text().catch(() => '');
+		console.error(
+			`[immich-thumbnail] upstream ${res.status} for asset ${assetId} size=${size}: ${bodyText.slice(0, 500)}`
+		);
+		error(502, `Immich upstream error (${res.status})`);
+	}
+
+	const contentType = res.headers.get('content-type') ?? 'image/jpeg';
+	const contentLength = res.headers.get('content-length');
+
+	const headers: Record<string, string> = {
+		'Content-Type': contentType,
+		'Cache-Control': 'private, max-age=300',
+		'X-Content-Type-Options': 'nosniff'
+	};
+	if (contentLength) headers['Content-Length'] = contentLength;
+
+	return new Response(res.body, { headers });
+};

--- a/src/routes/api/photos/[...path]/+server.ts
+++ b/src/routes/api/photos/[...path]/+server.ts
@@ -3,27 +3,15 @@ import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq, and } from 'drizzle-orm';
-import { createReadStream } from 'fs';
-import { Readable } from 'stream';
-import { stat } from 'fs/promises';
-import { join, normalize, resolve } from 'path';
-import { DATA_DIR } from '$lib/server/paths';
-
-const UPLOAD_DIR = join(DATA_DIR, 'uploads');
+import { getStorage } from '$lib/server/storage';
 
 export const GET: RequestHandler = async ({ params, locals, request }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
 
-	// Path traversal guard: resolve and ensure it stays within UPLOAD_DIR
-	const requestedPath = normalize(params.path ?? '');
-	const fullPath = resolve(join(UPLOAD_DIR, requestedPath));
-
-	if (!fullPath.startsWith(resolve(UPLOAD_DIR))) {
-		error(403, t(locals.locale, 'error.forbidden'));
-	}
+	const key = params.path ?? '';
 
 	// Verify the photo record exists in DB (don't serve arbitrary files)
-	const filename = requestedPath.split('/').pop() ?? '';
+	const filename = key.split('/').pop() ?? '';
 	const photo = await db.query.journalPhotos.findFirst({
 		where: eq(schema.journalPhotos.filename, filename)
 	});
@@ -45,25 +33,34 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 		if (!assignment) error(403, t(locals.locale, 'error.forbidden'));
 	}
 
-	let fileStat: Awaited<ReturnType<typeof stat>>;
+	const storage = getStorage();
+
+	let stat: Awaited<ReturnType<typeof storage.stat>>;
 	try {
-		fileStat = await stat(fullPath);
+		stat = await storage.stat(key);
 	} catch {
-		error(404, t(locals.locale, 'error.fileNotFound'));
+		error(403, t(locals.locale, 'error.forbidden'));
 	}
+	if (!stat) error(404, t(locals.locale, 'error.fileNotFound'));
 
-	const etag = `"${fileStat.mtimeMs.toString(36)}-${fileStat.size.toString(36)}"`;
-
-	if (request.headers.get('if-none-match') === etag) {
+	if (request.headers.get('if-none-match') === stat.etag) {
 		return new Response(null, { status: 304 });
 	}
 
-	return new Response(Readable.toWeb(createReadStream(fullPath)) as ReadableStream, {
+	let result: Awaited<ReturnType<typeof storage.get>>;
+	try {
+		result = await storage.get(key);
+	} catch {
+		error(403, t(locals.locale, 'error.forbidden'));
+	}
+	if (!result) error(404, t(locals.locale, 'error.fileNotFound'));
+
+	return new Response(result.stream, {
 		headers: {
 			'Content-Type': photo.mimeType,
-			'Content-Length': String(fileStat.size),
+			'Content-Length': String(result.stat.size),
 			'Cache-Control': 'private, max-age=31536000, immutable',
-			ETag: etag,
+			ETag: result.stat.etag,
 			'X-Content-Type-Options': 'nosniff'
 		}
 	});

--- a/src/routes/api/photos/[...path]/+server.ts
+++ b/src/routes/api/photos/[...path]/+server.ts
@@ -8,10 +8,10 @@ import { getStorage } from '$lib/server/storage';
 export const GET: RequestHandler = async ({ params, locals, request }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
 
-	const key = params.path ?? '';
+	const requestedPath = params.path ?? '';
 
 	// Verify the photo record exists in DB (don't serve arbitrary files)
-	const filename = key.split('/').pop() ?? '';
+	const filename = requestedPath.split('/').pop() ?? '';
 	const photo = await db.query.journalPhotos.findFirst({
 		where: eq(schema.journalPhotos.filename, filename)
 	});
@@ -33,34 +33,40 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 		if (!assignment) error(403, t(locals.locale, 'error.forbidden'));
 	}
 
-	const storage = getStorage();
+	// For local rows the URL path IS the storage key. For S3 rows we ignore
+	// the URL prefix and use the row's storage_key column instead.
+	const key = photo.storageKey ?? requestedPath;
+	const ifNoneMatch = request.headers.get('if-none-match');
 
-	let stat: Awaited<ReturnType<typeof storage.stat>>;
+	let res: Awaited<ReturnType<ReturnType<typeof getStorage>['get']>>;
 	try {
-		stat = await storage.stat(key);
+		res = await getStorage(photo.provider).get(key, { ifNoneMatch });
 	} catch {
 		error(403, t(locals.locale, 'error.forbidden'));
 	}
-	if (!stat) error(404, t(locals.locale, 'error.fileNotFound'));
+	if (!res) error(404, t(locals.locale, 'error.fileNotFound'));
 
-	if (request.headers.get('if-none-match') === stat.etag) {
-		return new Response(null, { status: 304 });
+	if (res.kind === 'notModified') {
+		return new Response(null, { status: 304, headers: { ETag: res.etag } });
 	}
 
-	let result: Awaited<ReturnType<typeof storage.get>>;
-	try {
-		result = await storage.get(key);
-	} catch {
-		error(403, t(locals.locale, 'error.forbidden'));
+	if (res.kind === 'redirect') {
+		return new Response(null, {
+			status: 302,
+			headers: {
+				Location: res.url,
+				'Cache-Control': `private, max-age=${res.cacheSeconds}`,
+				'Referrer-Policy': 'no-referrer'
+			}
+		});
 	}
-	if (!result) error(404, t(locals.locale, 'error.fileNotFound'));
 
-	return new Response(result.stream, {
+	return new Response(res.stream, {
 		headers: {
 			'Content-Type': photo.mimeType,
-			'Content-Length': String(result.stat.size),
+			'Content-Length': String(res.stat.size),
 			'Cache-Control': 'private, max-age=31536000, immutable',
-			ETag: result.stat.etag,
+			ETag: res.stat.etag,
 			'X-Content-Type-Options': 'nosniff'
 		}
 	});

--- a/src/routes/api/photos/[...path]/+server.ts
+++ b/src/routes/api/photos/[...path]/+server.ts
@@ -3,46 +3,59 @@ import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq, and } from 'drizzle-orm';
-import { getStorage } from '$lib/server/storage';
+import { getStorage, type GetResult } from '$lib/server/storage';
+
+// URL shape: /api/photos/journal/{companionId}/{date}/{filename}
+const JOURNAL_PREFIX = 'journal';
 
 export const GET: RequestHandler = async ({ params, locals, request }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
 
 	const requestedPath = params.path ?? '';
+	const segments = requestedPath.split('/');
+	if (segments.length !== 4 || segments[0] !== JOURNAL_PREFIX) {
+		error(404, t(locals.locale, 'error.notFound'));
+	}
+	const [, urlCompanionId, urlDate, filename] = segments;
 
-	// Verify the photo record exists in DB (don't serve arbitrary files)
-	const filename = requestedPath.split('/').pop() ?? '';
+	// Look up by filename, then verify the row belongs to the companion + date
+	// asserted in the URL. Without this scoping, two rows sharing a filename
+	// (unlikely for local/S3, possible across providers) could let one URL
+	// surface another row's content.
 	const photo = await db.query.journalPhotos.findFirst({
-		where: eq(schema.journalPhotos.filename, filename)
+		where: eq(schema.journalPhotos.filename, filename),
+		with: { entry: { columns: { companionId: true, date: true } } }
 	});
-	if (!photo) error(404, t(locals.locale, 'error.notFound'));
+	if (!photo || !photo.entry) error(404, t(locals.locale, 'error.notFound'));
+	if (photo.entry.companionId !== urlCompanionId || photo.entry.date !== urlDate) {
+		error(404, t(locals.locale, 'error.notFound'));
+	}
 
 	// For caretakers, verify they are assigned to the companion that owns this photo
 	if (locals.user.role === 'caretaker') {
-		const entry = await db.query.journalEntries.findFirst({
-			where: eq(schema.journalEntries.id, photo.entryId),
-			columns: { companionId: true }
-		});
-		if (!entry) error(404, t(locals.locale, 'error.notFound'));
 		const assignment = await db.query.companionCaretakers.findFirst({
 			where: and(
-				eq(schema.companionCaretakers.companionId, entry.companionId),
+				eq(schema.companionCaretakers.companionId, photo.entry.companionId),
 				eq(schema.companionCaretakers.userId, locals.user.id)
 			)
 		});
 		if (!assignment) error(403, t(locals.locale, 'error.forbidden'));
 	}
 
-	// For local rows the URL path IS the storage key. For S3 rows we ignore
-	// the URL prefix and use the row's storage_key column instead.
+	// For local rows the URL path IS the storage key. For S3 / Immich rows we
+	// use the row's storage_key column instead.
 	const key = photo.storageKey ?? requestedPath;
 	const ifNoneMatch = request.headers.get('if-none-match');
 
-	let res: Awaited<ReturnType<ReturnType<typeof getStorage>['get']>>;
+	let res: GetResult | null;
 	try {
 		res = await getStorage(photo.provider).get(key, { ifNoneMatch });
-	} catch {
-		error(403, t(locals.locale, 'error.forbidden'));
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('escapes upload root')) {
+			error(403, t(locals.locale, 'error.forbidden'));
+		}
+		console.error(`[photos] storage error provider=${photo.provider} key=${key}:`, err);
+		error(502, t(locals.locale, 'error.fileNotFound'));
 	}
 	if (!res) error(404, t(locals.locale, 'error.fileNotFound'));
 
@@ -61,11 +74,17 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 		});
 	}
 
+	// Local + S3 (when streamed) produce stable bytes per key; Immich serves a
+	// derivative that the server can regenerate, so its content is not safe to
+	// mark immutable.
+	const cacheControl =
+		photo.provider === 'immich' ? 'private, max-age=300' : 'private, max-age=31536000, immutable';
+
 	return new Response(res.stream, {
 		headers: {
 			'Content-Type': photo.mimeType,
 			'Content-Length': String(res.stat.size),
-			'Cache-Control': 'private, max-age=31536000, immutable',
+			'Cache-Control': cacheControl,
 			ETag: res.stat.etag,
 			'X-Content-Type-Options': 'nosniff'
 		}


### PR DESCRIPTION
Closes #13.

Adds two opt-in external image storage paths alongside the existing local-disk default. Both gated on env vars; existing installs unaffected. Reads dispatch on a per-row `provider` column so switching backends does not break previously-uploaded photos.

## S3-compatible storage (`STORAGE_BACKEND=s3`)

Works with AWS, Garage, MinIO, Backblaze B2, Cloudflare R2. Client is `aws4fetch` (~6KB, native fetch + SubtleCrypto). I realize this package has not been updated in some time, but the use-case for s3 features is pretty small at the moment. Will re-explore in the future.

- Server still receives uploads (sharp resize, GIF validation, `UPLOAD_MAX_MB` still apply), then PUTs to the bucket.
- Downloads issue short-lived presigned GETs; `/api/photos` and `/api/avatars` 302 to them after the access check. The presigned URL remains valid for its full TTL; documented tradeoff.
- CSP `img-src` is patched at runtime with the configured S3 origin so the redirect target isn't blocked. Driven by env so swapping `S3_ENDPOINT` doesn't require a rebuild.

Config: `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` (required together), `S3_REGION` (default `auto`), `S3_FORCE_PATH_STYLE` (true for Garage/MinIO), `S3_PRESIGN_TTL_SECONDS` (default 300).

## Immich integration (reference mode)

When `IMMICH_URL` + `IMMICH_API_KEY` are set, members and admins can attach existing Immich assets to journal entries and companion avatars. EinVault stores a reference and proxies reads server-side using the API key — it never uploads to Immich and never deletes Immich assets. Caretakers are blocked from both picker endpoints. Optional `IMMICH_ALBUM_ID` scopes the picker to a single album.

API key needs `asset.read`, `asset.view`, and `album.read` (when album-scoped). Partial config logs a warning at boot and disables the integration.

## Schema

`drizzle/0012` adds `provider` + `storage_key` to `journal_photos` and `avatar_provider` + `avatar_storage_key` to `companions`. All nullable with `'local'` defaults so existing rows keep streaming from disk. Auto-applied at boot.

## Docs

`.env.example`, `README.md`, and both compose files updated. i18n keys added across all six locales.

## Testing results
- Tested against my own Garage instance, works as-intended
    - Mixed-mode (locally- and s3-stored media works)
- Tested against my own Immich instance, works as-intended
    - Picking via most recent and setting `IMMICH_ALBUM_ID`