### PR TITLE
feat: support video uploads in journal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,22 +33,22 @@ ORIGIN=https://einvault.yourdomain.com
 
 # Optional: app
 
-# Maximum file size in MB for avatar and journal photo uploads (default: 10).
-# If you raise this above 50, raise BODY_SIZE_LIMIT to match.
+# Maximum file size in MB for avatar and journal photo (image) uploads (default: 10).
 # UPLOAD_MAX_MB=10
 
-# Maximum number of journal photos per companion per day (default: 5).
-# MAX_DAILY_PHOTOS=5
+# Maximum file size in MB for journal video uploads (default: 100).
+# Videos are stored as-is (no transcoding). BODY_SIZE_LIMIT is derived from the
+# larger of UPLOAD_MAX_MB and VIDEO_MAX_MB at container start.
+# VIDEO_MAX_MB=100
+
+# Maximum number of journal photos and videos (combined) per companion per day (default: 5).
+# (Renamed from MAX_DAILY_PHOTOS, which is still honored but logs a deprecation warning.)
+# MAX_DAILY_MEDIA=5
 
 # Default undo window (in seconds) for dismissing a Reminder (default: 7).
 # Set to 0 to disable the undo window entirely (dismissals commit immediately).
 # Per-user override available in the settings UI.
 # REMINDER_UNDO_SECONDS=7
-
-# SvelteKit's internal request body cap (default: 50M).
-# Must be >= UPLOAD_MAX_MB. SvelteKit enforces this before the upload handler runs,
-# so it needs to be high enough to let requests through. Accepts K, M, G suffixes.
-# BODY_SIZE_LIMIT=50M
 
 # Override the database path inside the container (rarely needed).
 # Defaults to /data/einvault.db, which maps to EINVAULT_DATA on the host.

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,10 +69,12 @@ ENV HOST=0.0.0.0
 ENV PORT=3000
 ENV DATABASE_URL=/data/einvault.db
 ENV UPLOAD_MAX_MB=10
-ENV MAX_DAILY_PHOTOS=5
+ENV VIDEO_MAX_MB=100
+ENV MAX_DAILY_MEDIA=5
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD wget -qO- http://127.0.0.1:3000/api/health || exit 1
 
