### PR TITLE
Improve Overview page UX consistency

### DIFF
--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -389,6 +389,8 @@ const messages: Record<keyof Messages, string> = {
 	'overview.empty.recent': 'In den letzten 7 Tagen keine Aktivität erfasst.',
 	'overview.empty.journal': 'Noch kein Eintrag für heute.',
 	'overview.journal.addToday': 'Heutigen Eintrag hinzufügen',
+	'overview.journal.openFor': '{name}s Tagebuch öffnen',
+	'overview.reminders.openFor': '{name}s Erinnerungen öffnen',
 	'overview.journal.editToday': 'Eintrag bearbeiten',
 	'overview.markDone': 'Als erledigt markieren',
 	'overview.day.today': 'Heute',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -384,6 +384,8 @@ const messages = {
 	'overview.empty.journal': 'No entry yet today.',
 	'overview.journal.addToday': "Add today's entry",
 	'overview.journal.editToday': 'Edit entry',
+	'overview.journal.openFor': "Open {name}'s journal",
+	'overview.reminders.openFor': "Open {name}'s reminders",
 	'overview.markDone': 'Mark as done',
 	'overview.day.today': 'Today',
 	'overview.day.tomorrow': 'Tomorrow',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -389,6 +389,8 @@ const messages: Record<keyof Messages, string> = {
 	'overview.empty.recent': 'Sin actividad registrada en los últimos 7 días.',
 	'overview.empty.journal': 'Aún no hay entrada hoy.',
 	'overview.journal.addToday': 'Añadir entrada de hoy',
+	'overview.journal.openFor': 'Abrir el diario de {name}',
+	'overview.reminders.openFor': 'Abrir los recordatorios de {name}',
 	'overview.journal.editToday': 'Editar entrada',
 	'overview.markDone': 'Marcar como hecho',
 	'overview.day.today': 'Hoy',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -388,6 +388,8 @@ const messages: Record<keyof Messages, string> = {
 	'overview.empty.recent': 'Aucune activité enregistrée ces 7 derniers jours.',
 	'overview.empty.journal': "Aucune entrée pour aujourd'hui.",
 	'overview.journal.addToday': "Ajouter l'entrée du jour",
+	'overview.journal.openFor': 'Ouvrir le journal de {name}',
+	'overview.reminders.openFor': 'Ouvrir les rappels de {name}',
 	'overview.journal.editToday': "Modifier l'entrée",
 	'overview.markDone': 'Marquer comme fait',
 	'overview.day.today': "Aujourd'hui",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -385,6 +385,8 @@ const messages: Record<keyof Messages, string> = {
 	'overview.empty.recent': 'Nessuna attività registrata negli ultimi 7 giorni.',
 	'overview.empty.journal': 'Ancora nessun appunto per oggi.',
 	'overview.journal.addToday': 'Aggiungi appunto di oggi',
+	'overview.journal.openFor': 'Apri il diario di {name}',
+	'overview.reminders.openFor': 'Apri i promemoria di {name}',
 	'overview.journal.editToday': 'Modifica appunto',
 	'overview.markDone': 'Segna come fatto',
 	'overview.day.today': 'Oggi',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -386,6 +386,8 @@ const messages: Record<keyof Messages, string> = {
 	'overview.empty.recent': 'Sem atividade registada nos últimos 7 dias.',
 	'overview.empty.journal': 'Ainda sem entrada hoje.',
 	'overview.journal.addToday': 'Adicionar entrada de hoje',
+	'overview.journal.openFor': 'Abrir o diário de {name}',
+	'overview.reminders.openFor': 'Abrir os lembretes de {name}',
 	'overview.journal.editToday': 'Editar entrada',
 	'overview.markDone': 'Marcar como concluído',
 	'overview.day.today': 'Hoje',

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -33,6 +33,11 @@ const ALLOWED_TAGS = [
 	'a'
 ];
 
+// Strip markdown syntax characters for compact, single-line previews.
+export function stripMarkdown(text: string): string {
+	return text.replace(/[#*_`~>[\]]/g, '').trim();
+}
+
 export function renderMarkdown(text: string): string {
 	const raw = marked.parse(text, { async: false }) as string;
 	return DOMPurify.sanitize(raw, {

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -24,7 +24,7 @@
 	} from '@lucide/svelte';
 	import { enhance } from '$app/forms';
 	import { tick } from 'svelte';
-	import { renderMarkdown } from '$lib/markdown';
+	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { t, getLocale } from '$lib/i18n';
 	import { createPendingDismissals } from '$lib/pendingDismiss.svelte';
@@ -607,7 +607,7 @@
 			<CardContent class="pt-0">
 				{#if todayJournal?.body}
 					<p class="text-sm line-clamp-3 text-muted-foreground">
-						{todayJournal.body.replace(/[#*_`~>[\]]/g, '').trim()}
+						{stripMarkdown(todayJournal.body)}
 					</p>
 					{#if todayJournal.mood}
 						<p class="mt-2 text-lg">{MOOD_LABEL[todayJournal.mood] ?? ''}</p>
@@ -793,7 +793,7 @@
 								<Badge variant="secondary" class="capitalize">{event.type}</Badge>
 								{#if event.notes}
 									<span class="truncate text-muted-foreground">
-										{event.notes.replace(/[#*_`~>[\]]/g, '').trim()}
+										{stripMarkdown(event.notes)}
 									</span>
 								{/if}
 							</div>

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -14,7 +14,7 @@
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { Scale, Plus, Pencil, Trash2, X } from '@lucide/svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
-	import { renderMarkdown } from '$lib/markdown';
+	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { tick } from 'svelte';
 	import { page } from '$app/state';
 	import { localDatetimes } from '$lib/actions/localDatetimes';
@@ -688,8 +688,7 @@
 									>{entry.weight} {entry.unit}</span
 								>
 								<div class="flex-1 min-w-0 text-xs text-muted-foreground">
-									<span class="truncate block"
-										>{entry.notes ? entry.notes.replace(/[#*_`~>[\]]/g, '').trim() : ''}</span
+									<span class="truncate block">{entry.notes ? stripMarkdown(entry.notes) : ''}</span
 									>
 									<ByLine user={entry.logger} />
 								</div>
@@ -866,7 +865,7 @@
 										{/if}
 										{#if event.notes}
 											<p class="text-sm mt-1 text-muted-foreground">
-												{event.notes.replace(/[#*_`~>[\]]/g, '').trim()}
+												{stripMarkdown(event.notes)}
 											</p>
 										{/if}
 										<ByLine user={event.logger} class="mt-0.5" />

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { renderMarkdown } from '$lib/markdown';
+	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { tick } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { enhance } from '$app/forms';
@@ -763,7 +763,7 @@
 								{:else}
 									{#if photo.notes}
 										<p class="text-sm text-muted-foreground">
-											{photo.notes.replace(/[#*_`~>[\]]/g, '').trim()}
+											{stripMarkdown(photo.notes)}
 										</p>
 									{:else}
 										<p class="text-sm italic text-muted-foreground">
@@ -1068,7 +1068,7 @@
 									</div>
 									{#if event.notes}
 										<p class="text-sm mt-0.5 text-muted-foreground">
-											{event.notes.replace(/[#*_`~>[\]]/g, '').trim()}
+											{stripMarkdown(event.notes)}
 										</p>
 									{/if}
 								</div>

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -6,11 +6,11 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Separator } from '$lib/components/ui/separator/index.js';
-	import { CheckCheck, Pencil, Plus, X, HeartPulse } from '@lucide/svelte';
+	import { CheckCheck, Pencil, Plus, X, HeartPulse, NotebookPen } from '@lucide/svelte';
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
-	import { renderMarkdown } from '$lib/markdown';
+	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { tick } from 'svelte';
 	import { formatRecurrence } from '$lib/reminderRecurrence';
 	import {
@@ -75,6 +75,9 @@
 	let selectedReminder = $state<Reminder | null>(null);
 	let reminderDialogEl = $state<HTMLElement | null>(null);
 
+	let selectedEvent = $state<MergedEvent | null>(null);
+	let eventDialogEl = $state<HTMLElement | null>(null);
+
 	async function openReminderDetail(r: Reminder) {
 		selectedReminder = r;
 		await tick();
@@ -85,10 +88,20 @@
 		selectedReminder = null;
 	}
 
-	function trapReminderFocus(e: KeyboardEvent) {
-		if (!reminderDialogEl) return;
+	async function openEventDetail(e: MergedEvent) {
+		selectedEvent = e;
+		await tick();
+		eventDialogEl?.focus();
+	}
+
+	function closeEventDetail() {
+		selectedEvent = null;
+	}
+
+	function trapFocus(e: KeyboardEvent, dialogEl: HTMLElement | null, onClose: () => void) {
+		if (!dialogEl) return;
 		const focusable = Array.from(
-			reminderDialogEl.querySelectorAll<HTMLElement>(
+			dialogEl.querySelectorAll<HTMLElement>(
 				'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
 			)
 		).filter((el) => !el.hasAttribute('disabled'));
@@ -108,7 +121,7 @@
 				}
 			}
 		}
-		if (e.key === 'Escape') closeReminderDetail();
+		if (e.key === 'Escape') onClose();
 	}
 
 	function submitWithAndEvent(reminderId: string) {
@@ -154,7 +167,7 @@
 			role="dialog"
 			aria-modal="true"
 			tabindex="-1"
-			onkeydown={trapReminderFocus}
+			onkeydown={(e) => trapFocus(e, reminderDialogEl, closeReminderDetail)}
 			class="relative z-10 w-full max-w-md rounded-xl border bg-card text-card-foreground shadow-xl focus:outline-none
 				animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-4 sm:slide-in-from-bottom-0 duration-200"
 		>
@@ -250,6 +263,157 @@
 	</div>
 {/if}
 
+<!-- Recent activity detail modal -->
+{#if selectedEvent}
+	{@const ev = selectedEvent}
+	{@const companion = companionsById[ev.row.companionId]}
+	{@const journalDay = localDateISO(ev.at)}
+	<div class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4 sm:p-6">
+		<button
+			tabindex="-1"
+			class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+			aria-label={t(locale, 'aria.closeDialog')}
+			onclick={closeEventDetail}
+		></button>
+		<div
+			bind:this={eventDialogEl}
+			role="dialog"
+			aria-modal="true"
+			tabindex="-1"
+			onkeydown={(e) => trapFocus(e, eventDialogEl, closeEventDetail)}
+			class="relative z-10 w-full max-w-md rounded-xl border bg-card text-card-foreground shadow-xl focus:outline-none
+				animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-4 sm:slide-in-from-bottom-0 duration-200"
+		>
+			<div class="flex items-center justify-between px-5 pt-5 pb-3">
+				<h2 class="font-semibold text-base text-foreground flex items-center gap-2">
+					{#if ev.kind === 'daily'}
+						<span aria-hidden="true">{ACTIVITY_ICONS[ev.row.type] ?? '📝'}</span>
+						{activityLabel(locale, ev.row.type)}
+					{:else}
+						<span aria-hidden="true">🏥</span>
+						{ev.row.title}
+					{/if}
+				</h2>
+				<button
+					onclick={closeEventDetail}
+					aria-label={t(locale, 'aria.close')}
+					class="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+				>
+					<X class="h-4 w-4" />
+				</button>
+			</div>
+
+			<Separator />
+
+			<div class="px-5 py-4 space-y-3 text-sm">
+				{#if ev.kind === 'daily'}
+					{@const e = ev.row}
+					<div class="flex items-center gap-3">
+						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
+							>{t(locale, 'page.dashboard.modalLabelType')}</span
+						>
+						<Badge variant="secondary" class="capitalize">{activityLabel(locale, e.type)}</Badge>
+					</div>
+					<div class="flex items-center gap-3">
+						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
+							>{t(locale, 'page.dashboard.modalLabelLogged')}</span
+						>
+						<span class="text-foreground"
+							><LocalTime date={e.loggedAt} format="datetime" /><ByLine
+								user={e.logger}
+								variant="inline"
+							/></span
+						>
+					</div>
+					{#if e.durationMinutes}
+						<div class="flex items-center gap-3">
+							<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
+								>{t(locale, 'page.dashboard.modalLabelDuration')}</span
+							>
+							<span class="text-foreground">{e.durationMinutes} min</span>
+						</div>
+					{/if}
+					{#if e.notes}
+						<div class="pt-1">
+							<p class="text-xs font-medium text-muted-foreground mb-1">
+								{t(locale, 'page.dashboard.modalLabelNotes')}
+							</p>
+							<div class="prose prose-sm dark:prose-invert max-w-none">
+								{@html renderMarkdown(e.notes)}
+							</div>
+						</div>
+					{/if}
+				{:else}
+					{@const h = ev.row}
+					<div class="flex items-center gap-3">
+						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
+							>{t(locale, 'page.dashboard.modalLabelType')}</span
+						>
+						<Badge variant="bark" class="capitalize">{healthTypeLabel(locale, h.type)}</Badge>
+					</div>
+					<div class="flex items-center gap-3">
+						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
+							>{t(locale, 'page.dashboard.modalLabelDate')}</span
+						>
+						<span class="text-foreground"
+							><LocalTime date={h.occurredAt} format="datetime" /><ByLine
+								user={h.logger}
+								variant="inline"
+							/></span
+						>
+					</div>
+					{#if h.vetName || h.vetClinic}
+						<div class="flex items-center gap-3">
+							<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
+								>{t(locale, 'page.dashboard.modalLabelVet')}</span
+							>
+							<span class="text-foreground"
+								>{[h.vetName, h.vetClinic].filter(Boolean).join(', ')}</span
+							>
+						</div>
+					{/if}
+					{#if h.notes}
+						<div class="pt-1">
+							<p class="text-xs font-medium text-muted-foreground mb-1">
+								{t(locale, 'page.dashboard.modalLabelNotes')}
+							</p>
+							<div class="prose prose-sm dark:prose-invert max-w-none">
+								{@html renderMarkdown(h.notes)}
+							</div>
+						</div>
+					{/if}
+				{/if}
+			</div>
+
+			{#if companion}
+				<Separator />
+				<div class="flex flex-wrap gap-2 px-5 py-4">
+					{#if ev.kind === 'health'}
+						<Button
+							href="/{companion.id}/health?edit={ev.row.id}"
+							variant="outline"
+							size="sm"
+							onclick={closeEventDetail}
+						>
+							<Pencil class="h-3.5 w-3.5 mr-1.5" />
+							{t(locale, 'page.dashboard.modalEditHealth')}
+						</Button>
+					{/if}
+					<Button
+						href="/{companion.id}/journal/{journalDay}"
+						variant="outline"
+						size="sm"
+						onclick={closeEventDetail}
+					>
+						<NotebookPen class="h-3.5 w-3.5 mr-1.5" />
+						{t(locale, 'page.dashboard.modalOpenJournal')}
+					</Button>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}
+
 <div class="space-y-8 pb-20 md:pb-0">
 	<h1 class="sr-only">{t(locale, 'overview.title')}</h1>
 
@@ -281,7 +445,11 @@
 									<CardContent class="py-3">
 										<div class="flex items-start gap-3">
 											{#if companion}
-												<a href="/{companion.id}" aria-label={companion.name} class="shrink-0">
+												<a
+													href="/{companion.id}/reminders"
+													aria-label={companion.name}
+													class="shrink-0"
+												>
 													<CompanionAvatar
 														companionId={companion.id}
 														avatarPath={companion.avatarPath}
@@ -354,24 +522,31 @@
 		<div class="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3">
 			{#each data.companions as companion (companion.id)}
 				{@const entry = data.todayJournalByCompanion[companion.id]}
+				{@const journalHref = `/${companion.id}/journal/${entry?.date ?? localDateISO(new Date())}`}
 				<Card>
 					<CardContent class="py-4">
 						<div class="flex items-center gap-2 mb-2">
-							<CompanionAvatar
-								companionId={companion.id}
-								avatarPath={companion.avatarPath}
-								name={companion.name}
-								size="sm"
-							/>
-							<span class="font-medium text-sm text-foreground truncate">{companion.name}</span>
+							<a
+								href={journalHref}
+								aria-label={companion.name}
+								class="flex min-w-0 items-center gap-2 -mx-2 rounded-md px-2 py-1.5 hover:bg-accent transition-colors"
+							>
+								<CompanionAvatar
+									companionId={companion.id}
+									avatarPath={companion.avatarPath}
+									name={companion.name}
+									size="sm"
+								/>
+								<span class="font-medium text-sm text-foreground truncate">{companion.name}</span>
+							</a>
 							{#if entry?.mood}
 								<span class="text-base ml-auto" aria-hidden="true">{MOOD_ICONS[entry.mood]}</span>
 							{/if}
 						</div>
 						{#if entry}
 							{#if entry.body}
-								<p class="text-sm text-muted-foreground line-clamp-3 mb-2 whitespace-pre-line">
-									{entry.body}
+								<p class="text-sm text-muted-foreground line-clamp-3 mb-2">
+									{stripMarkdown(entry.body)}
 								</p>
 							{:else}
 								<p class="text-xs italic text-muted-foreground mb-2">
@@ -429,7 +604,11 @@
 						<CardContent class="py-3">
 							<div class="flex items-start gap-3">
 								{#if companion}
-									<a href="/{companion.id}" aria-label={companion.name} class="shrink-0">
+									<a
+										href="/{companion.id}/journal/{localDateISO(event.at)}"
+										aria-label={companion.name}
+										class="shrink-0"
+									>
 										<CompanionAvatar
 											companionId={companion.id}
 											avatarPath={companion.avatarPath}
@@ -438,7 +617,11 @@
 										/>
 									</a>
 								{/if}
-								<div class="flex-1 min-w-0">
+								<button
+									type="button"
+									onclick={() => openEventDetail(event)}
+									class="flex-1 min-w-0 text-left rounded-md px-2 py-1 -mx-2 hover:bg-accent transition-colors"
+								>
 									<div class="flex items-center gap-2 flex-wrap">
 										{#if event.kind === 'daily'}
 											<span class="text-base" aria-hidden="true"
@@ -460,7 +643,7 @@
 									</div>
 									{#if event.kind === 'daily' && event.row.notes}
 										<p class="text-xs mt-0.5 text-muted-foreground line-clamp-2">
-											{event.row.notes}
+											{stripMarkdown(event.row.notes)}
 										</p>
 									{/if}
 									<p class="text-xs mt-0.5 text-muted-foreground">
@@ -470,7 +653,7 @@
 											variant="inline"
 										/>
 									</p>
-								</div>
+								</button>
 							</div>
 						</CardContent>
 					</Card>

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -447,8 +447,10 @@
 											{#if companion}
 												<a
 													href="/{companion.id}/reminders"
-													aria-label={companion.name}
-													class="shrink-0"
+													aria-label={t(locale, 'overview.reminders.openFor', {
+														name: companion.name
+													})}
+													class="shrink-0 -m-1 rounded-full p-1 hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 												>
 													<CompanionAvatar
 														companionId={companion.id}
@@ -606,8 +608,8 @@
 								{#if companion}
 									<a
 										href="/{companion.id}/journal/{localDateISO(event.at)}"
-										aria-label={companion.name}
-										class="shrink-0"
+										aria-label={t(locale, 'overview.journal.openFor', { name: companion.name })}
+										class="shrink-0 -m-1 rounded-full p-1 hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 									>
 										<CompanionAvatar
 											companionId={companion.id}
@@ -627,7 +629,7 @@
 											<span class="text-base" aria-hidden="true"
 												>{ACTIVITY_ICONS[event.row.type] ?? '📝'}</span
 											>
-											<span class="font-medium text-sm text-foreground"
+											<span class="font-medium text-sm text-foreground truncate"
 												>{activityLabel(locale, event.row.type)}</span
 											>
 											{#if event.row.durationMinutes}

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -8,7 +8,7 @@
 	import { Phone, Mail, X, Bell, CheckCheck } from '@lucide/svelte';
 	import { enhance } from '$app/forms';
 	import { Separator } from '$lib/components/ui/separator/index.js';
-	import { renderMarkdown } from '$lib/markdown';
+	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { tick } from 'svelte';
 	import { t, getLocale } from '$lib/i18n';
@@ -686,7 +686,7 @@
 									{/if}
 									{#if event.notes}
 										<span class="truncate text-muted-foreground text-xs"
-											>{event.notes.replace(/[#*_`~>[\]]/g, '').trim()}</span
+											>{stripMarkdown(event.notes)}</span
 										>
 									{/if}
 									<span class="ml-auto text-xs shrink-0 text-muted-foreground">

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
+	import { stripMarkdown } from '$lib/markdown';
 	import { canModifyPhoto } from '$lib/permissions';
 	import { Trash2 } from '@lucide/svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
@@ -369,7 +370,7 @@
 									{:else}
 										{#if photo.notes}
 											<p class="text-sm text-muted-foreground">
-												{photo.notes.replace(/[#*_`~>[\]]/g, '').trim()}
+												{stripMarkdown(photo.notes)}
 											</p>
 										{:else}
 											<p class="text-sm italic text-muted-foreground">


### PR DESCRIPTION
Fixes #83.

Makes interactive elements on the Overview page consistent with the companion sections.

## Changes
- Journal card avatar/name links to the companion's journal entry for the day
- Upcoming reminder avatars link to the companion's reminders page
- Recent activity avatars link to the journal entry for that event's day
- Recent activity rows open a detail modal, matching the reminder rows
- Journal preview and recent activity notes strip markdown so syntax characters no longer show raw

## Refactor
Extracted the duplicated markdown-stripping regex into a `stripMarkdown` helper in `$lib/markdown` and applied it across all preview call sites (overview, companion dashboard, journal, health, caretaker pages).

## Verification
`npm run lint` and `npm run check` pass. Verified in the browser.