-# BODY_SIZE_LIMIT is derived from UPLOAD_MAX_MB so users only set one value.
-CMD ["sh", "-c", "BODY_SIZE_LIMIT=${UPLOAD_MAX_MB}M exec node build"]
+# BODY_SIZE_LIMIT is derived from the larger of UPLOAD_MAX_MB and VIDEO_MAX_MB
+# so a single request body can carry either an image or a (larger) video.
+CMD ["sh", "-c", "if [ \"${VIDEO_MAX_MB:-0}\" -gt \"${UPLOAD_MAX_MB:-0}\" ]; then LIMIT=$VIDEO_MAX_MB; else LIMIT=$UPLOAD_MAX_MB; fi; BODY_SIZE_LIMIT=${LIMIT}M exec node build"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ EinVault is a private, self-hosted companion health and care tracker built for h
 ## Features
 
 - **Companion profiles:** breed, bio, vet info, emergency contacts, and avatar photo
-- **Daily journal:** per-companion entries with mood tracking and configurable daily photo limit (default 5)
+- **Daily journal:** per-companion entries with mood tracking, photo and video uploads, and a configurable daily media limit (default 5)
 - **Health tracking:** vet visits, vaccinations, medications, procedures, and weight history
 - **Activity logging:** walks, meals, bathroom trips, treats, play sessions, and grooming
 - **Reminders:** recurring and one-time reminders for medications, vaccinations, grooming, and more
@@ -87,15 +87,16 @@ Open your domain and follow the `/setup` prompt to create your admin account.
 
 Everything else in the compose file can be edited directly:
 
-|                         | Default             | Description                                                                                                                       |
-| ----------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `TZ`                    | `UTC`               | Container timezone. Set to your local timezone (e.g. `America/New_York`, `Europe/London`) so dates and times display correctly.   |
-| `UPLOAD_MAX_MB`         | `10`                | Maximum upload size in MB. SvelteKit's internal `BODY_SIZE_LIMIT` is derived from this automatically at container start.          |
-| `MAX_DAILY_PHOTOS`      | `5`                 | Maximum number of journal photos per companion per day.                                                                           |
-| `REMINDER_UNDO_SECONDS` | `7`                 | Default undo window (seconds) when dismissing a Reminder. `0` disables the undo window. Each user can override in their settings. |
-| `user`                  | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                         |
-| `./data` volume         | `./data`            | Where the database and uploads are stored on the host.                                                                            |
-| `DATABASE_URL`          | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                    |
+|                         | Default             | Description                                                                                                                                                |
+| ----------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TZ`                    | `UTC`               | Container timezone. Set to your local timezone (e.g. `America/New_York`, `Europe/London`) so dates and times display correctly.                            |
+| `UPLOAD_MAX_MB`         | `10`                | Maximum size in MB for image (photo and avatar) uploads. `BODY_SIZE_LIMIT` is derived from the larger of this and `VIDEO_MAX_MB` at container start.       |
+| `VIDEO_MAX_MB`          | `100`               | Maximum size in MB for journal video uploads. Videos are stored as-is (no transcoding).                                                                    |
+| `MAX_DAILY_MEDIA`       | `5`                 | Maximum number of journal photos and videos (combined) per companion per day. (Renamed from `MAX_DAILY_PHOTOS`, still honored with a deprecation warning.) |
+| `REMINDER_UNDO_SECONDS` | `7`                 | Default undo window (seconds) when dismissing a Reminder. `0` disables the undo window. Each user can override in their settings.                          |
+| `user`                  | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                                                  |
+| `./data` volume         | `./data`            | Where the database and uploads are stored on the host.                                                                                                     |
+| `DATABASE_URL`          | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                                             |
 
 ### External image storage (optional)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,10 +29,12 @@ services:
 
       NODE_ENV: production
       DATABASE_URL: /data/einvault.db
-      # Maximum upload size in MB. BODY_SIZE_LIMIT is derived automatically.
+      # Maximum image upload size in MB. BODY_SIZE_LIMIT is derived automatically.
       UPLOAD_MAX_MB: ${UPLOAD_MAX_MB:-10}
-      # Maximum journal photos per companion per day.
-      MAX_DAILY_PHOTOS: ${MAX_DAILY_PHOTOS:-5}
+      # Maximum journal video upload size in MB (stored as-is, no transcoding).
+      VIDEO_MAX_MB: ${VIDEO_MAX_MB:-100}
+      # Maximum journal photos and videos (combined) per companion per day.
+      MAX_DAILY_MEDIA: ${MAX_DAILY_MEDIA:-5}
       # Default undo window (seconds) for dismissing a Reminder. 0 disables it.
       REMINDER_UNDO_SECONDS: ${REMINDER_UNDO_SECONDS:-7}
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,10 +26,12 @@ services:
 
       NODE_ENV: production
       DATABASE_URL: /data/einvault.db
-      # Maximum upload size in MB. BODY_SIZE_LIMIT is derived automatically.
+      # Maximum image upload size in MB. BODY_SIZE_LIMIT is derived automatically.
       UPLOAD_MAX_MB: 10
-      # Maximum journal photos per companion per day.
-      MAX_DAILY_PHOTOS: 5
+      # Maximum journal video upload size in MB (stored as-is, no transcoding).
+      VIDEO_MAX_MB: 100
+      # Maximum journal photos and videos (combined) per companion per day.
+      MAX_DAILY_MEDIA: 5
       # Default undo window (seconds) for dismissing a Reminder. 0 disables it.
       # Each user can override in their settings.
       REMINDER_UNDO_SECONDS: 7

--- a/drizzle/0013_brave_lenny_balinger.sql
+++ b/drizzle/0013_brave_lenny_balinger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `journal_photos` ADD `media_type` text DEFAULT 'photo' NOT NULL;

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1326 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bf5346bd-c715-42a5-95e2-919c133854dd",
+  "prevId": "4a23eb88-a800-4096-800b-d3da707bd9fd",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'photo'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1779721030065,
       "tag": "0012_curved_baron_zemo",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1780012333513,
+      "tag": "0013_brave_lenny_balinger",
+      "breakpoints": true
     }
   ]
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,18 +4,24 @@ import { validateAuth } from '$server/auth';
 import { env } from '$env/dynamic/private';
 import { resolveLocale, parseAcceptLanguage } from '$lib/i18n';
 import { logOidcBootStatus } from '$lib/server/auth/oidc';
-import { S3_CONFIG, logImmichBootStatus, logStorageBootStatus } from '$lib/server/env';
+import {
+	S3_CONFIG,
+	logImmichBootStatus,
+	logStorageBootStatus,
+	logDeprecatedEnvWarnings
+} from '$lib/server/env';
 
 logOidcBootStatus();
 logStorageBootStatus();
 logImmichBootStatus();
+logDeprecatedEnvWarnings();
 
 // When S3 storage is configured, /api/photos and /api/avatars 302 to the S3
-// host. CSP is enforced on the final navigation target after redirects, so
-// the S3 origin has to appear in img-src or the browser blocks the load.
-// Computed once at boot from runtime env so swapping S3_ENDPOINT only needs a
-// container restart, not a rebuild.
-const S3_IMG_ORIGIN: string | null = (() => {
+// host. CSP is enforced on the final navigation target after redirects, so the
+// S3 origin has to appear in img-src (photos/avatars) AND media-src (videos) or
+// the browser blocks the load. Computed once at boot from runtime env so
+// swapping S3_ENDPOINT only needs a container restart, not a rebuild.
+const S3_ASSET_ORIGIN: string | null = (() => {
 	if (!S3_CONFIG) return null;
 	try {
 		return new URL(S3_CONFIG.endpoint).origin;
@@ -24,15 +30,28 @@ const S3_IMG_ORIGIN: string | null = (() => {
 	}
 })();
 
-function injectImgSrcOrigin(csp: string, origin: string): string {
-	// Append the origin inside every img-src directive. Callback form so
-	// arbitrary characters in `origin` are not interpreted as $1 backrefs.
-	// `gi` so multiple directives all pick up the origin.
-	if (/(^|;)\s*img-src\b/i.test(csp)) {
-		return csp.replace(/(img-src\b[^;]*)/gi, (_m, captured) => `${captured} ${origin}`);
+// Default sources used when a directive is absent and we need to add it.
+const DIRECTIVE_DEFAULTS: Record<string, string> = {
+	'img-src': "'self' data: blob:",
+	'media-src': "'self' blob:"
+};
+
+function injectAssetOrigin(csp: string, origin: string): string {
+	let result = csp;
+	for (const directive of Object.keys(DIRECTIVE_DEFAULTS)) {
+		const present = new RegExp(`(^|;)\\s*${directive}\\b`, 'i').test(result);
+		if (present) {
+			// Append the origin inside every matching directive. Callback form so
+			// arbitrary characters in `origin` are not interpreted as backrefs.
+			result = result.replace(
+				new RegExp(`(${directive}\\b[^;]*)`, 'gi'),
+				(_m, captured) => `${captured} ${origin}`
+			);
+		} else {
+			result = `${result.replace(/;?\s*$/, '')}; ${directive} ${DIRECTIVE_DEFAULTS[directive]} ${origin}`;
+		}
 	}
-	// No img-src directive present; add one.
-	return `${csp.replace(/;?\s*$/, '')}; img-src 'self' data: blob: ${origin}`;
+	return result;
 }
 
 const securityHeaders: Handle = async ({ event, resolve }) => {
@@ -51,14 +70,14 @@ const securityHeaders: Handle = async ({ event, resolve }) => {
 	if (contentType.startsWith('text/html') && !response.headers.has('content-security-policy')) {
 		response.headers.set(
 			'Content-Security-Policy',
-			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 		);
 	}
 
-	if (S3_IMG_ORIGIN) {
+	if (S3_ASSET_ORIGIN) {
 		const csp = response.headers.get('content-security-policy');
 		if (csp) {
-			response.headers.set('content-security-policy', injectImgSrcOrigin(csp, S3_IMG_ORIGIN));
+			response.headers.set('content-security-policy', injectAssetOrigin(csp, S3_ASSET_ORIGIN));
 		}
 	}
 

--- a/src/lib/components/ImmichPicker.svelte
+++ b/src/lib/components/ImmichPicker.svelte
@@ -159,7 +159,7 @@
 			<div class="flex-1 overflow-y-auto p-4" onscroll={handleScroll}>
 				{#if error}
 					<div
-						class="rounded-lg bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive mb-3"
+						class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-600 dark:text-red-300 mb-3"
 					>
 						{error}
 					</div>

--- a/src/lib/components/ImmichPicker.svelte
+++ b/src/lib/components/ImmichPicker.svelte
@@ -159,7 +159,8 @@
 			<div class="flex-1 overflow-y-auto p-4" onscroll={handleScroll}>
 				{#if error}
 					<div
-						class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-600 dark:text-red-300 mb-3"
+						role="alert"
+						class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300 mb-3"
 					>
 						{error}
 					</div>

--- a/src/lib/components/JournalVideo.svelte
+++ b/src/lib/components/JournalVideo.svelte
@@ -8,6 +8,8 @@
 		label?: string;
 		class?: string;
 		autoplay?: boolean;
+		/** Compact fallback for small thumbnails: hides the message, shows only the download link. */
+		compact?: boolean;
 	}
 
 	let {
@@ -15,7 +17,8 @@
 		downloadName = null,
 		label,
 		class: className = '',
-		autoplay = false
+		autoplay = false,
+		compact = false
 	}: Props = $props();
 	const locale = getLocale();
 
@@ -23,19 +26,28 @@
 	// as-is, no transcode). On a decode/metadata error, fall back to a download
 	// link instead of a dead player.
 	let failed = $state(false);
+
+	// Honor the user's reduced-motion preference: don't auto-start playback.
+	const reduceMotion =
+		typeof window !== 'undefined' &&
+		!!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
 </script>
 
 {#if failed}
 	<div
-		class="flex flex-col items-center justify-center gap-1.5 bg-stone-100 dark:bg-stone-800 text-center p-3 {className}"
+		class="flex flex-col items-center justify-center gap-1.5 bg-stone-100 dark:bg-stone-800 text-center {compact
+			? 'p-2'
+			: 'p-3'} {className}"
 	>
-		<p class="text-xs text-muted-foreground">{t(locale, 'page.journal.videoUnsupported')}</p>
+		{#if !compact}
+			<p class="text-xs text-muted-foreground">{t(locale, 'page.journal.videoUnsupported')}</p>
+		{/if}
 		<a
 			href={src}
 			download={downloadName ?? true}
-			class="inline-flex items-center gap-1 text-xs font-medium text-red-600 dark:text-red-300 hover:underline"
+			class="inline-flex items-center gap-1 rounded px-2 py-1.5 text-xs font-medium text-red-700 dark:text-red-300 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
 		>
-			<Download class="h-3.5 w-3.5" />
+			<Download class="h-3.5 w-3.5 shrink-0" />
 			{t(locale, 'aria.downloadMedia')}
 		</a>
 	</div>
@@ -44,7 +56,7 @@
 	<video
 		{src}
 		controls
-		{autoplay}
+		autoplay={autoplay && !reduceMotion}
 		preload="metadata"
 		playsinline
 		class={className}

--- a/src/lib/components/JournalVideo.svelte
+++ b/src/lib/components/JournalVideo.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { Download } from '@lucide/svelte';
+	import { t, getLocale } from '$lib/i18n';
+
+	interface Props {
+		src: string;
+		downloadName?: string | null;
+		label?: string;
+		class?: string;
+		autoplay?: boolean;
+	}
+
+	let {
+		src,
+		downloadName = null,
+		label,
+		class: className = '',
+		autoplay = false
+	}: Props = $props();
+	const locale = getLocale();
+
+	// Browsers can't decode every container/codec we accept (videos are stored
+	// as-is, no transcode). On a decode/metadata error, fall back to a download
+	// link instead of a dead player.
+	let failed = $state(false);
+</script>
+
+{#if failed}
+	<div
+		class="flex flex-col items-center justify-center gap-1.5 bg-stone-100 dark:bg-stone-800 text-center p-3 {className}"
+	>
+		<p class="text-xs text-muted-foreground">{t(locale, 'page.journal.videoUnsupported')}</p>
+		<a
+			href={src}
+			download={downloadName ?? true}
+			class="inline-flex items-center gap-1 text-xs font-medium text-red-600 dark:text-red-300 hover:underline"
+		>
+			<Download class="h-3.5 w-3.5" />
+			{t(locale, 'aria.downloadMedia')}
+		</a>
+	</div>
+{:else}
+	<!-- svelte-ignore a11y_media_has_caption -->
+	<video
+		{src}
+		controls
+		{autoplay}
+		preload="metadata"
+		playsinline
+		class={className}
+		aria-label={label ?? t(locale, 'page.journal.videoAlt')}
+		onerror={() => (failed = true)}
+	></video>
+{/if}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -8,24 +8,15 @@ const messages: Record<keyof Messages, string> = {
 	'common.delete': 'Löschen',
 	'common.edit': 'Bearbeiten',
 	'common.close': 'Schließen',
-	'common.confirm': 'Bestätigen',
 	'common.loading': 'Laden…',
-	'common.noResults': 'Keine Ergebnisse',
 	'common.back': 'Zurück',
 	'common.placeholderPhone': '+49 30 123456',
-	'common.add': 'Hinzufügen',
-	'common.remove': 'Entfernen',
-	'common.yes': 'Ja',
-	'common.no': 'Nein',
 	'common.or': 'oder',
-	'common.optional': 'optional',
 	'common.loggedBy': 'von {name}',
 
 	// Common: Reminder actions
-	'common.reminder.undo': 'Rückgängig',
 	'common.reminder.done': 'Erledigt',
 	'common.reminder.dismissedAnnounce': '{title} verworfen',
-	'common.reminder.untitled': 'Unbenannte Erinnerung',
 	'common.reminder.logEvent': 'Erledigt & Ereignis erfassen',
 	'common.reminder.logEventAria': 'Als erledigt markieren und Gesundheitsereignis erfassen',
 	'common.reminder.toastUndoLabel': 'Rückgängig',
@@ -165,7 +156,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidFileTypeAvatar': 'Ungültiger Dateityp. Muss JPEG, PNG oder WebP sein.',
 	'error.invalidFileType': 'Ungültiger Dateityp',
 	'error.invalidGifFile': 'Ungültige GIF-Datei',
-	'error.maxPhotosExceeded': 'Maximal {max} Fotos pro Tag',
+	'error.maxMediaExceeded': 'Maximal {max} Fotos oder Videos pro Tag',
 	'error.requestBodyTooLarge': 'Anfrage zu groß',
 
 	// Navigation
@@ -430,7 +421,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.modalLabelDuration': 'Dauer',
 	'page.dashboard.modalLabelDate': 'Datum',
 	'page.dashboard.modalLabelVet': 'Tierarzt',
-	'page.dashboard.modalDurationMin': '{count} Min.',
 	'page.dashboard.modalEditReminders': 'In Erinnerungen bearbeiten',
 	'page.dashboard.modalEditHealth': 'In Gesundheit bearbeiten',
 	'page.dashboard.modalOpenJournal': 'Tagebuch öffnen',
@@ -447,9 +437,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardReminders': 'Anstehende Erinnerungen',
 	'page.dashboard.caretaker.remindersEmpty': 'Keine anstehenden Erinnerungen.',
 	'page.dashboard.caretaker.reminderOverdue': 'Überfällig',
-	'page.dashboard.caretaker.reminderMarkDone': 'Als erledigt markieren',
-	'page.dashboard.caretaker.reminderShiftRequired':
-		'Starte deine Schicht, um Erinnerungen zu erledigen',
 	'page.dashboard.caretaker.cardVetInfo': 'Tierarztinfo',
 	'page.dashboard.caretaker.cardEmergencyContact': 'Notfallkontakt',
 	'page.dashboard.caretaker.householdOwner': 'Besitzer',
@@ -465,8 +452,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.modalLabelNotes': 'Notizen',
 	'page.dashboard.caretaker.modalLabelDue': 'Fällig',
 	'page.dashboard.caretaker.modalLabelRepeats': 'Wiederholt sich',
-	'page.dashboard.caretaker.modalShiftRequired':
-		'Starte deine Schicht, um Erinnerungen zu erledigen',
 	'page.dashboard.caretaker.closeDialog': 'Dialog schließen',
 
 	// Page: caretaker home
@@ -491,10 +476,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.activityDetailNotes': 'Notizen',
 	'page.journal.activityDetailOpenInJournal': 'Im Tagebuch öffnen',
 	'page.journal.photoAlt': 'Tagebuchfoto',
-	'page.journal.photoLightboxLabel': 'Fotoanzeige',
+	'page.journal.videoAlt': 'Tagebuchvideo',
+	'page.journal.videoUnsupported': 'Dieses Video kann in deinem Browser nicht abgespielt werden.',
+	'page.journal.mediaLightboxLabel': 'Medienanzeige',
 
 	// Page: Journal day (app)
-	'page.journal.day.title': 'Tagebuch',
 	'page.journal.day.mood': 'Stimmung',
 	'page.journal.day.moodQuestion': 'Wie geht es {name}?',
 	'page.journal.day.write': 'Schreiben',
@@ -505,11 +491,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.day.savingStatus': 'Speichern…',
 	'page.journal.day.saveFailedStatus': 'Speichern fehlgeschlagen',
 	'page.journal.day.saveFailedRetry': 'Erneut versuchen',
-	'page.journal.day.photosTitle': 'Fotos',
-	'page.journal.day.addPhoto': 'Foto hinzufügen',
+	'page.journal.day.mediaTitle': 'Fotos & Videos',
+	'page.journal.day.addMedia': 'Medien hinzufügen',
 	'page.journal.day.uploading': 'Hochladen…',
-	'page.journal.day.dropPhotos': 'Fotos hierher ziehen oder klicken zum Hochladen',
-	'page.journal.day.photoTypes': 'JPEG, PNG oder WebP (max. {max}MB pro Bild)',
+	'page.journal.day.dropMedia': 'Fotos oder Videos hierher ziehen oder klicken zum Hochladen',
+	'page.journal.day.mediaTypes': 'Bilder (max. {imgMax}MB) oder Videos (max. {vidMax}MB)',
 	'page.journal.day.noCaption': 'Keine Bildunterschrift',
 	'page.journal.day.addCaption': 'Bildunterschrift hinzufügen…',
 	'page.journal.day.editCaption': 'Bildunterschrift bearbeiten',
@@ -541,9 +527,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.caretaker.savedStatus': '✓ Gespeichert',
 	'page.journal.caretaker.savingStatus': 'Speichern…',
 	'page.journal.caretaker.saveFailedStatus': 'Speichern fehlgeschlagen',
-	'page.journal.caretaker.photos': 'Fotos',
-	'page.journal.caretaker.addPhoto': '+ Foto hinzufügen',
-	'page.journal.caretaker.dropPhotos': 'Fotos hierher ziehen oder klicken zum Hochladen',
+	'page.journal.caretaker.media': 'Fotos & Videos',
+	'page.journal.caretaker.addMedia': '+ Medien hinzufügen',
+	'page.journal.caretaker.dropMedia': 'Fotos oder Videos hierher ziehen oder klicken zum Hochladen',
 	'page.journal.caretaker.noCaption': 'Keine Bildunterschrift',
 	'page.journal.caretaker.addCaption': 'Bildunterschrift hinzufügen…',
 	'page.journal.caretaker.editCaption': 'Bildunterschrift bearbeiten',
@@ -607,7 +593,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.anchorMonthFromDueDate': 'Gleiches Datum wie Fälligkeitsdatum',
 	'page.reminders.anchorMonthSpecificDay': 'Bestimmter Tag',
 	'page.reminders.anchorMonthClampWarning': 'Monate ohne diesen Tag verwenden den letzten Tag.',
-	'page.reminders.anchorYearLabel': 'Am Datum',
 	'page.reminders.anchorYearMonth': 'Monat',
 	'page.reminders.anchorYearDay': 'Tag',
 	'page.reminders.anchorYearFromDueDate': 'Gleiches Datum wie Fälligkeitsdatum',
@@ -716,12 +701,12 @@ const messages: Record<keyof Messages, string> = {
 	'aria.mainNav': 'Hauptnavigation',
 	'aria.moreActions': 'Weitere Aktionen',
 	'aria.deleteEntry': 'Eintrag löschen',
-	'aria.deletePhoto': 'Foto löschen',
-	'aria.downloadPhoto': 'Foto herunterladen',
+	'aria.deleteMedia': 'Medien löschen',
+	'aria.downloadMedia': 'Medien herunterladen',
 	'aria.closeDialog': 'Dialog schließen',
 	'aria.close': 'Schließen',
-	'aria.previousPhoto': 'Vorheriges Foto',
-	'aria.nextPhoto': 'Nächstes Foto',
+	'aria.previousMedia': 'Vorheriges Medium',
+	'aria.nextMedia': 'Nächstes Medium',
 	'aria.viewPhoto': '{name}s Foto anzeigen',
 
 	// Immich picker
@@ -732,10 +717,9 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Auswahl schließen',
 	'immich.picker.loadError': 'Immich-Bibliothek konnte nicht geladen werden.',
 	'immich.picker.button': 'Aus Immich auswählen',
-	'immich.picker.pickFailed': 'Immich-Inhalt konnte nicht angehängt werden.',
+	'immich.picker.pickFailed': 'Immich-Inhalt konnte nicht angehängt werden.'
 
 	// Meta
-	'meta.description': 'EinVault: privates Gesundheits- und Pflegetagebuch für Hunde'
 } satisfies Record<keyof Messages, string>;
 
 export default messages;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -6,24 +6,15 @@ const messages = {
 	'common.delete': 'Delete',
 	'common.edit': 'Edit',
 	'common.close': 'Close',
-	'common.confirm': 'Confirm',
 	'common.loading': 'Loading…',
-	'common.noResults': 'No results',
 	'common.back': 'Back',
 	'common.placeholderPhone': '(555) 000-0000',
-	'common.add': 'Add',
-	'common.remove': 'Remove',
-	'common.yes': 'Yes',
-	'common.no': 'No',
 	'common.or': 'or',
-	'common.optional': 'optional',
 	'common.loggedBy': 'by {name}',
 
 	// Common: Reminder actions (shared across companion dashboard, reminders list, caretaker)
-	'common.reminder.undo': 'Undo',
 	'common.reminder.done': 'Done',
 	'common.reminder.dismissedAnnounce': '{title} dismissed',
-	'common.reminder.untitled': 'Untitled reminder',
 	'common.reminder.logEvent': 'Done & Log Event',
 	'common.reminder.logEventAria': 'Mark done and log a Health Event',
 	'common.reminder.toastUndoLabel': 'Undo',
@@ -152,7 +143,7 @@ const messages = {
 	'error.invalidFileTypeAvatar': 'Invalid file type. Must be JPEG, PNG, or WebP.',
 	'error.invalidFileType': 'Invalid file type',
 	'error.invalidGifFile': 'Invalid GIF file',
-	'error.maxPhotosExceeded': 'Maximum {max} photos per day',
+	'error.maxMediaExceeded': 'Maximum {max} photos or videos per day',
 	'error.requestBodyTooLarge': 'Request body too large',
 
 	// Navigation
@@ -424,7 +415,6 @@ const messages = {
 	'page.dashboard.modalLabelDuration': 'Duration',
 	'page.dashboard.modalLabelDate': 'Date',
 	'page.dashboard.modalLabelVet': 'Vet',
-	'page.dashboard.modalDurationMin': '{count} min',
 	'page.dashboard.modalEditReminders': 'Edit in Reminders',
 	'page.dashboard.modalEditHealth': 'Edit in Health',
 	'page.dashboard.modalOpenJournal': 'Open Journal',
@@ -441,8 +431,6 @@ const messages = {
 	'page.dashboard.caretaker.cardReminders': 'Upcoming Reminders',
 	'page.dashboard.caretaker.remindersEmpty': 'No upcoming reminders.',
 	'page.dashboard.caretaker.reminderOverdue': 'Overdue',
-	'page.dashboard.caretaker.reminderMarkDone': 'Mark as done',
-	'page.dashboard.caretaker.reminderShiftRequired': 'Start your shift to mark reminders done',
 	'page.dashboard.caretaker.cardVetInfo': 'Vet Info',
 	'page.dashboard.caretaker.cardEmergencyContact': 'Emergency Contact',
 	'page.dashboard.caretaker.householdOwner': 'Owner',
@@ -458,7 +446,6 @@ const messages = {
 	'page.dashboard.caretaker.modalLabelNotes': 'Notes',
 	'page.dashboard.caretaker.modalLabelDue': 'Due',
 	'page.dashboard.caretaker.modalLabelRepeats': 'Repeats',
-	'page.dashboard.caretaker.modalShiftRequired': 'Start your shift to mark reminders done',
 	'page.dashboard.caretaker.closeDialog': 'Close dialog',
 
 	// Page: caretaker home
@@ -483,10 +470,11 @@ const messages = {
 	'page.journal.activityDetailNotes': 'Notes',
 	'page.journal.activityDetailOpenInJournal': 'Open in Journal',
 	'page.journal.photoAlt': 'Journal photo',
-	'page.journal.photoLightboxLabel': 'Photo viewer',
+	'page.journal.videoAlt': 'Journal video',
+	'page.journal.videoUnsupported': "This video can't be played in your browser.",
+	'page.journal.mediaLightboxLabel': 'Media viewer',
 
 	// Page: Journal day (app)
-	'page.journal.day.title': 'Journal',
 	'page.journal.day.mood': 'Mood',
 	'page.journal.day.moodQuestion': 'How is {name} feeling?',
 	'page.journal.day.write': 'Write',
@@ -497,11 +485,11 @@ const messages = {
 	'page.journal.day.savingStatus': 'Saving…',
 	'page.journal.day.saveFailedStatus': 'Save failed',
 	'page.journal.day.saveFailedRetry': 'Retry',
-	'page.journal.day.photosTitle': 'Photos',
-	'page.journal.day.addPhoto': 'Add Photo',
+	'page.journal.day.mediaTitle': 'Photos & Videos',
+	'page.journal.day.addMedia': 'Add Media',
 	'page.journal.day.uploading': 'Uploading…',
-	'page.journal.day.dropPhotos': 'Drop photos here or click to upload',
-	'page.journal.day.photoTypes': 'JPEG, PNG, or WebP (max {max}MB each)',
+	'page.journal.day.dropMedia': 'Drop photos or videos here or click to upload',
+	'page.journal.day.mediaTypes': 'Images (max {imgMax}MB) or videos (max {vidMax}MB)',
 	'page.journal.day.noCaption': 'No caption',
 	'page.journal.day.addCaption': 'Add a caption…',
 	'page.journal.day.editCaption': 'Edit Caption',
@@ -532,9 +520,9 @@ const messages = {
 	'page.journal.caretaker.savedStatus': '✓ Saved',
 	'page.journal.caretaker.savingStatus': 'Saving…',
 	'page.journal.caretaker.saveFailedStatus': 'Save failed',
-	'page.journal.caretaker.photos': 'Photos',
-	'page.journal.caretaker.addPhoto': '+ Add photo',
-	'page.journal.caretaker.dropPhotos': 'Drop photos here or click to upload',
+	'page.journal.caretaker.media': 'Photos & Videos',
+	'page.journal.caretaker.addMedia': '+ Add media',
+	'page.journal.caretaker.dropMedia': 'Drop photos or videos here or click to upload',
 	'page.journal.caretaker.noCaption': 'No caption',
 	'page.journal.caretaker.addCaption': 'Add a caption…',
 	'page.journal.caretaker.editCaption': 'Edit Caption',
@@ -598,7 +586,6 @@ const messages = {
 	'page.reminders.anchorMonthFromDueDate': 'Same date as due date',
 	'page.reminders.anchorMonthSpecificDay': 'Specific day',
 	'page.reminders.anchorMonthClampWarning': 'Months without this day use the last day.',
-	'page.reminders.anchorYearLabel': 'On date',
 	'page.reminders.anchorYearMonth': 'Month',
 	'page.reminders.anchorYearDay': 'Day',
 	'page.reminders.anchorYearFromDueDate': 'Same date as due date',
@@ -706,12 +693,12 @@ const messages = {
 	'aria.mainNav': 'Main navigation',
 	'aria.moreActions': 'More actions',
 	'aria.deleteEntry': 'Delete entry',
-	'aria.deletePhoto': 'Delete photo',
-	'aria.downloadPhoto': 'Download photo',
+	'aria.deleteMedia': 'Delete media',
+	'aria.downloadMedia': 'Download media',
 	'aria.closeDialog': 'Close dialog',
 	'aria.close': 'Close',
-	'aria.previousPhoto': 'Previous photo',
-	'aria.nextPhoto': 'Next photo',
+	'aria.previousMedia': 'Previous media',
+	'aria.nextMedia': 'Next media',
 	'aria.viewPhoto': "View {name}'s photo",
 
 	// Immich picker
@@ -722,10 +709,9 @@ const messages = {
 	'immich.picker.close': 'Close picker',
 	'immich.picker.loadError': 'Could not load Immich library.',
 	'immich.picker.button': 'Pick from Immich',
-	'immich.picker.pickFailed': 'Could not attach Immich asset.',
+	'immich.picker.pickFailed': 'Could not attach Immich asset.'
 
 	// Meta
-	'meta.description': 'EinVault: private dog health & care tracker'
 } as const;
 
 export type Messages = typeof messages;

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -8,24 +8,15 @@ const messages: Record<keyof Messages, string> = {
 	'common.delete': 'Eliminar',
 	'common.edit': 'Editar',
 	'common.close': 'Cerrar',
-	'common.confirm': 'Confirmar',
 	'common.loading': 'Cargando…',
-	'common.noResults': 'Sin resultados',
 	'common.back': 'Atrás',
 	'common.placeholderPhone': '+34 612 345 678',
-	'common.add': 'Añadir',
-	'common.remove': 'Eliminar',
-	'common.yes': 'Sí',
-	'common.no': 'No',
 	'common.or': 'o',
-	'common.optional': 'opcional',
 	'common.loggedBy': 'por {name}',
 
 	// Common: Reminder actions
-	'common.reminder.undo': 'Deshacer',
 	'common.reminder.done': 'Hecho',
 	'common.reminder.dismissedAnnounce': '{title} descartado',
-	'common.reminder.untitled': 'Recordatorio sin título',
 	'common.reminder.logEvent': 'Hecho y registrar evento',
 	'common.reminder.logEventAria': 'Marcar como hecho y registrar un evento de salud',
 	'common.reminder.toastUndoLabel': 'Deshacer',
@@ -165,7 +156,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidFileTypeAvatar': 'Tipo de archivo no válido. Debe ser JPEG, PNG o WebP.',
 	'error.invalidFileType': 'Tipo de archivo no válido',
 	'error.invalidGifFile': 'Archivo GIF no válido',
-	'error.maxPhotosExceeded': 'Máximo {max} fotos por día',
+	'error.maxMediaExceeded': 'Máximo {max} fotos o vídeos por día',
 	'error.requestBodyTooLarge': 'Solicitud demasiado grande',
 
 	// Navigation
@@ -430,7 +421,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.modalLabelDuration': 'Duración',
 	'page.dashboard.modalLabelDate': 'Fecha',
 	'page.dashboard.modalLabelVet': 'Veterinario',
-	'page.dashboard.modalDurationMin': '{count} min',
 	'page.dashboard.modalEditReminders': 'Editar en Recordatorios',
 	'page.dashboard.modalEditHealth': 'Editar en Salud',
 	'page.dashboard.modalOpenJournal': 'Abrir diario',
@@ -447,8 +437,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardReminders': 'Recordatorios próximos',
 	'page.dashboard.caretaker.remindersEmpty': 'No hay recordatorios próximos.',
 	'page.dashboard.caretaker.reminderOverdue': 'Vencido',
-	'page.dashboard.caretaker.reminderMarkDone': 'Marcar como hecho',
-	'page.dashboard.caretaker.reminderShiftRequired': 'Inicia tu turno para completar recordatorios',
 	'page.dashboard.caretaker.cardVetInfo': 'Info del veterinario',
 	'page.dashboard.caretaker.cardEmergencyContact': 'Contacto de emergencia',
 	'page.dashboard.caretaker.householdOwner': 'Propietario',
@@ -464,7 +452,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.modalLabelNotes': 'Notas',
 	'page.dashboard.caretaker.modalLabelDue': 'Vencimiento',
 	'page.dashboard.caretaker.modalLabelRepeats': 'Se repite',
-	'page.dashboard.caretaker.modalShiftRequired': 'Inicia tu turno para completar recordatorios',
 	'page.dashboard.caretaker.closeDialog': 'Cerrar diálogo',
 
 	// Page: caretaker home
@@ -489,10 +476,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.activityDetailNotes': 'Notas',
 	'page.journal.activityDetailOpenInJournal': 'Abrir en el diario',
 	'page.journal.photoAlt': 'Foto del diario',
-	'page.journal.photoLightboxLabel': 'Visor de fotos',
+	'page.journal.videoAlt': 'Vídeo del diario',
+	'page.journal.videoUnsupported': 'Este vídeo no se puede reproducir en tu navegador.',
+	'page.journal.mediaLightboxLabel': 'Visor multimedia',
 
 	// Page: Journal day (app)
-	'page.journal.day.title': 'Diario',
 	'page.journal.day.mood': 'Estado de ánimo',
 	'page.journal.day.moodQuestion': '¿Cómo está {name}?',
 	'page.journal.day.write': 'Escribir',
@@ -503,11 +491,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.day.savingStatus': 'Guardando…',
 	'page.journal.day.saveFailedStatus': 'Error al guardar',
 	'page.journal.day.saveFailedRetry': 'Reintentar',
-	'page.journal.day.photosTitle': 'Fotos',
-	'page.journal.day.addPhoto': 'Añadir foto',
+	'page.journal.day.mediaTitle': 'Fotos y vídeos',
+	'page.journal.day.addMedia': 'Añadir contenido',
 	'page.journal.day.uploading': 'Subiendo…',
-	'page.journal.day.dropPhotos': 'Arrastra fotos aquí o haz clic para subir',
-	'page.journal.day.photoTypes': 'JPEG, PNG o WebP (máx. {max}MB cada una)',
+	'page.journal.day.dropMedia': 'Arrastra fotos o vídeos aquí o haz clic para subir',
+	'page.journal.day.mediaTypes': 'Imágenes (máx. {imgMax}MB) o vídeos (máx. {vidMax}MB)',
 	'page.journal.day.noCaption': 'Sin pie de foto',
 	'page.journal.day.addCaption': 'Añadir un pie de foto…',
 	'page.journal.day.editCaption': 'Editar pie de foto',
@@ -539,9 +527,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.caretaker.savedStatus': '✓ Guardado',
 	'page.journal.caretaker.savingStatus': 'Guardando…',
 	'page.journal.caretaker.saveFailedStatus': 'Error al guardar',
-	'page.journal.caretaker.photos': 'Fotos',
-	'page.journal.caretaker.addPhoto': '+ Añadir foto',
-	'page.journal.caretaker.dropPhotos': 'Arrastra fotos aquí o haz clic para subir',
+	'page.journal.caretaker.media': 'Fotos y vídeos',
+	'page.journal.caretaker.addMedia': '+ Añadir contenido',
+	'page.journal.caretaker.dropMedia': 'Arrastra fotos o vídeos aquí o haz clic para subir',
 	'page.journal.caretaker.noCaption': 'Sin pie de foto',
 	'page.journal.caretaker.addCaption': 'Añadir un pie de foto…',
 	'page.journal.caretaker.editCaption': 'Editar pie de foto',
@@ -605,7 +593,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.anchorMonthFromDueDate': 'Misma fecha que la de vencimiento',
 	'page.reminders.anchorMonthSpecificDay': 'Día específico',
 	'page.reminders.anchorMonthClampWarning': 'Los meses sin este día usan el último día.',
-	'page.reminders.anchorYearLabel': 'En fecha',
 	'page.reminders.anchorYearMonth': 'Mes',
 	'page.reminders.anchorYearDay': 'Día',
 	'page.reminders.anchorYearFromDueDate': 'Misma fecha que la de vencimiento',
@@ -714,12 +701,12 @@ const messages: Record<keyof Messages, string> = {
 	'aria.mainNav': 'Navegación principal',
 	'aria.moreActions': 'Más acciones',
 	'aria.deleteEntry': 'Eliminar entrada',
-	'aria.deletePhoto': 'Eliminar foto',
-	'aria.downloadPhoto': 'Descargar foto',
+	'aria.deleteMedia': 'Eliminar contenido',
+	'aria.downloadMedia': 'Descargar contenido',
 	'aria.closeDialog': 'Cerrar diálogo',
 	'aria.close': 'Cerrar',
-	'aria.previousPhoto': 'Foto anterior',
-	'aria.nextPhoto': 'Foto siguiente',
+	'aria.previousMedia': 'Contenido anterior',
+	'aria.nextMedia': 'Contenido siguiente',
 	'aria.viewPhoto': 'Ver foto de {name}',
 
 	// Immich picker
@@ -730,10 +717,9 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Cerrar selector',
 	'immich.picker.loadError': 'No se pudo cargar la biblioteca de Immich.',
 	'immich.picker.button': 'Elegir desde Immich',
-	'immich.picker.pickFailed': 'No se pudo adjuntar el elemento de Immich.',
+	'immich.picker.pickFailed': 'No se pudo adjuntar el elemento de Immich.'
 
 	// Meta
-	'meta.description': 'EinVault: diario privado de salud y cuidado canino'
 } satisfies Record<keyof Messages, string>;
 
 export default messages;

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -8,24 +8,15 @@ const messages: Record<keyof Messages, string> = {
 	'common.delete': 'Supprimer',
 	'common.edit': 'Modifier',
 	'common.close': 'Fermer',
-	'common.confirm': 'Confirmer',
 	'common.loading': 'Chargement…',
-	'common.noResults': 'Aucun résultat',
 	'common.back': 'Retour',
 	'common.placeholderPhone': '+33 1 23 45 67 89',
-	'common.add': 'Ajouter',
-	'common.remove': 'Retirer',
-	'common.yes': 'Oui',
-	'common.no': 'Non',
 	'common.or': 'ou',
-	'common.optional': 'facultatif',
 	'common.loggedBy': 'par {name}',
 
 	// Common: Reminder actions
-	'common.reminder.undo': 'Annuler',
 	'common.reminder.done': 'Fait',
 	'common.reminder.dismissedAnnounce': '{title} rejeté',
-	'common.reminder.untitled': 'Rappel sans titre',
 	'common.reminder.logEvent': 'Fait et consigner un événement',
 	'common.reminder.logEventAria': 'Marquer comme fait et consigner un événement de santé',
 	'common.reminder.toastUndoLabel': 'Annuler',
@@ -163,7 +154,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidFileTypeAvatar': 'Type de fichier invalide. Doit être JPEG, PNG ou WebP.',
 	'error.invalidFileType': 'Type de fichier invalide',
 	'error.invalidGifFile': 'Fichier GIF invalide',
-	'error.maxPhotosExceeded': 'Maximum {max} photos par jour',
+	'error.maxMediaExceeded': 'Maximum {max} photos ou vidéos par jour',
 	'error.requestBodyTooLarge': 'Requête trop volumineuse',
 
 	// Navigation
@@ -429,7 +420,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.modalLabelDuration': 'Durée',
 	'page.dashboard.modalLabelDate': 'Date',
 	'page.dashboard.modalLabelVet': 'Vétérinaire',
-	'page.dashboard.modalDurationMin': '{count} min',
 	'page.dashboard.modalEditReminders': 'Modifier dans Rappels',
 	'page.dashboard.modalEditHealth': 'Modifier dans Santé',
 	'page.dashboard.modalOpenJournal': 'Ouvrir le journal',
@@ -446,9 +436,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardReminders': 'Rappels à venir',
 	'page.dashboard.caretaker.remindersEmpty': 'Aucun rappel à venir.',
 	'page.dashboard.caretaker.reminderOverdue': 'En retard',
-	'page.dashboard.caretaker.reminderMarkDone': 'Marquer comme fait',
-	'page.dashboard.caretaker.reminderShiftRequired':
-		'Commencez votre garde pour valider les rappels',
 	'page.dashboard.caretaker.cardVetInfo': 'Info vétérinaire',
 	'page.dashboard.caretaker.cardEmergencyContact': "Contact d'urgence",
 	'page.dashboard.caretaker.householdOwner': 'Propriétaire',
@@ -464,7 +451,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.modalLabelNotes': 'Notes',
 	'page.dashboard.caretaker.modalLabelDue': 'Échéance',
 	'page.dashboard.caretaker.modalLabelRepeats': 'Se répète',
-	'page.dashboard.caretaker.modalShiftRequired': 'Commencez votre garde pour valider les rappels',
 	'page.dashboard.caretaker.closeDialog': 'Fermer la boîte de dialogue',
 
 	// Page: caretaker home
@@ -489,10 +475,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.activityDetailNotes': 'Notes',
 	'page.journal.activityDetailOpenInJournal': 'Ouvrir dans le journal',
 	'page.journal.photoAlt': 'Photo du journal',
-	'page.journal.photoLightboxLabel': 'Visionneuse de photos',
+	'page.journal.videoAlt': 'Vidéo du journal',
+	'page.journal.videoUnsupported': 'Cette vidéo ne peut pas être lue dans votre navigateur.',
+	'page.journal.mediaLightboxLabel': 'Visionneuse de médias',
 
 	// Page: Journal day (app)
-	'page.journal.day.title': 'Journal',
 	'page.journal.day.mood': 'Humeur',
 	'page.journal.day.moodQuestion': 'Comment va {name} ?',
 	'page.journal.day.write': 'Écrire',
@@ -504,11 +491,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.day.savingStatus': 'Enregistrement…',
 	'page.journal.day.saveFailedStatus': "Échec de l'enregistrement",
 	'page.journal.day.saveFailedRetry': 'Réessayer',
-	'page.journal.day.photosTitle': 'Photos',
-	'page.journal.day.addPhoto': 'Ajouter une photo',
+	'page.journal.day.mediaTitle': 'Photos et vidéos',
+	'page.journal.day.addMedia': 'Ajouter un média',
 	'page.journal.day.uploading': 'Envoi…',
-	'page.journal.day.dropPhotos': 'Glissez des photos ici ou cliquez pour envoyer',
-	'page.journal.day.photoTypes': 'JPEG, PNG ou WebP (max {max}Mo chacun)',
+	'page.journal.day.dropMedia': 'Glissez des photos ou des vidéos ici ou cliquez pour envoyer',
+	'page.journal.day.mediaTypes': 'Images (max {imgMax}Mo) ou vidéos (max {vidMax}Mo)',
 	'page.journal.day.noCaption': 'Pas de légende',
 	'page.journal.day.addCaption': 'Ajouter une légende…',
 	'page.journal.day.editCaption': 'Modifier la légende',
@@ -540,9 +527,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.caretaker.savedStatus': '✓ Enregistré',
 	'page.journal.caretaker.savingStatus': 'Enregistrement…',
 	'page.journal.caretaker.saveFailedStatus': "Échec de l'enregistrement",
-	'page.journal.caretaker.photos': 'Photos',
-	'page.journal.caretaker.addPhoto': '+ Ajouter une photo',
-	'page.journal.caretaker.dropPhotos': 'Glissez des photos ici ou cliquez pour envoyer',
+	'page.journal.caretaker.media': 'Photos et vidéos',
+	'page.journal.caretaker.addMedia': '+ Ajouter un média',
+	'page.journal.caretaker.dropMedia':
+		'Glissez des photos ou des vidéos ici ou cliquez pour envoyer',
 	'page.journal.caretaker.noCaption': 'Pas de légende',
 	'page.journal.caretaker.addCaption': 'Ajouter une légende…',
 	'page.journal.caretaker.editCaption': 'Modifier la légende',
@@ -606,7 +594,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.anchorMonthFromDueDate': "Même date que l'échéance",
 	'page.reminders.anchorMonthSpecificDay': 'Jour spécifique',
 	'page.reminders.anchorMonthClampWarning': 'Les mois sans ce jour utilisent le dernier jour.',
-	'page.reminders.anchorYearLabel': 'À la date',
 	'page.reminders.anchorYearMonth': 'Mois',
 	'page.reminders.anchorYearDay': 'Jour',
 	'page.reminders.anchorYearFromDueDate': "Même date que l'échéance",
@@ -715,12 +702,12 @@ const messages: Record<keyof Messages, string> = {
 	'aria.mainNav': 'Navigation principale',
 	'aria.moreActions': "Plus d'actions",
 	'aria.deleteEntry': "Supprimer l'entrée",
-	'aria.deletePhoto': 'Supprimer la photo',
-	'aria.downloadPhoto': 'Télécharger la photo',
+	'aria.deleteMedia': 'Supprimer le média',
+	'aria.downloadMedia': 'Télécharger le média',
 	'aria.closeDialog': 'Fermer la boîte de dialogue',
 	'aria.close': 'Fermer',
-	'aria.previousPhoto': 'Photo précédente',
-	'aria.nextPhoto': 'Photo suivante',
+	'aria.previousMedia': 'Média précédent',
+	'aria.nextMedia': 'Média suivant',
 	'aria.viewPhoto': 'Voir la photo de {name}',
 
 	// Immich picker
@@ -731,10 +718,9 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Fermer le sélecteur',
 	'immich.picker.loadError': 'Impossible de charger la bibliothèque Immich.',
 	'immich.picker.button': 'Choisir depuis Immich',
-	'immich.picker.pickFailed': "Impossible d'attacher l'élément Immich.",
+	'immich.picker.pickFailed': "Impossible d'attacher l'élément Immich."
 
 	// Meta
-	'meta.description': 'EinVault : journal privé de santé et soins canins'
 } satisfies Record<keyof Messages, string>;
 
 export default messages;

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -8,24 +8,15 @@ const messages: Record<keyof Messages, string> = {
 	'common.delete': 'Elimina',
 	'common.edit': 'Modifica',
 	'common.close': 'Chiudi',
-	'common.confirm': 'Conferma',
 	'common.loading': 'Caricamento…',
-	'common.noResults': 'Nessun risultato',
 	'common.back': 'Indietro',
 	'common.placeholderPhone': '+39 012 345 6789',
-	'common.add': 'Aggiungi',
-	'common.remove': 'Rimuovi',
-	'common.yes': 'Sì',
-	'common.no': 'No',
 	'common.or': 'o',
-	'common.optional': 'facoltativo',
 	'common.loggedBy': 'da {name}',
 
 	// Common: Reminder actions
-	'common.reminder.undo': 'Annulla',
 	'common.reminder.done': 'Fatto',
 	'common.reminder.dismissedAnnounce': '{title} ignorato',
-	'common.reminder.untitled': 'Promemoria senza titolo',
 	'common.reminder.logEvent': 'Fatto e registra evento',
 	'common.reminder.logEventAria': 'Segna come fatto e registra un evento sanitario',
 	'common.reminder.toastUndoLabel': 'Annulla',
@@ -161,7 +152,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidFileTypeAvatar': 'Tipo di file non valido. Deve essere JPEG, PNG o WebP.',
 	'error.invalidFileType': 'Tipo di file non valido',
 	'error.invalidGifFile': 'File GIF non valido',
-	'error.maxPhotosExceeded': 'Massimo {max} foto al giorno',
+	'error.maxMediaExceeded': 'Massimo {max} foto o video al giorno',
 	'error.requestBodyTooLarge': 'Corpo della richiesta troppo grande',
 
 	// Navigation
@@ -426,7 +417,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.modalLabelDuration': 'Durata',
 	'page.dashboard.modalLabelDate': 'Data',
 	'page.dashboard.modalLabelVet': 'Veterinario',
-	'page.dashboard.modalDurationMin': '{count} min',
 	'page.dashboard.modalEditReminders': 'Modifica nei promemoria',
 	'page.dashboard.modalEditHealth': 'Modifica in salute',
 	'page.dashboard.modalOpenJournal': 'Apri diario',
@@ -443,9 +433,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardReminders': 'Promemoria in arrivo',
 	'page.dashboard.caretaker.remindersEmpty': 'Nessun promemoria in arrivo.',
 	'page.dashboard.caretaker.reminderOverdue': 'Scaduto',
-	'page.dashboard.caretaker.reminderMarkDone': 'Segna come fatto',
-	'page.dashboard.caretaker.reminderShiftRequired':
-		'Inizia il tuo turno per completare i promemoria',
 	'page.dashboard.caretaker.cardVetInfo': 'Info veterinario',
 	'page.dashboard.caretaker.cardEmergencyContact': 'Contatto di emergenza',
 	'page.dashboard.caretaker.householdOwner': 'Proprietario',
@@ -461,7 +448,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.modalLabelNotes': 'Note',
 	'page.dashboard.caretaker.modalLabelDue': 'Scadenza',
 	'page.dashboard.caretaker.modalLabelRepeats': 'Si ripete',
-	'page.dashboard.caretaker.modalShiftRequired': 'Inizia il tuo turno per completare i promemoria',
 	'page.dashboard.caretaker.closeDialog': 'Chiudi finestra',
 
 	// Page: caretaker home
@@ -486,10 +472,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.activityDetailNotes': 'Note',
 	'page.journal.activityDetailOpenInJournal': 'Apri nel diario',
 	'page.journal.photoAlt': 'Foto del diario',
-	'page.journal.photoLightboxLabel': 'Visualizzatore foto',
+	'page.journal.videoAlt': 'Video del diario',
+	'page.journal.videoUnsupported': 'Questo video non può essere riprodotto nel tuo browser.',
+	'page.journal.mediaLightboxLabel': 'Visualizzatore multimediale',
 
 	// Page: Journal day (app)
-	'page.journal.day.title': 'Diario',
 	'page.journal.day.mood': 'Umore',
 	'page.journal.day.moodQuestion': 'Come sta {name}?',
 	'page.journal.day.write': 'Scrivi',
@@ -500,11 +487,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.day.savingStatus': 'Salvataggio…',
 	'page.journal.day.saveFailedStatus': 'Salvataggio non riuscito',
 	'page.journal.day.saveFailedRetry': 'Riprova',
-	'page.journal.day.photosTitle': 'Foto',
-	'page.journal.day.addPhoto': 'Aggiungi foto',
+	'page.journal.day.mediaTitle': 'Foto e video',
+	'page.journal.day.addMedia': 'Aggiungi contenuti',
 	'page.journal.day.uploading': 'Caricamento…',
-	'page.journal.day.dropPhotos': 'Trascina le foto qui o clicca per caricare',
-	'page.journal.day.photoTypes': 'JPEG, PNG o WebP (max {max}MB ciascuno)',
+	'page.journal.day.dropMedia': 'Trascina foto o video qui o clicca per caricare',
+	'page.journal.day.mediaTypes': 'Immagini (max {imgMax}MB) o video (max {vidMax}MB)',
 	'page.journal.day.noCaption': 'Nessuna didascalia',
 	'page.journal.day.addCaption': 'Aggiungi una didascalia…',
 	'page.journal.day.editCaption': 'Modifica didascalia',
@@ -535,9 +522,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.caretaker.savedStatus': '✓ Salvato',
 	'page.journal.caretaker.savingStatus': 'Salvataggio…',
 	'page.journal.caretaker.saveFailedStatus': 'Salvataggio non riuscito',
-	'page.journal.caretaker.photos': 'Foto',
-	'page.journal.caretaker.addPhoto': '+ Aggiungi foto',
-	'page.journal.caretaker.dropPhotos': 'Trascina le foto qui o clicca per caricare',
+	'page.journal.caretaker.media': 'Foto e video',
+	'page.journal.caretaker.addMedia': '+ Aggiungi contenuti',
+	'page.journal.caretaker.dropMedia': 'Trascina foto o video qui o clicca per caricare',
 	'page.journal.caretaker.noCaption': 'Nessuna didascalia',
 	'page.journal.caretaker.addCaption': 'Aggiungi una didascalia…',
 	'page.journal.caretaker.editCaption': 'Modifica didascalia',
@@ -601,7 +588,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.anchorMonthFromDueDate': 'Stessa data della scadenza',
 	'page.reminders.anchorMonthSpecificDay': 'Giorno specifico',
 	'page.reminders.anchorMonthClampWarning': 'I mesi senza questo giorno usano l’ultimo giorno.',
-	'page.reminders.anchorYearLabel': 'Alla data',
 	'page.reminders.anchorYearMonth': 'Mese',
 	'page.reminders.anchorYearDay': 'Giorno',
 	'page.reminders.anchorYearFromDueDate': 'Stessa data della scadenza',
@@ -710,12 +696,12 @@ const messages: Record<keyof Messages, string> = {
 	'aria.mainNav': 'Navigazione principale',
 	'aria.moreActions': 'Altre azioni',
 	'aria.deleteEntry': 'Elimina voce',
-	'aria.deletePhoto': 'Elimina foto',
-	'aria.downloadPhoto': 'Scarica foto',
+	'aria.deleteMedia': 'Elimina contenuto',
+	'aria.downloadMedia': 'Scarica contenuto',
 	'aria.closeDialog': 'Chiudi finestra',
 	'aria.close': 'Chiudi',
-	'aria.previousPhoto': 'Foto precedente',
-	'aria.nextPhoto': 'Foto successiva',
+	'aria.previousMedia': 'Contenuto precedente',
+	'aria.nextMedia': 'Contenuto successivo',
 	'aria.viewPhoto': 'Vedi la foto di {name}',
 
 	// Immich picker
@@ -726,10 +712,9 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Chiudi selettore',
 	'immich.picker.loadError': 'Impossibile caricare la libreria Immich.',
 	'immich.picker.button': 'Scegli da Immich',
-	'immich.picker.pickFailed': "Impossibile allegare l'elemento Immich.",
+	'immich.picker.pickFailed': "Impossibile allegare l'elemento Immich."
 
 	// Meta
-	'meta.description': 'EinVault: diario privato per la salute e la cura del cane'
 } satisfies Record<keyof Messages, string>;
 
 export default messages;

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -8,24 +8,15 @@ const messages: Record<keyof Messages, string> = {
 	'common.delete': 'Eliminar',
 	'common.edit': 'Editar',
 	'common.close': 'Fechar',
-	'common.confirm': 'Confirmar',
 	'common.loading': 'A carregar…',
-	'common.noResults': 'Sem resultados',
 	'common.back': 'Voltar',
 	'common.placeholderPhone': '+351 912 345 678',
-	'common.add': 'Adicionar',
-	'common.remove': 'Remover',
-	'common.yes': 'Sim',
-	'common.no': 'Não',
 	'common.or': 'ou',
-	'common.optional': 'opcional',
 	'common.loggedBy': 'por {name}',
 
 	// Common: Reminder actions
-	'common.reminder.undo': 'Desfazer',
 	'common.reminder.done': 'Feito',
 	'common.reminder.dismissedAnnounce': '{title} dispensado',
-	'common.reminder.untitled': 'Lembrete sem título',
 	'common.reminder.logEvent': 'Feito e registar evento',
 	'common.reminder.logEventAria': 'Marcar como feito e registar um evento de saúde',
 	'common.reminder.toastUndoLabel': 'Desfazer',
@@ -162,7 +153,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidFileTypeAvatar': 'Tipo de ficheiro inválido. Deve ser JPEG, PNG ou WebP.',
 	'error.invalidFileType': 'Tipo de ficheiro inválido',
 	'error.invalidGifFile': 'Ficheiro GIF inválido',
-	'error.maxPhotosExceeded': 'Máximo de {max} fotos por dia',
+	'error.maxMediaExceeded': 'Máximo de {max} fotos ou vídeos por dia',
 	'error.requestBodyTooLarge': 'Pedido demasiado grande',
 
 	// Navigation
@@ -427,7 +418,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.modalLabelDuration': 'Duração',
 	'page.dashboard.modalLabelDate': 'Data',
 	'page.dashboard.modalLabelVet': 'Veterinário',
-	'page.dashboard.modalDurationMin': '{count} min',
 	'page.dashboard.modalEditReminders': 'Editar em Lembretes',
 	'page.dashboard.modalEditHealth': 'Editar em Saúde',
 	'page.dashboard.modalOpenJournal': 'Abrir diário',
@@ -444,8 +434,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardReminders': 'Lembretes próximos',
 	'page.dashboard.caretaker.remindersEmpty': 'Sem lembretes próximos.',
 	'page.dashboard.caretaker.reminderOverdue': 'Atrasado',
-	'page.dashboard.caretaker.reminderMarkDone': 'Marcar como feito',
-	'page.dashboard.caretaker.reminderShiftRequired': 'Inicie o seu turno para concluir lembretes',
 	'page.dashboard.caretaker.cardVetInfo': 'Info do veterinário',
 	'page.dashboard.caretaker.cardEmergencyContact': 'Contacto de emergência',
 	'page.dashboard.caretaker.householdOwner': 'Dono',
@@ -461,7 +449,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.modalLabelNotes': 'Notas',
 	'page.dashboard.caretaker.modalLabelDue': 'Vencimento',
 	'page.dashboard.caretaker.modalLabelRepeats': 'Repete-se',
-	'page.dashboard.caretaker.modalShiftRequired': 'Inicie o seu turno para concluir lembretes',
 	'page.dashboard.caretaker.closeDialog': 'Fechar diálogo',
 
 	// Page: caretaker home
@@ -486,10 +473,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.activityDetailNotes': 'Notas',
 	'page.journal.activityDetailOpenInJournal': 'Abrir no diário',
 	'page.journal.photoAlt': 'Foto do diário',
-	'page.journal.photoLightboxLabel': 'Visualizador de fotos',
+	'page.journal.videoAlt': 'Vídeo do diário',
+	'page.journal.videoUnsupported': 'Não é possível reproduzir este vídeo no seu navegador.',
+	'page.journal.mediaLightboxLabel': 'Visualizador de mídia',
 
 	// Page: Journal day (app)
-	'page.journal.day.title': 'Diário',
 	'page.journal.day.mood': 'Humor',
 	'page.journal.day.moodQuestion': 'Como está {name}?',
 	'page.journal.day.write': 'Escrever',
@@ -500,11 +488,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.day.savingStatus': 'A guardar…',
 	'page.journal.day.saveFailedStatus': 'Falha ao guardar',
 	'page.journal.day.saveFailedRetry': 'Tentar novamente',
-	'page.journal.day.photosTitle': 'Fotos',
-	'page.journal.day.addPhoto': 'Adicionar foto',
+	'page.journal.day.mediaTitle': 'Fotos e vídeos',
+	'page.journal.day.addMedia': 'Adicionar conteúdo',
 	'page.journal.day.uploading': 'A enviar…',
-	'page.journal.day.dropPhotos': 'Arraste fotos para aqui ou clique para enviar',
-	'page.journal.day.photoTypes': 'JPEG, PNG ou WebP (máx. {max}MB cada)',
+	'page.journal.day.dropMedia': 'Arraste fotos ou vídeos para aqui ou clique para enviar',
+	'page.journal.day.mediaTypes': 'Imagens (máx. {imgMax}MB) ou vídeos (máx. {vidMax}MB)',
 	'page.journal.day.noCaption': 'Sem legenda',
 	'page.journal.day.addCaption': 'Adicionar legenda…',
 	'page.journal.day.editCaption': 'Editar legenda',
@@ -536,9 +524,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.caretaker.savedStatus': '✓ Guardado',
 	'page.journal.caretaker.savingStatus': 'A guardar…',
 	'page.journal.caretaker.saveFailedStatus': 'Falha ao guardar',
-	'page.journal.caretaker.photos': 'Fotos',
-	'page.journal.caretaker.addPhoto': '+ Adicionar foto',
-	'page.journal.caretaker.dropPhotos': 'Arraste fotos para aqui ou clique para enviar',
+	'page.journal.caretaker.media': 'Fotos e vídeos',
+	'page.journal.caretaker.addMedia': '+ Adicionar conteúdo',
+	'page.journal.caretaker.dropMedia': 'Arraste fotos ou vídeos para aqui ou clique para enviar',
 	'page.journal.caretaker.noCaption': 'Sem legenda',
 	'page.journal.caretaker.addCaption': 'Adicionar legenda…',
 	'page.journal.caretaker.editCaption': 'Editar legenda',
@@ -602,7 +590,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.anchorMonthFromDueDate': 'Mesma data que o vencimento',
 	'page.reminders.anchorMonthSpecificDay': 'Dia específico',
 	'page.reminders.anchorMonthClampWarning': 'Meses sem este dia usam o último dia.',
-	'page.reminders.anchorYearLabel': 'Na data',
 	'page.reminders.anchorYearMonth': 'Mês',
 	'page.reminders.anchorYearDay': 'Dia',
 	'page.reminders.anchorYearFromDueDate': 'Mesma data que o vencimento',
@@ -711,12 +698,12 @@ const messages: Record<keyof Messages, string> = {
 	'aria.mainNav': 'Navegação principal',
 	'aria.moreActions': 'Mais ações',
 	'aria.deleteEntry': 'Eliminar entrada',
-	'aria.deletePhoto': 'Eliminar foto',
-	'aria.downloadPhoto': 'Baixar foto',
+	'aria.deleteMedia': 'Eliminar mídia',
+	'aria.downloadMedia': 'Baixar mídia',
 	'aria.closeDialog': 'Fechar diálogo',
 	'aria.close': 'Fechar',
-	'aria.previousPhoto': 'Foto anterior',
-	'aria.nextPhoto': 'Próxima foto',
+	'aria.previousMedia': 'Mídia anterior',
+	'aria.nextMedia': 'Próxima mídia',
 	'aria.viewPhoto': 'Ver foto de {name}',
 
 	// Immich picker
@@ -727,10 +714,9 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Fechar seletor',
 	'immich.picker.loadError': 'Não foi possível carregar a biblioteca do Immich.',
 	'immich.picker.button': 'Escolher do Immich',
-	'immich.picker.pickFailed': 'Não foi possível anexar o item do Immich.',
+	'immich.picker.pickFailed': 'Não foi possível anexar o item do Immich.'
 
 	// Meta
-	'meta.description': 'EinVault: diário privado de saúde e cuidados caninos'
 } satisfies Record<keyof Messages, string>;
 
 export default messages;

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -1,0 +1,10 @@
+// Client-safe helpers for journal media. The server stores photos and videos
+// in the same table; the row's mimeType (or mediaType) tells them apart.
+
+/** File input `accept` value for the journal media picker (images + videos). */
+export const MEDIA_ACCEPT =
+	'image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm,video/quicktime';
+
+export function isVideoMime(mime: string | null | undefined): boolean {
+	return !!mime && mime.startsWith('video/');
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -139,6 +139,9 @@ export const journalPhotos = sqliteTable(
 			.default('local'),
 		storageKey: text('storage_key'),
 		originalName: text('original_name'),
+		mediaType: text('media_type', { enum: ['photo', 'video'] })
+			.notNull()
+			.default('photo'),
 		mimeType: text('mime_type').notNull(),
 		sizeBytes: integer('size_bytes').notNull(),
 		notes: text('notes'),

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -29,7 +29,21 @@ function envNonNegativeInt(value: string | undefined, defaultValue: number): num
 }
 
 export const UPLOAD_MAX_MB = envInt(env.UPLOAD_MAX_MB, 10);
-export const MAX_DAILY_PHOTOS = envInt(env.MAX_DAILY_PHOTOS, 5);
+export const VIDEO_MAX_MB = envInt(env.VIDEO_MAX_MB, 100);
+
+// MAX_DAILY_PHOTOS was renamed to MAX_DAILY_MEDIA when journal video support
+// landed: the daily cap now counts photos and videos together. The old name is
+// still honored as a fallback; logDeprecatedEnvWarnings() warns about it at boot.
+export const MAX_DAILY_MEDIA = envInt(env.MAX_DAILY_MEDIA ?? env.MAX_DAILY_PHOTOS, 5);
+
+export function logDeprecatedEnvWarnings(): void {
+	if (env.MAX_DAILY_PHOTOS !== undefined) {
+		console.warn(
+			'[env] MAX_DAILY_PHOTOS is deprecated and will be removed in a future release. ' +
+				'Rename it to MAX_DAILY_MEDIA. The cap now counts photos and videos together.'
+		);
+	}
+}
 
 // Storage backend selection. 'local' writes to DATA_DIR/uploads; 's3' uses an
 // S3-compatible bucket (AWS, Garage, MinIO, Backblaze B2, R2, ...). Reads

--- a/src/lib/server/storage/local.ts
+++ b/src/lib/server/storage/local.ts
@@ -16,6 +16,36 @@ function resolveKey(key: string): string {
 	return full;
 }
 
+// Parse a single-range `bytes=start-end` header against a known size. Returns
+// inclusive start/end offsets, or null for absent/multi/malformed/unsatisfiable
+// ranges (caller then serves the full object).
+function parseRange(
+	header: string | null | undefined,
+	size: number
+): { start: number; end: number } | null {
+	if (!header || size === 0) return null;
+	const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+	if (!m) return null;
+	const [, rawStart, rawEnd] = m;
+	let start: number;
+	let end: number;
+	if (rawStart === '') {
+		// Suffix range: last N bytes.
+		if (rawEnd === '') return null;
+		const suffix = Number(rawEnd);
+		if (suffix <= 0) return null;
+		start = Math.max(0, size - suffix);
+		end = size - 1;
+	} else {
+		start = Number(rawStart);
+		end = rawEnd === '' ? size - 1 : Number(rawEnd);
+	}
+	if (!Number.isInteger(start) || !Number.isInteger(end)) return null;
+	if (start > end || start >= size) return null;
+	if (end >= size) end = size - 1;
+	return { start, end };
+}
+
 function makeStat(size: number, mtimeMs: number, mtime: Date): BlobStat {
 	return {
 		size,
@@ -46,6 +76,21 @@ export const LocalBackend: StorageBackend = {
 		if (opts?.ifNoneMatch && opts.ifNoneMatch === blobStat.etag) {
 			return { kind: 'notModified', etag: blobStat.etag };
 		}
+
+		// Honor a single byte range (enough for <video> seeking). Multi-range and
+		// unsatisfiable/malformed values fall back to a full 200 response.
+		const range = parseRange(opts?.range, s.size);
+		if (range) {
+			return {
+				kind: 'stream',
+				stream: Readable.toWeb(
+					createReadStream(full, { start: range.start, end: range.end })
+				) as ReadableStream,
+				stat: blobStat,
+				range: { start: range.start, end: range.end, total: s.size }
+			};
+		}
+
 		return {
 			kind: 'stream',
 			stream: Readable.toWeb(createReadStream(full)) as ReadableStream,

--- a/src/lib/server/storage/mime.ts
+++ b/src/lib/server/storage/mime.ts
@@ -11,8 +11,25 @@ export const ALLOWED_PHOTO_MIME = [
 
 export const ALLOWED_AVATAR_MIME = ['image/jpeg', 'image/png', 'image/webp'] as const;
 
+// Video formats accepted for journal media. quicktime covers .mov files from
+// iPhones. Videos are stored as-is (no transcode), so we keep to the widely
+// browser-playable container/codec combinations.
+export const ALLOWED_VIDEO_MIME = ['video/mp4', 'video/webm', 'video/quicktime'] as const;
+
 export function isAllowedPhotoMime(mime: string | null | undefined): boolean {
 	return !!mime && (ALLOWED_PHOTO_MIME as readonly string[]).includes(mime);
+}
+
+export function isAllowedVideoMime(mime: string | null | undefined): boolean {
+	return !!mime && (ALLOWED_VIDEO_MIME as readonly string[]).includes(mime);
+}
+
+// Safe lowercase file extension for an accepted video mime type.
+export function videoExtFromMime(mime: string): string {
+	if (mime === 'video/mp4') return 'mp4';
+	if (mime === 'video/webm') return 'webm';
+	if (mime === 'video/quicktime') return 'mov';
+	return 'mp4';
 }
 
 export function isAllowedAvatarMime(mime: string | null | undefined): boolean {

--- a/src/lib/server/storage/mime.ts
+++ b/src/lib/server/storage/mime.ts
@@ -24,6 +24,28 @@ export function isAllowedVideoMime(mime: string | null | undefined): boolean {
 	return !!mime && (ALLOWED_VIDEO_MIME as readonly string[]).includes(mime);
 }
 
+// Lightweight container sniff confirming an accepted video mime actually looks
+// like that container, mirroring the GIF magic-byte check on the image path.
+// Not a full parse: it just rejects obviously-mislabeled uploads (e.g. an HTML
+// document sent as video/mp4) as defense in depth.
+export function looksLikeVideo(bytes: Uint8Array, mime: string): boolean {
+	if (mime === 'video/webm') {
+		// Matroska/WebM EBML header: 1A 45 DF A3
+		return (
+			bytes.length >= 4 &&
+			bytes[0] === 0x1a &&
+			bytes[1] === 0x45 &&
+			bytes[2] === 0xdf &&
+			bytes[3] === 0xa3
+		);
+	}
+	// mp4 / quicktime use the ISO base media format: bytes 4..8 hold the first
+	// box type, almost always 'ftyp'. Allow the other common leading boxes too.
+	if (bytes.length < 12) return false;
+	const box = String.fromCharCode(bytes[4], bytes[5], bytes[6], bytes[7]);
+	return ['ftyp', 'moov', 'mdat', 'free', 'skip', 'wide'].includes(box);
+}
+
 // Safe lowercase file extension for an accepted video mime type.
 export function videoExtFromMime(mime: string): string {
 	if (mime === 'video/mp4') return 'mp4';

--- a/src/lib/server/storage/s3.ts
+++ b/src/lib/server/storage/s3.ts
@@ -59,6 +59,9 @@ export function createS3Backend(config: S3Config): StorageBackend {
 			// Issue a presigned GET URL. Caller redirects browser to it.
 			// We do not HEAD first — if the object is missing the eventual fetch
 			// will 404, which is acceptable for a homelab.
+			// Range requests are intentionally not handled here: the browser follows
+			// the 302 and re-issues its Range header directly to S3, which serves the
+			// 206 itself. So <video> seeking works without us proxying bytes.
 			const url = `${objectUrl(key)}?X-Amz-Expires=${config.presignTtlSeconds}`;
 			const signed = await aws.sign(new Request(url, { method: 'GET' }), {
 				aws: { signQuery: true }

--- a/src/lib/server/storage/types.ts
+++ b/src/lib/server/storage/types.ts
@@ -13,12 +13,22 @@ export interface BlobStat {
 }
 
 export type GetResult =
-	| { kind: 'stream'; stream: ReadableStream; stat: BlobStat }
+	| {
+			kind: 'stream';
+			stream: ReadableStream;
+			stat: BlobStat;
+			// Present when the response satisfies a byte-range request (HTTP 206).
+			// `total` is the full object size; `start`/`end` are inclusive offsets.
+			range?: { start: number; end: number; total: number };
+	  }
 	| { kind: 'redirect'; url: string; cacheSeconds: number }
 	| { kind: 'notModified'; etag: string };
 
 export interface GetOptions {
 	ifNoneMatch?: string | null;
+	// Raw value of the request's `Range` header, if any. Backends that can serve
+	// partial content (local files) honor it; others ignore it.
+	range?: string | null;
 }
 
 export interface StorageBackend {

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -12,8 +12,11 @@
 		Pencil,
 		NotebookPen,
 		ArrowRight,
-		Download
+		Download,
+		Play
 	} from '@lucide/svelte';
+	import { isVideoMime } from '$lib/media';
+	import JournalVideo from '$lib/components/JournalVideo.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
 	import { tick } from 'svelte';
@@ -203,7 +206,7 @@
 		bind:this={lightboxEl}
 		role="dialog"
 		aria-modal="true"
-		aria-label={t(locale, 'page.journal.photoLightboxLabel')}
+		aria-label={t(locale, 'page.journal.mediaLightboxLabel')}
 		tabindex="-1"
 		class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/85 focus:outline-none"
 		onclick={closeLightbox}
@@ -229,7 +232,7 @@
 						href={photoUrl(lightboxPhoto, lightboxDate)}
 						download={lightboxPhoto.originalName ?? lightboxPhoto.filename}
 						class="text-white/70 hover:text-white p-1 rounded"
-						aria-label={t(locale, 'aria.downloadPhoto')}
+						aria-label={t(locale, 'aria.downloadMedia')}
 					>
 						<Download class="h-5 w-5" />
 					</a>
@@ -245,11 +248,21 @@
 			</div>
 
 			<div class="relative">
-				<img
-					src={photoUrl(lightboxPhoto, lightboxDate)}
-					alt={lightboxPhoto.originalName ?? ''}
-					class="max-h-[78vh] w-full object-contain rounded-lg"
-				/>
+				{#if isVideoMime(lightboxPhoto.mimeType)}
+					<JournalVideo
+						src={photoUrl(lightboxPhoto, lightboxDate)}
+						downloadName={lightboxPhoto.originalName}
+						label={lightboxPhoto.originalName ?? undefined}
+						autoplay
+						class="max-h-[78vh] w-full object-contain rounded-lg bg-black"
+					/>
+				{:else}
+					<img
+						src={photoUrl(lightboxPhoto, lightboxDate)}
+						alt={lightboxPhoto.originalName ?? ''}
+						class="max-h-[78vh] w-full object-contain rounded-lg"
+					/>
+				{/if}
 				{#if lightboxPhotos.length > 1}
 					<button
 						type="button"
@@ -259,7 +272,7 @@
 						0
 							? 'opacity-20 cursor-default'
 							: 'opacity-70 hover:opacity-100'}"
-						aria-label={t(locale, 'aria.previousPhoto')}
+						aria-label={t(locale, 'aria.previousMedia')}
 					>
 						<ChevronLeft class="h-5 w-5" />
 					</button>
@@ -271,7 +284,7 @@
 						lightboxPhotos.length - 1
 							? 'opacity-20 cursor-default'
 							: 'opacity-70 hover:opacity-100'}"
-						aria-label={t(locale, 'aria.nextPhoto')}
+						aria-label={t(locale, 'aria.nextMedia')}
 					>
 						<ChevronRight class="h-5 w-5" />
 					</button>
@@ -485,17 +498,35 @@
 								<button
 									type="button"
 									onclick={() => openLightbox(entry.photos, entry.date, i)}
-									class="block overflow-hidden {entry.photos.length === 1
+									class="relative block overflow-hidden {entry.photos.length === 1
 										? 'aspect-video'
 										: 'aspect-square'} hover:opacity-95 transition-opacity"
 									title={photo.originalName ?? 'Journal photo'}
 								>
-									<img
-										src={photoUrl(photo, entry.date)}
-										alt={photo.originalName ?? ''}
-										class="w-full h-full object-cover"
-										loading="lazy"
-									/>
+									{#if isVideoMime(photo.mimeType)}
+										<video
+											src={photoUrl(photo, entry.date)}
+											preload="metadata"
+											muted
+											playsinline
+											class="w-full h-full object-cover pointer-events-none"
+										></video>
+										<span
+											class="absolute inset-0 flex items-center justify-center bg-black/20"
+											aria-hidden="true"
+										>
+											<span class="rounded-full bg-black/55 p-2">
+												<Play class="h-5 w-5 text-white" />
+											</span>
+										</span>
+									{:else}
+										<img
+											src={photoUrl(photo, entry.date)}
+											alt={photo.originalName ?? ''}
+											class="w-full h-full object-cover"
+											loading="lazy"
+										/>
+									{/if}
 								</button>
 							{/each}
 						</div>

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -15,7 +15,6 @@
 		Download,
 		Play
 	} from '@lucide/svelte';
-	import { isVideoMime } from '$lib/media';
 	import JournalVideo from '$lib/components/JournalVideo.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
@@ -248,7 +247,7 @@
 			</div>
 
 			<div class="relative">
-				{#if isVideoMime(lightboxPhoto.mimeType)}
+				{#if lightboxPhoto.mediaType === 'video'}
 					<JournalVideo
 						src={photoUrl(lightboxPhoto, lightboxDate)}
 						downloadName={lightboxPhoto.originalName}
@@ -501,9 +500,15 @@
 									class="relative block overflow-hidden {entry.photos.length === 1
 										? 'aspect-video'
 										: 'aspect-square'} hover:opacity-95 transition-opacity"
-									title={photo.originalName ?? 'Journal photo'}
+									title={photo.originalName ??
+										t(
+											locale,
+											photo.mediaType === 'video'
+												? 'page.journal.videoAlt'
+												: 'page.journal.photoAlt'
+										)}
 								>
-									{#if isVideoMime(photo.mimeType)}
+									{#if photo.mediaType === 'video'}
 										<video
 											src={photoUrl(photo, entry.date)}
 											preload="metadata"

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
@@ -7,7 +7,7 @@ import { generateId } from '$lib/server/utils';
 import { parseMood, parseDailyEventType, isValidDate } from '$lib/server/validation';
 import { localDateISO } from '$lib/date';
 import { upsertJournalEntry } from '$lib/server/journal';
-import { MAX_DAILY_PHOTOS, UPLOAD_MAX_MB } from '$lib/server/env';
+import { MAX_DAILY_MEDIA, UPLOAD_MAX_MB, VIDEO_MAX_MB } from '$lib/server/env';
 
 export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -67,7 +67,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		today,
 		isToday: date === today,
 		uploadMaxMb: UPLOAD_MAX_MB,
-		maxDailyPhotos: MAX_DAILY_PHOTOS
+		videoMaxMb: VIDEO_MAX_MB,
+		maxDailyMedia: MAX_DAILY_MEDIA
 	};
 };
 

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -687,7 +687,8 @@
 
 		{#if uploadError}
 			<div
-				class="mx-4 my-3 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-600 dark:text-red-300"
+				role="alert"
+				class="mx-4 my-3 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
 			>
 				{uploadError}
 			</div>
@@ -722,16 +723,17 @@
 					{#each photos as photo (photo.id)}
 						<div class="flex gap-3 items-start">
 							<div
-								class="group relative shrink-0 {isVideoMime(photo.mimeType)
+								class="group relative shrink-0 {photo.mediaType === 'video'
 									? 'w-40'
 									: 'w-24'} h-24 rounded-lg overflow-hidden bg-stone-100 dark:bg-stone-800"
 							>
-								{#if isVideoMime(photo.mimeType)}
+								{#if photo.mediaType === 'video'}
 									<JournalVideo
 										src={photoUrl(photo)}
 										downloadName={photo.originalName}
 										label={photo.originalName ?? undefined}
 										class="w-full h-full object-cover"
+										compact
 									/>
 								{:else}
 									<img

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -6,6 +6,8 @@
 	import { enhance } from '$app/forms';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import { canModifyPhoto } from '$lib/permissions';
+	import { isVideoMime, MEDIA_ACCEPT } from '$lib/media';
+	import JournalVideo from '$lib/components/JournalVideo.svelte';
 	import { localDateISO } from '$lib/date';
 	import { getContext } from 'svelte';
 
@@ -115,8 +117,8 @@
 	}
 
 	async function uploadPhoto(file: File) {
-		if (photos.length >= data.maxDailyPhotos) {
-			setUploadError(t(locale, 'error.maxPhotosExceeded', { max: data.maxDailyPhotos }));
+		if (photos.length >= data.maxDailyMedia) {
+			setUploadError(t(locale, 'error.maxMediaExceeded', { max: data.maxDailyMedia }));
 			return;
 		}
 		uploadError = '';
@@ -144,6 +146,7 @@
 					storageKey,
 					entryId: data.entry?.id ?? '',
 					originalName: file.name,
+					mediaType: isVideoMime(file.type) ? 'video' : 'photo',
 					mimeType: file.type,
 					sizeBytes: file.size,
 					notes: null,
@@ -196,7 +199,7 @@
 		const files = (e.target as HTMLInputElement).files;
 		if (!files?.length) return;
 		for (const file of Array.from(files)) {
-			if (photos.length < data.maxDailyPhotos) uploadPhoto(file);
+			if (photos.length < data.maxDailyMedia) uploadPhoto(file);
 		}
 		if (fileInputEl) fileInputEl.value = '';
 	}
@@ -643,12 +646,12 @@
 		<div class="flex items-center justify-between px-5 py-3 border-b border-border">
 			<h2 class="font-semibold flex items-center gap-2 text-foreground">
 				<Camera class="h-4 w-4" />
-				{t(locale, 'page.journal.day.photosTitle')}
+				{t(locale, 'page.journal.day.mediaTitle')}
 				<span class="text-xs font-normal text-muted-foreground"
-					>{photos.length}/{data.maxDailyPhotos}</span
+					>{photos.length}/{data.maxDailyMedia}</span
 				>
 			</h2>
-			{#if photos.length < data.maxDailyPhotos}
+			{#if photos.length < data.maxDailyMedia}
 				<div class="flex items-center gap-2">
 					{#if data.immichEnabled}
 						<button
@@ -666,12 +669,12 @@
 						{#if uploading}{t(locale, 'page.journal.day.uploading')}{:else}<Plus
 								class="h-3.5 w-3.5"
 							/>
-							{t(locale, 'page.journal.day.addPhoto')}{/if}
+							{t(locale, 'page.journal.day.addMedia')}{/if}
 						<input
 							bind:this={fileInputEl}
 							type="file"
 							name="photos"
-							accept="image/jpeg,image/png,image/webp,image/gif"
+							accept={MEDIA_ACCEPT}
 							multiple
 							class="sr-only"
 							onchange={handleFileInput}
@@ -684,7 +687,7 @@
 
 		{#if uploadError}
 			<div
-				class="mx-4 mb-3 rounded-lg bg-destructive/10 border border-destructive/20 px-3 py-2 text-sm text-destructive"
+				class="mx-4 my-3 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-600 dark:text-red-300"
 			>
 				{uploadError}
 			</div>
@@ -697,15 +700,18 @@
 				>
 					<ImageIcon class="h-8 w-8 mb-2 text-muted-foreground" />
 					<span class="text-sm text-muted-foreground"
-						>{t(locale, 'page.journal.day.dropPhotos')}</span
+						>{t(locale, 'page.journal.day.dropMedia')}</span
 					>
 					<span class="text-xs mt-1 text-muted-foreground"
-						>{t(locale, 'page.journal.day.photoTypes', { max: data.uploadMaxMb })}</span
+						>{t(locale, 'page.journal.day.mediaTypes', {
+							imgMax: data.uploadMaxMb,
+							vidMax: data.videoMaxMb
+						})}</span
 					>
 					<input
 						type="file"
 						name="photos"
-						accept="image/jpeg,image/png,image/webp,image/gif"
+						accept={MEDIA_ACCEPT}
 						multiple
 						class="sr-only"
 						onchange={handleFileInput}
@@ -716,14 +722,25 @@
 					{#each photos as photo (photo.id)}
 						<div class="flex gap-3 items-start">
 							<div
-								class="group relative shrink-0 w-24 h-24 rounded-lg overflow-hidden bg-stone-100 dark:bg-stone-800"
+								class="group relative shrink-0 {isVideoMime(photo.mimeType)
+									? 'w-40'
+									: 'w-24'} h-24 rounded-lg overflow-hidden bg-stone-100 dark:bg-stone-800"
 							>
-								<img
-									src={photoUrl(photo)}
-									alt={photo.originalName ?? t(locale, 'page.journal.photoAlt')}
-									class="w-full h-full object-cover"
-									loading="lazy"
-								/>
+								{#if isVideoMime(photo.mimeType)}
+									<JournalVideo
+										src={photoUrl(photo)}
+										downloadName={photo.originalName}
+										label={photo.originalName ?? undefined}
+										class="w-full h-full object-cover"
+									/>
+								{:else}
+									<img
+										src={photoUrl(photo)}
+										alt={photo.originalName ?? t(locale, 'page.journal.photoAlt')}
+										class="w-full h-full object-cover"
+										loading="lazy"
+									/>
+								{/if}
 								{#if canModifyPhoto(data.user, photo)}
 									<button
 										type="button"
@@ -731,7 +748,7 @@
 										class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
 										flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
 										hover:bg-red-600 transition-all"
-										aria-label={t(locale, 'aria.deletePhoto')}
+										aria-label={t(locale, 'aria.deleteMedia')}
 									>
 										<Trash2 class="h-3 w-3" />
 									</button>

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
@@ -7,7 +7,7 @@ import { parseMood } from '$lib/server/validation';
 import { getShiftStatus } from '$lib/server/shifts';
 import { localDateISO } from '$lib/date';
 import { upsertJournalEntry } from '$lib/server/journal';
-import { MAX_DAILY_PHOTOS } from '$lib/server/env';
+import { MAX_DAILY_MEDIA } from '$lib/server/env';
 
 export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	const { companions, isOnShift } = await parent();
@@ -23,7 +23,7 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	const today = localDateISO();
 
 	if (!isOnShift) {
-		return { companion, todayEntry: null, photos: [], today, maxDailyPhotos: MAX_DAILY_PHOTOS };
+		return { companion, todayEntry: null, photos: [], today, maxDailyMedia: MAX_DAILY_MEDIA };
 	}
 
 	const todayEntry = await db.query.journalEntries.findFirst({
@@ -47,7 +47,7 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 		todayEntry: todayEntry ?? null,
 		photos,
 		today,
-		maxDailyPhotos: MAX_DAILY_PHOTOS
+		maxDailyMedia: MAX_DAILY_MEDIA
 	};
 };
 

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -3,6 +3,8 @@
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import { stripMarkdown } from '$lib/markdown';
 	import { canModifyPhoto } from '$lib/permissions';
+	import { isVideoMime, MEDIA_ACCEPT } from '$lib/media';
+	import JournalVideo from '$lib/components/JournalVideo.svelte';
 	import { Trash2 } from '@lucide/svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
@@ -66,8 +68,8 @@
 	}
 
 	async function uploadPhoto(file: File) {
-		if (photos.length >= data.maxDailyPhotos) {
-			setUploadError(t(locale, 'error.maxPhotosExceeded', { max: data.maxDailyPhotos }));
+		if (photos.length >= data.maxDailyMedia) {
+			setUploadError(t(locale, 'error.maxMediaExceeded', { max: data.maxDailyMedia }));
 			return;
 		}
 		uploadError = '';
@@ -95,6 +97,7 @@
 					storageKey,
 					entryId: data.todayEntry?.id ?? '',
 					originalName: file.name,
+					mediaType: isVideoMime(file.type) ? 'video' : 'photo',
 					mimeType: file.type,
 					sizeBytes: file.size,
 					notes: null,
@@ -144,7 +147,7 @@
 		const files = (e.target as HTMLInputElement).files;
 		if (!files?.length) return;
 		for (const file of Array.from(files)) {
-			if (photos.length < data.maxDailyPhotos) uploadPhoto(file);
+			if (photos.length < data.maxDailyMedia) uploadPhoto(file);
 		}
 		if (fileInputEl) fileInputEl.value = '';
 	}
@@ -268,16 +271,16 @@
 			<CardHeader class="pb-3 flex flex-row items-center justify-between">
 				<h2 class="font-semibold flex items-center gap-2">
 					<span>📷</span>
-					{t(locale, 'page.journal.caretaker.photos')}
+					{t(locale, 'page.journal.caretaker.media')}
 					<span class="text-xs font-normal text-muted-foreground"
-						>{photos.length}/{data.maxDailyPhotos}</span
+						>{photos.length}/{data.maxDailyMedia}</span
 					>
 				</h2>
-				{#if photos.length < data.maxDailyPhotos}
+				{#if photos.length < data.maxDailyMedia}
 					<label
 						class="inline-flex items-center justify-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent hover:text-accent-foreground cursor-pointer transition-colors"
 					>
-						{uploading ? t(locale, 'common.loading') : t(locale, 'page.journal.caretaker.addPhoto')}
+						{uploading ? t(locale, 'common.loading') : t(locale, 'page.journal.caretaker.addMedia')}
 						<input
 							bind:this={fileInputEl}
 							type="file"
@@ -293,7 +296,7 @@
 			</CardHeader>
 			{#if uploadError}
 				<div
-					class="mx-4 mb-3 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-3 py-2 text-sm text-red-600 dark:text-red-300"
+					class="mx-4 my-3 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-600 dark:text-red-300"
 				>
 					{uploadError}
 				</div>
@@ -306,12 +309,12 @@
 					>
 						<span class="text-3xl mb-2">🖼️</span>
 						<span class="text-sm text-muted-foreground"
-							>{t(locale, 'page.journal.caretaker.dropPhotos')}</span
+							>{t(locale, 'page.journal.caretaker.dropMedia')}</span
 						>
 						<input
 							type="file"
 							name="photos"
-							accept="image/jpeg,image/png,image/webp,image/gif"
+							accept={MEDIA_ACCEPT}
 							multiple
 							class="sr-only"
 							onchange={handleFileInput}
@@ -322,18 +325,29 @@
 						{#each photos as photo (photo.id)}
 							<div class="flex gap-3 items-start">
 								<div
-									class="group relative shrink-0 w-24 h-24 rounded-lg overflow-hidden bg-stone-100 dark:bg-stone-800"
+									class="group relative shrink-0 {isVideoMime(photo.mimeType)
+										? 'w-40'
+										: 'w-24'} h-24 rounded-lg overflow-hidden bg-stone-100 dark:bg-stone-800"
 								>
-									<img
-										src={photoUrl(photo)}
-										alt={photo.originalName ?? t(locale, 'page.journal.photoAlt')}
-										class="w-full h-full object-cover"
-										loading="lazy"
-									/>
+									{#if isVideoMime(photo.mimeType)}
+										<JournalVideo
+											src={photoUrl(photo)}
+											downloadName={photo.originalName}
+											label={photo.originalName ?? undefined}
+											class="w-full h-full object-cover"
+										/>
+									{:else}
+										<img
+											src={photoUrl(photo)}
+											alt={photo.originalName ?? t(locale, 'page.journal.photoAlt')}
+											class="w-full h-full object-cover"
+											loading="lazy"
+										/>
+									{/if}
 									{#if canModifyPhoto(data.user, photo)}
 										<button
 											onclick={() => deletePhoto(photo.id)}
-											aria-label={t(locale, 'aria.deletePhoto')}
+											aria-label={t(locale, 'aria.deleteMedia')}
 											class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
 											flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
 											hover:bg-red-600 transition-all"
@@ -393,7 +407,7 @@
 								</div>
 							</div>
 						{/each}
-						{#if photos.length < data.maxDailyPhotos}
+						{#if photos.length < data.maxDailyMedia}
 							<label
 								class="aspect-square w-24 rounded-lg border-2 border-dashed flex flex-col items-center
 							justify-center cursor-pointer hover:opacity-80 transition-colors"

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -296,7 +296,8 @@
 			</CardHeader>
 			{#if uploadError}
 				<div
-					class="mx-4 my-3 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-600 dark:text-red-300"
+					role="alert"
+					class="mx-4 my-3 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
 				>
 					{uploadError}
 				</div>
@@ -325,16 +326,17 @@
 						{#each photos as photo (photo.id)}
 							<div class="flex gap-3 items-start">
 								<div
-									class="group relative shrink-0 {isVideoMime(photo.mimeType)
+									class="group relative shrink-0 {photo.mediaType === 'video'
 										? 'w-40'
 										: 'w-24'} h-24 rounded-lg overflow-hidden bg-stone-100 dark:bg-stone-800"
 								>
-									{#if isVideoMime(photo.mimeType)}
+									{#if photo.mediaType === 'video'}
 										<JournalVideo
 											src={photoUrl(photo)}
 											downloadName={photo.originalName}
 											label={photo.originalName ?? undefined}
 											class="w-full h-full object-cover"
+											compact
 										/>
 									{:else}
 										<img

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
@@ -76,7 +76,8 @@
 
 		{#if form?.error}
 			<div
-				class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-600 dark:text-red-300"
+				role="alert"
+				class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
 			>
 				{form.error}
 			</div>

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
@@ -76,7 +76,7 @@
 
 		{#if form?.error}
 			<div
-				class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
+				class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-600 dark:text-red-300"
 			>
 				{form.error}
 			</div>

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -6,12 +6,14 @@ import { eq, and, count } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 import sharp from 'sharp';
 import { getStorage, STORAGE_BACKEND } from '$lib/server/storage';
-import { MAX_DAILY_PHOTOS, UPLOAD_MAX_MB } from '$lib/server/env';
+import { MAX_DAILY_MEDIA, UPLOAD_MAX_MB, VIDEO_MAX_MB } from '$lib/server/env';
+import { isAllowedVideoMime, videoExtFromMime } from '$lib/server/storage/mime';
 import { canModifyPhoto } from '$lib/permissions';
 import { isValidDate } from '$lib/server/validation';
 
-const MAX_FILE_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
-const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const MAX_IMAGE_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
+const MAX_VIDEO_SIZE = VIDEO_MAX_MB * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 
 function journalKey(companionId: string, date: string, filename: string): string {
 	return `journal/${companionId}/${date}/${filename}`;
@@ -56,25 +58,39 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		.from(schema.journalPhotos)
 		.where(eq(schema.journalPhotos.entryId, entry.id));
 
-	if (photoCount >= MAX_DAILY_PHOTOS) {
-		error(400, t(locals.locale, 'error.maxPhotosExceeded', { max: MAX_DAILY_PHOTOS }));
+	if (photoCount >= MAX_DAILY_MEDIA) {
+		error(400, t(locals.locale, 'error.maxMediaExceeded', { max: MAX_DAILY_MEDIA }));
 	}
 
 	const formData = await request.formData();
 	const file = formData.get('photo') as File | null;
 
 	if (!file || file.size === 0) error(400, t(locals.locale, 'error.noFileProvided'));
-	if (file.size > MAX_FILE_SIZE)
+
+	const isVideo = isAllowedVideoMime(file.type);
+	if (!isVideo && !ALLOWED_IMAGE_TYPES.includes(file.type))
+		error(400, t(locals.locale, 'error.invalidFileType'));
+
+	if (isVideo) {
+		if (file.size > MAX_VIDEO_SIZE)
+			error(400, t(locals.locale, 'error.fileTooLarge', { max: VIDEO_MAX_MB }));
+	} else if (file.size > MAX_IMAGE_SIZE) {
 		error(400, t(locals.locale, 'error.fileTooLarge', { max: UPLOAD_MAX_MB }));
-	if (!ALLOWED_TYPES.includes(file.type)) error(400, t(locals.locale, 'error.invalidFileType'));
+	}
 
 	const raw = Buffer.from(await file.arrayBuffer());
 	const photoId = generateId(15);
 	let processed: Buffer;
 	let ext: string;
 	let mimeType: string;
+	const mediaType: 'photo' | 'video' = isVideo ? 'video' : 'photo';
 
-	if (file.type === 'image/gif') {
+	if (isVideo) {
+		// Videos are stored as-is: no server-side transcode or resize.
+		processed = raw;
+		ext = videoExtFromMime(file.type);
+		mimeType = file.type;
+	} else if (file.type === 'image/gif') {
 		// Validate GIF magic bytes before passing through
 		const sig = raw.slice(0, 6).toString('ascii');
 		if (sig !== 'GIF87a' && sig !== 'GIF89a') {
@@ -114,6 +130,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		provider: STORAGE_BACKEND,
 		storageKey: key,
 		originalName: file.name,
+		mediaType,
 		mimeType,
 		sizeBytes: processed.length,
 		loggedBy: locals.user.id

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -7,7 +7,7 @@ import { generateId } from '$lib/server/utils';
 import sharp from 'sharp';
 import { getStorage, STORAGE_BACKEND } from '$lib/server/storage';
 import { MAX_DAILY_MEDIA, UPLOAD_MAX_MB, VIDEO_MAX_MB } from '$lib/server/env';
-import { isAllowedVideoMime, videoExtFromMime } from '$lib/server/storage/mime';
+import { isAllowedVideoMime, looksLikeVideo, videoExtFromMime } from '$lib/server/storage/mime';
 import { canModifyPhoto } from '$lib/permissions';
 import { isValidDate } from '$lib/server/validation';
 
@@ -86,6 +86,9 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	const mediaType: 'photo' | 'video' = isVideo ? 'video' : 'photo';
 
 	if (isVideo) {
+		// Confirm the bytes match the declared container before trusting the
+		// client mime type (we store videos as-is, with no re-encode to sanitize).
+		if (!looksLikeVideo(raw, file.type)) error(400, t(locals.locale, 'error.invalidFileType'));
 		// Videos are stored as-is: no server-side transcode or resize.
 		processed = raw;
 		ext = videoExtFromMime(file.type);

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
@@ -6,7 +6,7 @@ import { eq, and, count } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 import { getImmichClient, immichKey, IMMICH_ASSET_ID_RE } from '$lib/server/storage';
 import { isAllowedPhotoMime, safeExtFromMime } from '$lib/server/storage/mime';
-import { MAX_DAILY_PHOTOS } from '$lib/server/env';
+import { MAX_DAILY_MEDIA } from '$lib/server/env';
 import { isValidDate } from '$lib/server/validation';
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
@@ -77,7 +77,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 				.where(eq(schema.journalPhotos.entryId, entryId))
 				.all();
 			const photoCount = rows[0]?.value ?? 0;
-			if (photoCount >= MAX_DAILY_PHOTOS) {
+			if (photoCount >= MAX_DAILY_MEDIA) {
 				return { ok: false as const };
 			}
 			tx.insert(schema.journalPhotos)
@@ -99,7 +99,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	);
 
 	if (!result.ok) {
-		error(400, t(locals.locale, 'error.maxPhotosExceeded', { max: MAX_DAILY_PHOTOS }));
+		error(400, t(locals.locale, 'error.maxMediaExceeded', { max: MAX_DAILY_MEDIA }));
 	}
 
 	const created = await db.query.journalPhotos.findFirst({

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
@@ -88,6 +88,9 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 					provider: 'immich',
 					storageKey: immichKey(assetId),
 					originalName: asset.originalFileName || null,
+					// Immich picker only surfaces images (videos are filtered out), so
+					// these are always photos.
+					mediaType: 'photo',
 					mimeType: asset.originalMimeType,
 					sizeBytes: asset.fileSizeInByte ?? 0,
 					loggedBy

--- a/src/routes/api/photos/[...path]/+server.ts
+++ b/src/routes/api/photos/[...path]/+server.ts
@@ -46,10 +46,11 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 	// use the row's storage_key column instead.
 	const key = photo.storageKey ?? requestedPath;
 	const ifNoneMatch = request.headers.get('if-none-match');
+	const range = request.headers.get('range');
 
 	let res: GetResult | null;
 	try {
-		res = await getStorage(photo.provider).get(key, { ifNoneMatch });
+		res = await getStorage(photo.provider).get(key, { ifNoneMatch, range });
 	} catch (err) {
 		if (err instanceof Error && err.message.includes('escapes upload root')) {
 			error(403, t(locals.locale, 'error.forbidden'));
@@ -80,13 +81,22 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 	const cacheControl =
 		photo.provider === 'immich' ? 'private, max-age=300' : 'private, max-age=31536000, immutable';
 
-	return new Response(res.stream, {
-		headers: {
-			'Content-Type': photo.mimeType,
-			'Content-Length': String(res.stat.size),
-			'Cache-Control': cacheControl,
-			ETag: res.stat.etag,
-			'X-Content-Type-Options': 'nosniff'
-		}
-	});
+	const headers: Record<string, string> = {
+		'Content-Type': photo.mimeType,
+		'Cache-Control': cacheControl,
+		ETag: res.stat.etag,
+		'X-Content-Type-Options': 'nosniff',
+		// Advertise range support so browsers will seek (needed for <video>).
+		'Accept-Ranges': 'bytes'
+	};
+
+	// Partial content: the backend satisfied a byte-range request.
+	if (res.range) {
+		headers['Content-Range'] = `bytes ${res.range.start}-${res.range.end}/${res.range.total}`;
+		headers['Content-Length'] = String(res.range.end - res.range.start + 1);
+		return new Response(res.stream, { status: 206, headers });
+	}
+
+	headers['Content-Length'] = String(res.stat.size);
+	return new Response(res.stream, { headers });
 };

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -28,6 +28,7 @@ const config = {
 				'style-src': ['self', 'unsafe-inline'],
 				'font-src': ['self'],
 				'img-src': ['self', 'data:', 'blob:'],
+				'media-src': ['self', 'blob:'],
 				'connect-src': ['self'],
 				'frame-ancestors': ['none'],
 				'base-uri': ['self'],


### PR DESCRIPTION
Closes #22.

Journal entries now accept videos alongside photos. Videos are stored as-is (no transcode) on the existing storage backends and play inline, with a graceful download fallback when the browser can't decode the codec.

## Changes
- **Schema:** `media_type` column on `journal_photos` (migration `0013`), distinguishing photo vs video rows.
- **Upload:** accept `video/mp4`, `video/webm`, `video/quicktime`; videos skip image resizing and are stored raw. New `VIDEO_MAX_MB` cap (default 100); daily cap counts photos + videos together.
- **Serving:** the local storage backend now honors HTTP `Range` requests (206) so `<video>` can seek; S3 keeps redirecting to a presigned GET (the browser ranges against the bucket directly).
- **CSP:** added a `media-src` directive and extended the S3-origin injector to cover it, so videos load from the configured S3/Garage origin (previously only `img-src` was patched).
- **UI:** `JournalVideo` component renders the player and falls back to a download link + message on decode error. Wired into the day page, caretaker page, and the journal lightbox.
- **Naming cleanup:** renamed photo-specific identifiers that now cover both media types — env `MAX_DAILY_PHOTOS` → `MAX_DAILY_MEDIA` (old name still honored with a boot-time deprecation warning), plus the relevant i18n keys. Pruned 17 unused i18n keys.
- **Fixes:** dark-mode contrast and padding on the upload error boxes.

## Notes
- Cross-browser playback of unsupported codecs (e.g. HEVC) needs server-side transcoding — deliberately out of scope, tracked in #86. Internal photo-named identifiers (`uploadPhoto`, `photoUrl`, etc.) deferred to #85.
- `npm run check`, `npm run lint`, and `npm run build` all pass. The DB migration applies cleanly.

## Verification
Manual upload/playback in the running app still needs a pass (file-picker flows can't be automated here).