### PR TITLE
Optional server-side video transcoding (#86)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,37 @@ ORIGIN=https://einvault.yourdomain.com
 # (Renamed from MAX_DAILY_PHOTOS, which is still honored but logs a deprecation warning.)
 # MAX_DAILY_MEDIA=5
 
+# Optional: server-side video transcoding (default: off).
+# When enabled, uploaded videos are transcoded to a universal web profile
+# (H.264 + AAC MP4, faststart) with a generated poster, so they play in every
+# browser instead of failing to decode (e.g. Apple HEVC in Firefox). Requires
+# the ffmpeg/ffprobe binaries; the official Docker image ships them. If the
+# binaries are absent the feature self-disables and videos are stored as-is.
+# Transcoding is CPU-intensive and runs in the background after upload.
+# VIDEO_TRANSCODE=true
+#
+# Keep the original source video alongside the transcoded copy (default: true).
+# The original is never served to clients; it is retained for re-encode/backup.
+# Set to false to discard the source after a successful transcode and save space.
+# VIDEO_KEEP_ORIGINAL=true
+#
+# Caps that bound transcode cost. An input exceeding any of these is rejected
+# (stored as-is) instead of transcoded. maxMb defaults to VIDEO_MAX_MB.
+# VIDEO_TRANSCODE_MAX_MB=100
+# VIDEO_TRANSCODE_MAX_SECONDS=600
+# VIDEO_TRANSCODE_MAX_WIDTH=4096
+# VIDEO_TRANSCODE_MAX_HEIGHT=4096
+#
+# Absolute paths to the ffmpeg/ffprobe binaries (defaults below match the Docker
+# image). On host dev (macOS/Homebrew) these may differ, e.g. /opt/homebrew/bin.
+# VIDEO_FFMPEG_PATH=/usr/bin/ffmpeg
+# VIDEO_FFPROBE_PATH=/usr/bin/ffprobe
+#
+# Scratch directory for per-job temp files. MUST be disk-backed and roomy (it
+# holds the original + decode scratch + output). Defaults to a subdir of the
+# data volume. Do NOT point this at the 64 MB RAM tmpfs mounted at /tmp.
+# VIDEO_TMP_DIR=/data/transcode-tmp
+
 # Default undo window (in seconds) for dismissing a Reminder (default: 7).
 # Set to 0 to disable the undo window entirely (dismissals commit immediately).
 # Per-user override available in the settings UI.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,13 @@ FROM ${NODE_IMAGE} AS runner
 
 WORKDIR /app
 
+# ffmpeg/ffprobe for optional server-side video transcoding (issue #86). The
+# feature is off by default (VIDEO_TRANSCODE unset); the binaries ship anyway so
+# operators can enable it by flipping one env var without rebuilding. Alpine's
+# ffmpeg includes the native HEVC decoder (reads Apple-recorded source) and
+# libx264 for H.264 encode. Adds ~100-150MB to the image.
+RUN apk add --no-cache ffmpeg
+
 # Strip npm, npx, corepack, and the bundled yarn from the runtime image. The
 # app starts with `node build` and never invokes a package manager at runtime;
 # keeping them adds attack surface and CVE noise (npm's transitives, etc.).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ EinVault is a private, self-hosted companion health and care tracker built for h
 - [Screenshots](#screenshots)
 - [Production (Docker)](#production-docker)
   - [Other options](#other-options)
+  - [Video transcoding (optional)](#video-transcoding-optional)
   - [External image storage (optional)](#external-image-storage-optional)
   - [Immich integration (optional)](#immich-integration-optional)
   - [Data and backup](#data-and-backup)
@@ -91,12 +92,34 @@ Everything else in the compose file can be edited directly:
 | ----------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `TZ`                    | `UTC`               | Container timezone. Set to your local timezone (e.g. `America/New_York`, `Europe/London`) so dates and times display correctly.                            |
 | `UPLOAD_MAX_MB`         | `10`                | Maximum size in MB for image (photo and avatar) uploads. `BODY_SIZE_LIMIT` is derived from the larger of this and `VIDEO_MAX_MB` at container start.       |
-| `VIDEO_MAX_MB`          | `100`               | Maximum size in MB for journal video uploads. Videos are stored as-is (no transcoding).                                                                    |
+| `VIDEO_MAX_MB`          | `100`               | Maximum size in MB for journal video uploads. Videos are stored as-is unless transcoding is enabled (see below).                                           |
 | `MAX_DAILY_MEDIA`       | `5`                 | Maximum number of journal photos and videos (combined) per companion per day. (Renamed from `MAX_DAILY_PHOTOS`, still honored with a deprecation warning.) |
 | `REMINDER_UNDO_SECONDS` | `7`                 | Default undo window (seconds) when dismissing a Reminder. `0` disables the undo window. Each user can override in their settings.                          |
 | `user`                  | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                                                  |
 | `./data` volume         | `./data`            | Where the database and uploads are stored on the host.                                                                                                     |
 | `DATABASE_URL`          | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                                             |
+
+### Video transcoding (optional)
+
+By default, uploaded videos are stored exactly as received. A browser can only play codecs it supports, so a clip in a format like H.265/HEVC (common from Apple devices) may fail to play and fall back to a download link.
+
+Set `VIDEO_TRANSCODE=true` to convert each uploaded video to a universal web profile (H.264 + AAC in an MP4 with the moov atom at the front) and generate a poster thumbnail. Conversion runs in the background after upload: the video shows a "converting" state and switches to the playable version when it finishes. The feature is off by default because it is CPU-intensive and depends on `ffmpeg`.
+
+`ffmpeg` and `ffprobe` ship in the official Docker image, including the HEVC decoder needed to read Apple-recorded source and `libx264` for H.264 output. If you run outside the image and the binaries are not found, the feature disables itself and videos are stored as-is.
+
+|                               | Default                | Description                                                                                                                                               |
+| ----------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VIDEO_TRANSCODE`             | `false`                | Enable background transcoding of uploaded videos to a web-playable MP4 plus a poster.                                                                     |
+| `VIDEO_KEEP_ORIGINAL`         | `true`                 | Keep the original source file alongside the transcoded copy. The original is never served; it is retained for re-encoding or backup. `false` discards it. |
+| `VIDEO_TRANSCODE_MAX_MB`      | `VIDEO_MAX_MB`         | Skip transcoding (store as-is) for inputs larger than this.                                                                                               |
+| `VIDEO_TRANSCODE_MAX_SECONDS` | `600`                  | Skip transcoding for inputs longer than this.                                                                                                             |
+| `VIDEO_TRANSCODE_MAX_WIDTH`   | `4096`                 | Skip transcoding for inputs wider than this.                                                                                                              |
+| `VIDEO_TRANSCODE_MAX_HEIGHT`  | `4096`                 | Skip transcoding for inputs taller than this.                                                                                                             |
+| `VIDEO_FFMPEG_PATH`           | `/usr/bin/ffmpeg`      | Absolute path to the `ffmpeg` binary. Override if it lives elsewhere (e.g. `/opt/homebrew/bin/ffmpeg` on macOS).                                          |
+| `VIDEO_FFPROBE_PATH`          | `/usr/bin/ffprobe`     | Absolute path to the `ffprobe` binary.                                                                                                                    |
+| `VIDEO_TMP_DIR`               | `<data>/transcode-tmp` | Scratch directory for in-progress transcodes. Must be on disk with room for the source plus output. Do not point it at the in-memory `/tmp` tmpfs.        |
+
+Transcoding decodes attacker-supplied media with `ffmpeg`. The shipped compose files already run the container with a read-only root filesystem, all capabilities dropped, and `no-new-privileges`, which contains a decoder exploit. For extra isolation you can run the container without network access. The conversion holds one CPU at a time (single job, capped threads); on the production compose file note the `cpus` limit and raise it if you process large clips.
 
 ### External image storage (optional)
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ Set `VIDEO_TRANSCODE=true` to convert each uploaded video to a universal web pro
 | `VIDEO_FFPROBE_PATH`          | `/usr/bin/ffprobe`     | Absolute path to the `ffprobe` binary.                                                                                                                    |
 | `VIDEO_TMP_DIR`               | `<data>/transcode-tmp` | Scratch directory for in-progress transcodes. Must be on disk with room for the source plus output. Do not point it at the in-memory `/tmp` tmpfs.        |
 
-Transcoding decodes attacker-supplied media with `ffmpeg`. The shipped compose files already run the container with a read-only root filesystem, all capabilities dropped, and `no-new-privileges`, which contains a decoder exploit. For extra isolation you can run the container without network access. The conversion holds one CPU at a time (single job, capped threads); on the production compose file note the `cpus` limit and raise it if you process large clips.
+Transcoding decodes attacker-supplied media with `ffmpeg`. The shipped compose files already run the container with a read-only root filesystem, all capabilities dropped, and `no-new-privileges`, which contains a decoder exploit. For extra isolation you can run the container without network access.
+
+Transcoding is the only CPU-heavy thing EinVault does. It runs one job at a time with `ffmpeg` capped at two threads, so it never grabs the whole host, but the default `cpus: 0.5` / `memory: 256M` limits in `docker-compose.prod.yml` are sized for the app alone and are too low once it is enabled. With transcoding on, raise them to roughly `cpus: 1.5` (use `1.0` on a small host, `2.0` for the fastest conversions) and `memory: 512M` (`1G` if you allow large or 4K clips). The memory bump matters most: the worker buffers the whole clip while converting, and too low a limit will OOM-kill the job rather than slow it down.
 
 ### External image storage (optional)
 
@@ -160,15 +162,15 @@ docker compose -f docker-compose.prod.yml start einvault
 
 ### Container hardening
 
-|                     |                               |
-| ------------------- | ----------------------------- |
-| Runs as root        | No (runs as `node`, UID 1000) |
-| `no-new-privileges` | Enabled                       |
-| Linux capabilities  | All dropped                   |
-| Root filesystem     | Read-only                     |
-| Writable `/tmp`     | tmpfs, 64 MB                  |
-| CPU limit           | 0.5 cores                     |
-| Memory limit        | 256 MB                        |
+|                     |                                         |
+| ------------------- | --------------------------------------- |
+| Runs as root        | No (runs as `node`, UID 1000)           |
+| `no-new-privileges` | Enabled                                 |
+| Linux capabilities  | All dropped                             |
+| Root filesystem     | Read-only                               |
+| Writable `/tmp`     | tmpfs, 64 MB                            |
+| CPU limit           | 0.5 cores (raise for video transcoding) |
+| Memory limit        | 256 MB (raise for video transcoding)    |
 
 ### Image tags
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,6 +38,16 @@ services:
       # Default undo window (seconds) for dismissing a Reminder. 0 disables it.
       REMINDER_UNDO_SECONDS: ${REMINDER_UNDO_SECONDS:-7}
 
+      # Optional: server-side video transcoding (off by default). When 'true',
+      # uploaded videos are transcoded to H.264/AAC MP4 + poster in the
+      # background so they play cross-browser. ffmpeg ships in the image.
+      # Transcode scratch is written under /data; do not point it at /tmp (the
+      # 64 MB RAM tmpfs below is too small for video).
+      VIDEO_TRANSCODE: ${VIDEO_TRANSCODE:-false}
+      VIDEO_KEEP_ORIGINAL: ${VIDEO_KEEP_ORIGINAL:-true}
+      # VIDEO_TRANSCODE_MAX_MB / _MAX_SECONDS / _MAX_WIDTH / _MAX_HEIGHT cap cost.
+      # VIDEO_TMP_DIR defaults to /data/transcode-tmp.
+
       # Set to your local timezone so dates and times display correctly.
       # Defaults to UTC if omitted. Example: America/New_York, Europe/London
       # TZ: ${TZ:-America/New_York}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -94,6 +94,11 @@ services:
     deploy:
       resources:
         limits:
+          # 0.5 / 256M is plenty for the app itself. If you enable VIDEO_TRANSCODE,
+          # raise both: transcoding bursts ffmpeg (capped at 2 threads, one job at
+          # a time) and the worker buffers the whole clip in memory. Suggested with
+          # transcoding on: cpus '1.5' (1.0 on a small host, 2.0 for fastest), and
+          # memory 512M (1G if you allow large/4K clips) to avoid an OOM mid-job.
           cpus: '0.5'
           memory: 256M
         reservations:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,23 @@ services:
       # Each user can override in their settings.
       REMINDER_UNDO_SECONDS: 7
 
+      # Optional: server-side video transcoding (off by default).
+      # Set VIDEO_TRANSCODE=true to transcode uploaded videos to H.264/AAC MP4
+      # (+ poster) in the background so they play in every browser. ffmpeg ships
+      # in the image. Transcoding is CPU-intensive — note the cpus limit below;
+      # raise it if you enable this and process large clips. Scratch files are
+      # written under /data (disk), never the 64 MB /tmp tmpfs.
+      # VIDEO_TRANSCODE: 'true'
+      # Keep the source video alongside the transcode (default true). The
+      # original is never served; set false to discard it and save space.
+      # VIDEO_KEEP_ORIGINAL: 'true'
+      # Cost caps (input is stored as-is if it exceeds any): defaults shown.
+      # VIDEO_TRANSCODE_MAX_MB: 100
+      # VIDEO_TRANSCODE_MAX_SECONDS: 600
+      # VIDEO_TRANSCODE_MAX_WIDTH: 4096
+      # VIDEO_TRANSCODE_MAX_HEIGHT: 4096
+      # VIDEO_TMP_DIR: /data/transcode-tmp
+
       # Set to your local timezone so dates and times display correctly.
       # Defaults to UTC if omitted. Example: America/New_York, Europe/London
       # TZ: America/New_York

--- a/drizzle/0014_low_the_liberteens.sql
+++ b/drizzle/0014_low_the_liberteens.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `journal_photos` ADD `status` text DEFAULT 'ready' NOT NULL;--> statement-breakpoint
+ALTER TABLE `journal_photos` ADD `original_key` text;--> statement-breakpoint
+ALTER TABLE `journal_photos` ADD `poster_key` text;--> statement-breakpoint
+ALTER TABLE `journal_photos` ADD `transcode_attempts` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX `photo_status_idx` ON `journal_photos` (`status`);

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1363 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ee4808c4-a138-44de-8705-61f45a925d36",
+  "prevId": "bf5346bd-c715-42a5-95e2-919c133854dd",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'photo'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_key": {
+          "name": "poster_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_attempts": {
+          "name": "transcode_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        },
+        "photo_status_idx": {
+          "name": "photo_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1780012333513,
       "tag": "0013_brave_lenny_balinger",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1780662158002,
+      "tag": "0014_low_the_liberteens",
+      "breakpoints": true
     }
   ]
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,11 +10,16 @@ import {
 	logStorageBootStatus,
 	logDeprecatedEnvWarnings
 } from '$lib/server/env';
+import { recoverAndStart } from '$lib/server/video/worker';
 
 logOidcBootStatus();
 logStorageBootStatus();
 logImmichBootStatus();
 logDeprecatedEnvWarnings();
+
+// Resume any transcode jobs interrupted by a restart and drain the queue. No-op
+// unless VIDEO_TRANSCODE is enabled and ffmpeg is present. Fire and forget.
+recoverAndStart();
 
 // When S3 storage is configured, /api/photos and /api/avatars 302 to the S3
 // host. CSP is enforced on the final navigation target after redirects, so the

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -8,7 +8,8 @@ import {
 	S3_CONFIG,
 	logImmichBootStatus,
 	logStorageBootStatus,
-	logDeprecatedEnvWarnings
+	logDeprecatedEnvWarnings,
+	logVideoTranscodeBootStatus
 } from '$lib/server/env';
 import { recoverAndStart } from '$lib/server/video/worker';
 
@@ -16,6 +17,7 @@ logOidcBootStatus();
 logStorageBootStatus();
 logImmichBootStatus();
 logDeprecatedEnvWarnings();
+logVideoTranscodeBootStatus();
 
 // Resume any transcode jobs interrupted by a restart and drain the queue. No-op
 // unless VIDEO_TRANSCODE is enabled and ffmpeg is present. Fire and forget.

--- a/src/lib/components/JournalVideo.svelte
+++ b/src/lib/components/JournalVideo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Download } from '@lucide/svelte';
+	import { Download, Loader2 } from '@lucide/svelte';
 	import { t, getLocale } from '$lib/i18n';
 
 	interface Props {
@@ -10,6 +10,15 @@
 		autoplay?: boolean;
 		/** Compact fallback for small thumbnails: hides the message, shows only the download link. */
 		compact?: boolean;
+		/**
+		 * Transcode lifecycle of the row. 'processing'/'claimed' shows a converting
+		 * placeholder; anything else renders the player. A 'failed' transcode leaves
+		 * the row pointing at the original upload, so we still try to play it and let
+		 * the decode-error fallback handle an unsupported codec.
+		 */
+		status?: string;
+		/** Poster image URL (the transcoded video's generated thumbnail), if any. */
+		poster?: string | null;
 	}
 
 	let {
@@ -18,7 +27,9 @@
 		label,
 		class: className = '',
 		autoplay = false,
-		compact = false
+		compact = false,
+		status = 'ready',
+		poster = null
 	}: Props = $props();
 	const locale = getLocale();
 
@@ -27,13 +38,28 @@
 	// link instead of a dead player.
 	let failed = $state(false);
 
+	// A queued/in-flight transcode has no playable transcoded file yet. Show a
+	// converting placeholder; the journal page polls and swaps in the player.
+	const processing = $derived(status === 'processing' || status === 'claimed');
+
 	// Honor the user's reduced-motion preference: don't auto-start playback.
 	const reduceMotion =
 		typeof window !== 'undefined' &&
 		!!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
 </script>
 
-{#if failed}
+{#if processing}
+	<div
+		class="flex flex-col items-center justify-center gap-1.5 bg-stone-100 dark:bg-stone-800 text-center {compact
+			? 'p-2'
+			: 'p-3'} {className}"
+	>
+		<Loader2 class="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+		{#if !compact}
+			<p class="text-xs text-muted-foreground">{t(locale, 'page.journal.videoProcessing')}</p>
+		{/if}
+	</div>
+{:else if failed}
 	<div
 		class="flex flex-col items-center justify-center gap-1.5 bg-stone-100 dark:bg-stone-800 text-center {compact
 			? 'p-2'
@@ -55,6 +81,7 @@
 	<!-- svelte-ignore a11y_media_has_caption -->
 	<video
 		{src}
+		poster={poster ?? undefined}
 		controls
 		autoplay={autoplay && !reduceMotion}
 		preload="metadata"

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -478,6 +478,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.photoAlt': 'Tagebuchfoto',
 	'page.journal.videoAlt': 'Tagebuchvideo',
 	'page.journal.videoUnsupported': 'Dieses Video kann in deinem Browser nicht abgespielt werden.',
+	'page.journal.videoProcessing': 'Video wird konvertiert…',
 	'page.journal.mediaLightboxLabel': 'Medienanzeige',
 
 	// Page: Journal day (app)

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -472,6 +472,7 @@ const messages = {
 	'page.journal.photoAlt': 'Journal photo',
 	'page.journal.videoAlt': 'Journal video',
 	'page.journal.videoUnsupported': "This video can't be played in your browser.",
+	'page.journal.videoProcessing': 'Converting video…',
 	'page.journal.mediaLightboxLabel': 'Media viewer',
 
 	// Page: Journal day (app)

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -478,6 +478,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.photoAlt': 'Foto del diario',
 	'page.journal.videoAlt': 'Vídeo del diario',
 	'page.journal.videoUnsupported': 'Este vídeo no se puede reproducir en tu navegador.',
+	'page.journal.videoProcessing': 'Convirtiendo vídeo…',
 	'page.journal.mediaLightboxLabel': 'Visor multimedia',
 
 	// Page: Journal day (app)

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -477,6 +477,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.photoAlt': 'Photo du journal',
 	'page.journal.videoAlt': 'Vidéo du journal',
 	'page.journal.videoUnsupported': 'Cette vidéo ne peut pas être lue dans votre navigateur.',
+	'page.journal.videoProcessing': 'Conversion de la vidéo…',
 	'page.journal.mediaLightboxLabel': 'Visionneuse de médias',
 
 	// Page: Journal day (app)

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -474,6 +474,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.photoAlt': 'Foto del diario',
 	'page.journal.videoAlt': 'Video del diario',
 	'page.journal.videoUnsupported': 'Questo video non può essere riprodotto nel tuo browser.',
+	'page.journal.videoProcessing': 'Conversione del video…',
 	'page.journal.mediaLightboxLabel': 'Visualizzatore multimediale',
 
 	// Page: Journal day (app)

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -475,6 +475,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.journal.photoAlt': 'Foto do diário',
 	'page.journal.videoAlt': 'Vídeo do diário',
 	'page.journal.videoUnsupported': 'Não é possível reproduzir este vídeo no seu navegador.',
+	'page.journal.videoProcessing': 'A converter vídeo…',
 	'page.journal.mediaLightboxLabel': 'Visualizador de mídia',
 
 	// Page: Journal day (app)

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -145,13 +145,32 @@ export const journalPhotos = sqliteTable(
 		mimeType: text('mime_type').notNull(),
 		sizeBytes: integer('size_bytes').notNull(),
 		notes: text('notes'),
+		// Transcode lifecycle. 'ready' = playable as stored (the default for
+		// every pre-existing row and for any media that isn't queued for
+		// transcoding). 'processing' = enqueued, awaiting the worker. 'claimed'
+		// = a worker has atomically taken the job (crash-recovery marker).
+		// 'failed' = transcode gave up; UI falls back to a download link. Only
+		// VIDEO_TRANSCODE=true ever produces non-'ready' values.
+		status: text('status', { enum: ['ready', 'processing', 'claimed', 'failed'] })
+			.notNull()
+			.default('ready'),
+		// Storage key of the kept source video (VIDEO_KEEP_ORIGINAL=true). Never
+		// served to clients; retained for re-encode/backup only.
+		originalKey: text('original_key'),
+		// Storage key of the generated poster/thumbnail JPEG.
+		posterKey: text('poster_key'),
+		// Times the worker has attempted this job. Bounds retries so a poison
+		// input can't be requeued forever on every boot.
+		transcodeAttempts: integer('transcode_attempts').notNull().default(0),
 		createdAt: integer('created_at', { mode: 'timestamp' })
 			.notNull()
 			.default(sql`(unixepoch())`),
 		loggedBy: text('logged_by').references(() => users.id, { onDelete: 'set null' })
 	},
 	(t) => ({
-		entryIdx: index('photo_entry_idx').on(t.entryId)
+		entryIdx: index('photo_entry_idx').on(t.entryId),
+		// The worker scans for queued jobs by status; index it.
+		statusIdx: index('photo_status_idx').on(t.status)
 	})
 );
 

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -93,17 +93,37 @@ export interface VideoTranscodeConfig {
 	tmpDir: string;
 }
 
+// Hard ceiling for the per-job duration cap. Bounds the transcode wall-clock
+// timeout (derived from maxSeconds) so a misconfigured large value can't
+// effectively disable the SIGKILL backstop and pin the single worker for days.
+const VIDEO_TRANSCODE_MAX_SECONDS_CEILING = 3600;
+
 export const VIDEO_TRANSCODE: VideoTranscodeConfig = {
 	enabled: envBool(env.VIDEO_TRANSCODE, false),
 	keepOriginal: envBool(env.VIDEO_KEEP_ORIGINAL, true),
 	maxMb: envInt(env.VIDEO_TRANSCODE_MAX_MB, VIDEO_MAX_MB),
-	maxSeconds: envInt(env.VIDEO_TRANSCODE_MAX_SECONDS, 600),
+	maxSeconds: Math.min(
+		envInt(env.VIDEO_TRANSCODE_MAX_SECONDS, 600),
+		VIDEO_TRANSCODE_MAX_SECONDS_CEILING
+	),
 	maxWidth: envInt(env.VIDEO_TRANSCODE_MAX_WIDTH, 4096),
 	maxHeight: envInt(env.VIDEO_TRANSCODE_MAX_HEIGHT, 4096),
 	ffmpegPath: env.VIDEO_FFMPEG_PATH?.trim() || '/usr/bin/ffmpeg',
 	ffprobePath: env.VIDEO_FFPROBE_PATH?.trim() || '/usr/bin/ffprobe',
 	tmpDir: env.VIDEO_TMP_DIR?.trim() || join(DATA_DIR, 'transcode-tmp')
 };
+
+export function logVideoTranscodeBootStatus(): void {
+	// A set-but-unrecognized value parses as `false` (fail-closed). Warn so an
+	// operator who wrote VIDEO_TRANSCODE=1/yes isn't left believing it is on.
+	const raw = env.VIDEO_TRANSCODE?.trim().toLowerCase();
+	if (raw !== undefined && raw !== 'true' && raw !== 'false') {
+		console.warn(
+			`[video] VIDEO_TRANSCODE='${env.VIDEO_TRANSCODE}' is not 'true' or 'false'; treating as disabled.`
+		);
+	}
+	console.info(`[video] transcoding ${VIDEO_TRANSCODE.enabled ? 'requested' : 'disabled'} (env)`);
+}
 
 // Storage backend selection. 'local' writes to DATA_DIR/uploads; 's3' uses an
 // S3-compatible bucket (AWS, Garage, MinIO, Backblaze B2, R2, ...). Reads

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -1,5 +1,7 @@
 import { env } from '$env/dynamic/private';
+import { join } from 'path';
 import { REMINDER_UNDO_MAX_SECONDS } from '$lib/reminderUndo';
+import { DATA_DIR } from '$lib/server/paths';
 import type { StorageProvider } from '$lib/server/storage/types';
 
 export {
@@ -28,6 +30,17 @@ function envNonNegativeInt(value: string | undefined, defaultValue: number): num
 	return Number.isInteger(n) && n >= 0 ? n : defaultValue;
 }
 
+/**
+ * Parse an env var as a boolean. Only the exact string 'true' (case-insensitive,
+ * trimmed) is truthy; everything else — including unset — is `defaultValue` when
+ * the value is undefined, otherwise false. Mirrors the existing
+ * `S3_FORCE_PATH_STYLE === 'true'` convention.
+ */
+function envBool(value: string | undefined, defaultValue: boolean): boolean {
+	if (value === undefined) return defaultValue;
+	return value.trim().toLowerCase() === 'true';
+}
+
 export const UPLOAD_MAX_MB = envInt(env.UPLOAD_MAX_MB, 10);
 export const VIDEO_MAX_MB = envInt(env.VIDEO_MAX_MB, 100);
 
@@ -44,6 +57,53 @@ export function logDeprecatedEnvWarnings(): void {
 		);
 	}
 }
+
+// Optional server-side video transcoding (issue #86). Off by default: it needs
+// the ffmpeg/ffprobe binaries in the image and is CPU-intensive. When enabled,
+// uploaded videos are transcoded to a universal web profile (H.264 + AAC MP4,
+// +faststart) with a generated poster, so they play cross-browser instead of
+// failing to decode (e.g. Apple HEVC in Firefox). The binaries are probed at
+// boot by the transcode module; if absent, the feature self-disables and videos
+// are stored as-is (the pre-#86 behavior). Hardening rationale for the caps and
+// pinned paths lives in src/lib/server/video/.
+export interface VideoTranscodeConfig {
+	// Operator intent. The effective on/off state also depends on the boot-time
+	// binary probe (see src/lib/server/video/transcode.ts).
+	enabled: boolean;
+	// Keep the original source video alongside the transcoded copy. The original
+	// is never served to clients; it is retained for re-encode/backup only.
+	keepOriginal: boolean;
+	// Refuse to transcode inputs larger than this many MB (bounds decode work in
+	// addition to the resolution/duration caps below). Defaults to VIDEO_MAX_MB.
+	maxMb: number;
+	// Reject (via ffprobe) inputs longer than this, or larger than these pixel
+	// dimensions, before spending CPU on a decode. Guards against decompression
+	// bombs where a tiny file expands to enormous decoded work.
+	maxSeconds: number;
+	maxWidth: number;
+	maxHeight: number;
+	// Absolute, pinned binary paths. Pinned (not PATH-resolved) so the boot probe
+	// and the spawn target the same binary — closes a PATH-hijack TOCTOU.
+	ffmpegPath: string;
+	ffprobePath: string;
+	// Scratch directory for per-job temp files. MUST be disk-backed and roomy:
+	// it holds the downloaded original + decode scratch + output, which exceed
+	// the 64 MB RAM tmpfs the container mounts at /tmp. Defaults to a subdir of
+	// the data volume.
+	tmpDir: string;
+}
+
+export const VIDEO_TRANSCODE: VideoTranscodeConfig = {
+	enabled: envBool(env.VIDEO_TRANSCODE, false),
+	keepOriginal: envBool(env.VIDEO_KEEP_ORIGINAL, true),
+	maxMb: envInt(env.VIDEO_TRANSCODE_MAX_MB, VIDEO_MAX_MB),
+	maxSeconds: envInt(env.VIDEO_TRANSCODE_MAX_SECONDS, 600),
+	maxWidth: envInt(env.VIDEO_TRANSCODE_MAX_WIDTH, 4096),
+	maxHeight: envInt(env.VIDEO_TRANSCODE_MAX_HEIGHT, 4096),
+	ffmpegPath: env.VIDEO_FFMPEG_PATH?.trim() || '/usr/bin/ffmpeg',
+	ffprobePath: env.VIDEO_FFPROBE_PATH?.trim() || '/usr/bin/ffprobe',
+	tmpDir: env.VIDEO_TMP_DIR?.trim() || join(DATA_DIR, 'transcode-tmp')
+};
 
 // Storage backend selection. 'local' writes to DATA_DIR/uploads; 's3' uses an
 // S3-compatible bucket (AWS, Garage, MinIO, Backblaze B2, R2, ...). Reads

--- a/src/lib/server/video/transcode.ts
+++ b/src/lib/server/video/transcode.ts
@@ -1,0 +1,397 @@
+// Server-side video transcoding (issue #86). Wraps ffmpeg/ffprobe to convert an
+// uploaded source video into a universal web profile (H.264 + AAC MP4 with the
+// moov atom at the front) plus a poster JPEG, so clips play cross-browser
+// instead of failing to decode (e.g. Apple HEVC in Firefox).
+//
+// SECURITY: the input is attacker-controlled media fed to ffmpeg's C demuxers
+// and decoders. The hardening here is deliberate and load-bearing:
+//   - spawn() with an argv array and shell:false — never a shell string. No
+//     metacharacter injection is possible.
+//   - The ffmpeg/ffprobe binaries are addressed by pinned ABSOLUTE paths from
+//     config (not PATH-resolved), so the boot probe and the spawn hit the same
+//     binary (no PATH-hijack TOCTOU).
+//   - -protocol_whitelist restricts ffmpeg to local files, blocking http/https
+//     (SSRF into the LAN / cloud metadata endpoint), file:// indirection,
+//     concat:, subfile:, and HLS segment fetches embedded in a crafted file.
+//   - The input demuxer is FORCED with -f from our own MIME-derived allowlist,
+//     never auto-detected, so a crafted file cannot be probed as a playlist.
+//   - Every -i argument is an absolute path we generated under the job temp dir;
+//     no user string (filename, storage key) ever reaches the argv. An assert
+//     guarantees no path can start with '-' and be read as an option.
+//   - ffprobe gates the source on stream count / dimensions / duration BEFORE a
+//     full decode, bounding decompression-bomb cost.
+//   - The poster is extracted from OUR transcoded MP4, not the untrusted source
+//     — one fewer untrusted decode.
+//   - Every spawn has a wall-clock timeout and is SIGKILLed on expiry; stderr
+//     capture is length-capped so a chatty/garbage input can't exhaust memory.
+//
+// Network/filesystem isolation of the ffmpeg process itself (read-only rootfs,
+// dropped caps, no-new-privileges) is provided by the container — see the
+// shipped docker-compose files — and documented as deploy guidance.
+
+import { spawn } from 'node:child_process';
+import { VIDEO_TRANSCODE } from '$lib/server/env';
+
+// Map an accepted upload MIME to the exact ffmpeg input demuxer(s) we force via
+// -f. Derived from our own allowlist (the upload handler already validated MIME
+// + magic bytes), NOT from file content, so ffmpeg cannot auto-select a
+// dangerous demuxer (e.g. a playlist) for a disguised input.
+const DEMUXER_BY_MIME: Record<string, string> = {
+	'video/mp4': 'mov,mp4,m4a,3gp,3g2,mj2',
+	'video/quicktime': 'mov,mp4,m4a,3gp,3g2,mj2',
+	'video/webm': 'matroska,webm'
+};
+
+// Demuxer for reading back our own transcoded MP4 (poster extraction).
+const MP4_DEMUXER = 'mov,mp4,m4a,3gp,3g2,mj2';
+
+// Cap stderr capture per process. ffmpeg/ffprobe error output is small; a flood
+// means a hostile input. Beyond this we stop buffering (still SIGKILL on timeout).
+const MAX_STDERR_BYTES = 64 * 1024;
+
+// Cap stdout too: ffprobe JSON for a normal file is a few KB. A crafted input
+// claiming thousands of streams could bloat it; truncating makes JSON.parse fail
+// and the source is treated as unprobeable (stored as-is) rather than OOMing.
+const MAX_STDOUT_BYTES = 4 * 1024 * 1024;
+
+// Wall-clock SIGKILL backstop for a single ffmpeg invocation. The resolution and
+// duration caps bound normal work; this only catches pathological inputs that
+// slip past them. ffprobe is quick and gets a short fixed timeout.
+const PROBE_TIMEOUT_MS = 30_000;
+function transcodeTimeoutMs(): number {
+	// Generous: encoding on a throttled core can run several times slower than
+	// realtime. Scaled to the max allowed duration plus a fixed floor.
+	return 60_000 + VIDEO_TRANSCODE.maxSeconds * 1000 * 6;
+}
+
+// Bound CPU. Concurrency is already 1 at the worker; cap threads per job too so a
+// single clip can't saturate every core on a larger host.
+const FFMPEG_THREADS = 2;
+
+export interface SourceMeta {
+	width: number;
+	height: number;
+	durationSeconds: number;
+	videoStreams: number;
+	hasAudio: boolean;
+}
+
+export interface TranscodeOutput {
+	mp4Path: string;
+	posterPath: string;
+	meta: SourceMeta;
+}
+
+interface ProcResult {
+	code: number | null;
+	stdout: string;
+	stderr: string;
+	timedOut: boolean;
+}
+
+/**
+ * Run a pinned binary with an argv array. Never a shell. Captures stdout/stderr
+ * (stderr length-capped) and SIGKILLs on wall-clock timeout. Rejects only on a
+ * spawn failure (e.g. ENOENT); a non-zero exit resolves with the code so callers
+ * can inspect stderr.
+ */
+function run(binPath: string, args: string[], timeoutMs: number): Promise<ProcResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(binPath, args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'] });
+		let stdout = '';
+		let stderr = '';
+		let stdoutBytes = 0;
+		let stderrBytes = 0;
+		let timedOut = false;
+
+		const timer = setTimeout(() => {
+			timedOut = true;
+			child.kill('SIGKILL');
+		}, timeoutMs);
+
+		child.stdout.on('data', (d: Buffer) => {
+			if (stdoutBytes < MAX_STDOUT_BYTES) {
+				stdout += d.toString();
+				stdoutBytes += d.length;
+			}
+		});
+		child.stdout.on('error', () => {});
+		child.stderr.on('data', (d: Buffer) => {
+			if (stderrBytes < MAX_STDERR_BYTES) {
+				stderr += d.toString();
+				stderrBytes += d.length;
+			}
+		});
+		child.stderr.on('error', () => {});
+
+		child.on('error', (err) => {
+			clearTimeout(timer);
+			reject(err);
+		});
+		child.on('close', (code) => {
+			clearTimeout(timer);
+			resolve({ code, stdout, stderr, timedOut });
+		});
+	});
+}
+
+/**
+ * Guard against argument injection: every path we hand to ffmpeg as an input or
+ * output must be absolute. An absolute path cannot start with '-', so ffmpeg can
+ * never misread it as an option. Worker-generated temp paths are always
+ * absolute; this asserts the invariant defensively.
+ */
+function assertSafePath(p: string): void {
+	if (!p.startsWith('/')) {
+		throw new Error(`refusing unsafe (non-absolute) ffmpeg path: ${JSON.stringify(p)}`);
+	}
+}
+
+// Module-level cache of the boot-time binary probe. A promise so concurrent
+// callers share one probe.
+let binaryProbe: Promise<boolean> | null = null;
+let availabilityLogged = false;
+
+async function probeBinary(path: string): Promise<boolean> {
+	try {
+		const r = await run(path, ['-version'], PROBE_TIMEOUT_MS);
+		return r.code === 0 && !r.timedOut;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Detect (once, cached) whether the pinned ffmpeg AND ffprobe binaries are both
+ * present and runnable. Result is cached for the process lifetime.
+ */
+export function detectBinaries(): Promise<boolean> {
+	if (!binaryProbe) {
+		binaryProbe = (async () => {
+			const [ffmpeg, ffprobe] = await Promise.all([
+				probeBinary(VIDEO_TRANSCODE.ffmpegPath),
+				probeBinary(VIDEO_TRANSCODE.ffprobePath)
+			]);
+			return ffmpeg && ffprobe;
+		})();
+	}
+	return binaryProbe;
+}
+
+/**
+ * Effective on/off state: operator opted in (VIDEO_TRANSCODE=true) AND both
+ * binaries are usable. Logs the resolved state once. When this is false, callers
+ * must store the video as-is (the pre-#86 behavior).
+ */
+export async function transcodeAvailable(): Promise<boolean> {
+	if (!VIDEO_TRANSCODE.enabled) return false;
+	const ok = await detectBinaries();
+	if (!availabilityLogged) {
+		availabilityLogged = true;
+		if (ok) {
+			console.info(
+				`[video] transcoding enabled (ffmpeg=${VIDEO_TRANSCODE.ffmpegPath}, ffprobe=${VIDEO_TRANSCODE.ffprobePath})`
+			);
+		} else {
+			console.warn(
+				`[video] VIDEO_TRANSCODE=true but ffmpeg/ffprobe not runnable at ` +
+					`${VIDEO_TRANSCODE.ffmpegPath} / ${VIDEO_TRANSCODE.ffprobePath}. ` +
+					`Transcoding disabled; videos will be stored as-is. Install ffmpeg or set VIDEO_FFMPEG_PATH/VIDEO_FFPROBE_PATH.`
+			);
+		}
+	}
+	return ok;
+}
+
+/**
+ * Resolve the forced input demuxer for an accepted upload MIME, or null if the
+ * MIME is outside our allowlist (caller should not transcode it).
+ */
+export function demuxerForMime(mime: string): string | null {
+	return DEMUXER_BY_MIME[mime] ?? null;
+}
+
+/**
+ * ffprobe the source (local file only, forced demuxer) and return its metadata.
+ * Throws on probe failure / timeout / unparseable output — the caller treats any
+ * throw as "unprobeable, do not transcode".
+ */
+export async function probeSource(inputPath: string, demuxer: string): Promise<SourceMeta> {
+	assertSafePath(inputPath);
+	const args = [
+		'-v',
+		'error',
+		'-hide_banner',
+		// Local files only. crypto allows ffprobe's internal AES protocol if a
+		// container references it; http/concat/hls/subfile remain blocked.
+		'-protocol_whitelist',
+		'file,crypto',
+		// Force the demuxer; do not let ffprobe auto-detect a playlist format.
+		'-f',
+		demuxer,
+		'-print_format',
+		'json',
+		'-show_streams',
+		'-show_format',
+		'-i',
+		inputPath
+	];
+	const r = await run(VIDEO_TRANSCODE.ffprobePath, args, PROBE_TIMEOUT_MS);
+	if (r.timedOut) throw new Error('ffprobe timed out');
+	if (r.code !== 0) throw new Error(`ffprobe exited ${r.code}`);
+
+	let parsed: {
+		streams?: Array<{
+			codec_type?: string;
+			width?: number;
+			height?: number;
+			duration?: string;
+		}>;
+		format?: { duration?: string };
+	};
+	try {
+		parsed = JSON.parse(r.stdout);
+	} catch {
+		throw new Error('ffprobe returned unparseable JSON');
+	}
+
+	const streams = parsed.streams ?? [];
+	const videoStreams = streams.filter((s) => s.codec_type === 'video');
+	const hasAudio = streams.some((s) => s.codec_type === 'audio');
+	const v = videoStreams[0];
+	const durationStr = parsed.format?.duration ?? v?.duration ?? '0';
+	const durationSeconds = Number.parseFloat(durationStr);
+
+	return {
+		width: v?.width ?? 0,
+		height: v?.height ?? 0,
+		durationSeconds: Number.isFinite(durationSeconds) ? durationSeconds : 0,
+		videoStreams: videoStreams.length,
+		hasAudio
+	};
+}
+
+/**
+ * Check probed metadata against the configured caps. Returns a human-readable
+ * reason string when the source must be rejected (and stored as-is), or null
+ * when it is within limits. Rejecting an oversized/over-long/multi-stream input
+ * bounds decode cost and rejects suspicious files.
+ */
+export function checkSourceLimits(meta: SourceMeta): string | null {
+	if (meta.videoStreams === 0) return 'no video stream';
+	if (meta.videoStreams > 1) return `multiple video streams (${meta.videoStreams})`;
+	if (meta.width <= 0 || meta.height <= 0) return 'missing video dimensions';
+	if (meta.width > VIDEO_TRANSCODE.maxWidth || meta.height > VIDEO_TRANSCODE.maxHeight) {
+		return `resolution ${meta.width}x${meta.height} exceeds cap ${VIDEO_TRANSCODE.maxWidth}x${VIDEO_TRANSCODE.maxHeight}`;
+	}
+	if (meta.durationSeconds > VIDEO_TRANSCODE.maxSeconds) {
+		return `duration ${Math.round(meta.durationSeconds)}s exceeds cap ${VIDEO_TRANSCODE.maxSeconds}s`;
+	}
+	return null;
+}
+
+/**
+ * Transcode a validated source video to H.264/AAC MP4 (+faststart) and extract a
+ * poster JPEG, writing both into `outDir`. Caller is responsible for creating and
+ * (always) cleaning up `outDir`. Throws on probe rejection, cap violation, or any
+ * ffmpeg failure; the worker maps a throw to status='failed'.
+ *
+ * @param inputPath absolute path to the downloaded source (under the job temp dir)
+ * @param outDir    absolute path of the job temp dir to write outputs into
+ * @param mime      validated source MIME, used to force the input demuxer
+ */
+export async function transcodeToWebProfile(
+	inputPath: string,
+	outDir: string,
+	mime: string
+): Promise<TranscodeOutput> {
+	assertSafePath(inputPath);
+	assertSafePath(outDir);
+	const demuxer = demuxerForMime(mime);
+	if (!demuxer) throw new Error(`unsupported source MIME for transcode: ${mime}`);
+
+	// Gate on probe + caps before spending CPU on a full decode.
+	const meta = await probeSource(inputPath, demuxer);
+	const violation = checkSourceLimits(meta);
+	if (violation) throw new Error(`source rejected: ${violation}`);
+
+	const mp4Path = `${outDir}/output.mp4`;
+	const posterPath = `${outDir}/poster.jpg`;
+
+	// --- Transcode ---------------------------------------------------------
+	const ffmpegArgs = [
+		'-nostdin',
+		'-hide_banner',
+		'-v',
+		'error',
+		'-protocol_whitelist',
+		'file,crypto',
+		'-f',
+		demuxer,
+		'-i',
+		inputPath,
+		// First video stream + first audio stream if present (? = optional).
+		'-map',
+		'0:v:0',
+		'-map',
+		'0:a:0?',
+		'-c:v',
+		'libx264',
+		'-preset',
+		'medium',
+		'-crf',
+		'23',
+		// yuv420p for the widest browser/decoder compatibility.
+		'-pix_fmt',
+		'yuv420p',
+		'-c:a',
+		'aac',
+		'-b:a',
+		'128k',
+		// moov atom at the front: enables progressive download / seeking.
+		'-movflags',
+		'+faststart',
+		'-threads',
+		String(FFMPEG_THREADS),
+		// Hard output-duration cap (defense in depth alongside the probe check).
+		'-t',
+		String(VIDEO_TRANSCODE.maxSeconds),
+		'-y',
+		mp4Path
+	];
+	const enc = await run(VIDEO_TRANSCODE.ffmpegPath, ffmpegArgs, transcodeTimeoutMs());
+	if (enc.timedOut) throw new Error('ffmpeg transcode timed out');
+	if (enc.code !== 0) {
+		throw new Error(`ffmpeg transcode exited ${enc.code}: ${enc.stderr.slice(0, 500)}`);
+	}
+
+	// --- Poster ------------------------------------------------------------
+	// Extracted from OUR transcoded MP4 (trusted), not the untrusted source.
+	const posterArgs = [
+		'-nostdin',
+		'-hide_banner',
+		'-v',
+		'error',
+		'-protocol_whitelist',
+		'file,crypto',
+		'-f',
+		MP4_DEMUXER,
+		'-ss',
+		'0',
+		'-i',
+		mp4Path,
+		'-frames:v',
+		'1',
+		'-q:v',
+		'3',
+		'-y',
+		posterPath
+	];
+	const poster = await run(VIDEO_TRANSCODE.ffmpegPath, posterArgs, PROBE_TIMEOUT_MS);
+	if (poster.timedOut) throw new Error('ffmpeg poster timed out');
+	if (poster.code !== 0) {
+		throw new Error(`ffmpeg poster exited ${poster.code}: ${poster.stderr.slice(0, 500)}`);
+	}
+
+	return { mp4Path, posterPath, meta };
+}

--- a/src/lib/server/video/worker.ts
+++ b/src/lib/server/video/worker.ts
@@ -47,13 +47,24 @@ async function ensureTmpBase(): Promise<void> {
 	await mkdir(VIDEO_TRANSCODE.tmpDir, { recursive: true });
 }
 
-/** Read a web ReadableStream fully into a Buffer. */
-async function streamToBuffer(stream: ReadableStream): Promise<Buffer> {
+/**
+ * Read a web ReadableStream into a Buffer, aborting if it exceeds `maxBytes`.
+ * The whole object is held in memory, so this cap (the transcode size limit)
+ * bounds peak RAM and stops an out-of-band-grown or oversized object — e.g. a
+ * pre-existing row reprocessed on boot — from OOMing the worker.
+ */
+async function streamToBuffer(stream: ReadableStream, maxBytes: number): Promise<Buffer> {
 	const reader = stream.getReader();
 	const chunks: Buffer[] = [];
+	let total = 0;
 	for (;;) {
 		const { done, value } = await reader.read();
 		if (done) break;
+		total += (value as Uint8Array).byteLength;
+		if (total > maxBytes) {
+			await reader.cancel().catch(() => {});
+			throw new Error(`source exceeds ${maxBytes}-byte transcode cap`);
+		}
 		chunks.push(Buffer.from(value as Uint8Array));
 	}
 	return Buffer.concat(chunks);
@@ -61,16 +72,25 @@ async function streamToBuffer(stream: ReadableStream): Promise<Buffer> {
 
 /**
  * Fetch the bytes of a stored object regardless of backend: local returns a
- * stream, S3 returns a presigned redirect URL we then fetch.
+ * stream, S3 returns a presigned redirect URL we then fetch. Both paths enforce
+ * the source size cap.
  */
 async function downloadObject(provider: StorageProvider, key: string): Promise<Buffer> {
+	const maxBytes = VIDEO_TRANSCODE.maxMb * 1024 * 1024;
 	const res = await getStorage(provider).get(key);
 	if (!res) throw new Error(`source object missing: ${key}`);
-	if (res.kind === 'stream') return streamToBuffer(res.stream);
+	if (res.kind === 'stream') return streamToBuffer(res.stream, maxBytes);
 	if (res.kind === 'redirect') {
 		const r = await fetch(res.url);
 		if (!r.ok) throw new Error(`source fetch failed (${r.status})`);
-		return Buffer.from(await r.arrayBuffer());
+		// Reject early on an advertised over-cap length; still stream-cap below
+		// since Content-Length can be absent or wrong.
+		const len = Number(r.headers.get('content-length'));
+		if (Number.isFinite(len) && len > maxBytes) {
+			throw new Error(`source exceeds ${maxBytes}-byte transcode cap (${len})`);
+		}
+		if (!r.body) return Buffer.from(await r.arrayBuffer());
+		return streamToBuffer(r.body, maxBytes);
 	}
 	throw new Error(`unexpected get result: ${res.kind}`);
 }
@@ -84,58 +104,60 @@ interface ClaimedJob {
 }
 
 /**
- * Atomically claim the oldest queued job. Selects the oldest 'processing' row,
- * then transitions it to 'claimed' guarded on its still being 'processing'
- * (incrementing the attempt counter). Returns null when the queue is empty or
- * the candidate was claimed by a racing writer (caller loops again).
+ * Atomically claim the oldest claimable job. Selects the oldest 'processing'
+ * row, then transitions it to 'claimed' guarded on its still being 'processing'
+ * (incrementing the attempt counter). Loops past candidates lost to a racing
+ * writer or unclaimable (no storage key) so a single skip never ends the drain;
+ * returns null only when the queue is genuinely empty.
  */
 async function claimNext(): Promise<ClaimedJob | null> {
-	const [candidate] = await db
-		.select({
-			id: schema.journalPhotos.id,
-			storageKey: schema.journalPhotos.storageKey,
-			provider: schema.journalPhotos.provider,
-			mimeType: schema.journalPhotos.mimeType
-		})
-		.from(schema.journalPhotos)
-		.where(eq(schema.journalPhotos.status, 'processing'))
-		.orderBy(asc(schema.journalPhotos.createdAt))
-		.limit(1);
+	for (;;) {
+		const [candidate] = await db
+			.select({ id: schema.journalPhotos.id })
+			.from(schema.journalPhotos)
+			.where(eq(schema.journalPhotos.status, 'processing'))
+			.orderBy(asc(schema.journalPhotos.createdAt))
+			.limit(1);
 
-	if (!candidate) return null;
+		if (!candidate) return null; // queue empty
 
-	const claimed = await db
-		.update(schema.journalPhotos)
-		.set({
-			status: 'claimed',
-			transcodeAttempts: sql`${schema.journalPhotos.transcodeAttempts} + 1`
-		})
-		.where(
-			and(eq(schema.journalPhotos.id, candidate.id), eq(schema.journalPhotos.status, 'processing'))
-		)
-		.returning({
-			id: schema.journalPhotos.id,
-			storageKey: schema.journalPhotos.storageKey,
-			provider: schema.journalPhotos.provider,
-			mimeType: schema.journalPhotos.mimeType,
-			attempts: schema.journalPhotos.transcodeAttempts
-		});
+		const claimed = await db
+			.update(schema.journalPhotos)
+			.set({
+				status: 'claimed',
+				transcodeAttempts: sql`${schema.journalPhotos.transcodeAttempts} + 1`
+			})
+			.where(
+				and(
+					eq(schema.journalPhotos.id, candidate.id),
+					eq(schema.journalPhotos.status, 'processing')
+				)
+			)
+			.returning({
+				id: schema.journalPhotos.id,
+				storageKey: schema.journalPhotos.storageKey,
+				provider: schema.journalPhotos.provider,
+				mimeType: schema.journalPhotos.mimeType,
+				attempts: schema.journalPhotos.transcodeAttempts
+			});
 
-	if (claimed.length === 0) return null; // lost the race; try again
+		if (claimed.length === 0) continue; // lost the race; pick the next candidate
 
-	const row = claimed[0];
-	if (!row.storageKey) {
-		// A video row always has a storage key; if not, it cannot be transcoded.
-		await markFailed(row.id);
-		return null;
+		const row = claimed[0];
+		if (!row.storageKey) {
+			// A video row always has a storage key; if not, it cannot be
+			// transcoded. Fail it and keep draining the rest of the queue.
+			await markFailed(row.id);
+			continue;
+		}
+		return {
+			id: row.id,
+			storageKey: row.storageKey,
+			provider: row.provider,
+			mimeType: row.mimeType,
+			attempts: row.attempts
+		};
 	}
-	return {
-		id: row.id,
-		storageKey: row.storageKey,
-		provider: row.provider,
-		mimeType: row.mimeType,
-		attempts: row.attempts
-	};
 }
 
 async function markFailed(id: string): Promise<void> {
@@ -147,15 +169,44 @@ async function markFailed(id: string): Promise<void> {
 		.where(eq(schema.journalPhotos.id, id));
 }
 
+/**
+ * Deterministic output object keys for a job, derived from the source key's
+ * directory. The names depend only on the (server-generated) row id, so every
+ * attempt targets the same keys — re-runs overwrite rather than orphan.
+ */
+function outputKeys(job: ClaimedJob): { mp4Filename: string; mp4Key: string; posterKey: string } {
+	const slash = job.storageKey.lastIndexOf('/');
+	if (slash < 0) throw new Error(`malformed storage key (no path separator): ${job.storageKey}`);
+	const dir = job.storageKey.slice(0, slash);
+	const mp4Filename = `${job.id}.mp4`;
+	return {
+		mp4Filename,
+		mp4Key: `${dir}/${mp4Filename}`,
+		posterKey: `${dir}/${job.id}.poster.jpg`
+	};
+}
+
+/**
+ * Best-effort removal of a job's transcode outputs. Called when a job ends
+ * 'failed': the row stays pointing at its original source, so any MP4/poster a
+ * prior attempt uploaded before crashing is unreferenced and must be cleaned up.
+ */
+async function cleanupOutputs(job: ClaimedJob): Promise<void> {
+	let keys: ReturnType<typeof outputKeys>;
+	try {
+		keys = outputKeys(job);
+	} catch {
+		return;
+	}
+	const backend = getStorage(job.provider);
+	await Promise.allSettled([backend.delete(keys.mp4Key), backend.delete(keys.posterKey)]);
+}
+
 /** Process one claimed job end to end. Throws on any failure. */
 async function processJob(job: ClaimedJob): Promise<void> {
 	const backend = getStorage(job.provider);
 	const sourceKey = job.storageKey;
-	const dir = sourceKey.slice(0, sourceKey.lastIndexOf('/'));
-	const mp4Filename = `${job.id}.mp4`;
-	const posterFilename = `${job.id}.poster.jpg`;
-	const mp4Key = `${dir}/${mp4Filename}`;
-	const posterKey = `${dir}/${posterFilename}`;
+	const { mp4Filename, mp4Key, posterKey } = outputKeys(job);
 
 	await ensureTmpBase();
 	const jobDir = await mkdtemp(join(VIDEO_TRANSCODE.tmpDir, TMP_PREFIX));
@@ -211,6 +262,7 @@ async function drain(): Promise<void> {
 			if (job.attempts > MAX_ATTEMPTS) {
 				console.warn(`[video] job ${job.id} exhausted ${MAX_ATTEMPTS} attempts, marking failed`);
 				await markFailed(job.id);
+				await cleanupOutputs(job);
 				continue;
 			}
 			try {
@@ -219,6 +271,7 @@ async function drain(): Promise<void> {
 			} catch (err) {
 				console.error(`[video] transcode failed for ${job.id} (attempt ${job.attempts}):`, err);
 				await markFailed(job.id);
+				await cleanupOutputs(job);
 			}
 		}
 	} finally {

--- a/src/lib/server/video/worker.ts
+++ b/src/lib/server/video/worker.ts
@@ -1,0 +1,283 @@
+// Background video transcode worker (issue #86). A single in-process loop that
+// drains queued transcode jobs (journal_photos rows with status='processing'),
+// converts the source to a web-playable MP4 + poster via the hardened ffmpeg
+// wrapper, and updates the row. No external job queue — this fits the app's
+// single-process adapter-node + SQLite model.
+//
+// State machine (journal_photos.status):
+//   processing -> claimed -> ready          (success)
+//   processing -> claimed -> failed         (error, or attempts exhausted)
+//
+// A 'processing'/'failed' row is a fully valid RAW-video row: filename/storageKey
+// point at the original upload exactly as a pre-#86 video. Only on success does
+// the worker repoint the row at the transcoded MP4. So a failed transcode simply
+// degrades to the original "stored as-is" behavior — the UI's existing
+// can't-play fallback still works.
+//
+// Crash safety: a job is atomically claimed (status -> 'claimed', attempt
+// counter incremented) before any async work. On boot, recover() resets orphaned
+// 'claimed' rows back to 'processing'; the per-claim attempt cap turns a crashing
+// poison input into a terminal 'failed' after a few boots rather than an infinite
+// requeue. Leftover temp dirs are purged on boot.
+
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { and, asc, eq, sql } from 'drizzle-orm';
+import { db, schema } from '$lib/server/db';
+import { getStorage } from '$lib/server/storage';
+import { videoExtFromMime } from '$lib/server/storage/mime';
+import { VIDEO_TRANSCODE } from '$lib/server/env';
+import type { StorageProvider } from '$lib/server/storage/types';
+import { transcodeAvailable, transcodeToWebProfile } from './transcode';
+
+// Give up after this many attempts. The counter increments on each atomic claim,
+// so a job that crashes the process mid-transcode is retried on the next boot up
+// to this cap, then marked 'failed' instead of requeued forever.
+const MAX_ATTEMPTS = 3;
+
+// Prefix for per-job temp directories under VIDEO_TRANSCODE.tmpDir. Used both to
+// create job dirs and to identify orphans to purge on boot.
+const TMP_PREFIX = 'einvault-';
+
+// Only one loop runs at a time in this process. kick() is a no-op while a drain
+// is already in flight; the in-flight loop picks up anything newly enqueued.
+let draining = false;
+
+async function ensureTmpBase(): Promise<void> {
+	await mkdir(VIDEO_TRANSCODE.tmpDir, { recursive: true });
+}
+
+/** Read a web ReadableStream fully into a Buffer. */
+async function streamToBuffer(stream: ReadableStream): Promise<Buffer> {
+	const reader = stream.getReader();
+	const chunks: Buffer[] = [];
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		chunks.push(Buffer.from(value as Uint8Array));
+	}
+	return Buffer.concat(chunks);
+}
+
+/**
+ * Fetch the bytes of a stored object regardless of backend: local returns a
+ * stream, S3 returns a presigned redirect URL we then fetch.
+ */
+async function downloadObject(provider: StorageProvider, key: string): Promise<Buffer> {
+	const res = await getStorage(provider).get(key);
+	if (!res) throw new Error(`source object missing: ${key}`);
+	if (res.kind === 'stream') return streamToBuffer(res.stream);
+	if (res.kind === 'redirect') {
+		const r = await fetch(res.url);
+		if (!r.ok) throw new Error(`source fetch failed (${r.status})`);
+		return Buffer.from(await r.arrayBuffer());
+	}
+	throw new Error(`unexpected get result: ${res.kind}`);
+}
+
+interface ClaimedJob {
+	id: string;
+	storageKey: string;
+	provider: StorageProvider;
+	mimeType: string;
+	attempts: number;
+}
+
+/**
+ * Atomically claim the oldest queued job. Selects the oldest 'processing' row,
+ * then transitions it to 'claimed' guarded on its still being 'processing'
+ * (incrementing the attempt counter). Returns null when the queue is empty or
+ * the candidate was claimed by a racing writer (caller loops again).
+ */
+async function claimNext(): Promise<ClaimedJob | null> {
+	const [candidate] = await db
+		.select({
+			id: schema.journalPhotos.id,
+			storageKey: schema.journalPhotos.storageKey,
+			provider: schema.journalPhotos.provider,
+			mimeType: schema.journalPhotos.mimeType
+		})
+		.from(schema.journalPhotos)
+		.where(eq(schema.journalPhotos.status, 'processing'))
+		.orderBy(asc(schema.journalPhotos.createdAt))
+		.limit(1);
+
+	if (!candidate) return null;
+
+	const claimed = await db
+		.update(schema.journalPhotos)
+		.set({
+			status: 'claimed',
+			transcodeAttempts: sql`${schema.journalPhotos.transcodeAttempts} + 1`
+		})
+		.where(
+			and(eq(schema.journalPhotos.id, candidate.id), eq(schema.journalPhotos.status, 'processing'))
+		)
+		.returning({
+			id: schema.journalPhotos.id,
+			storageKey: schema.journalPhotos.storageKey,
+			provider: schema.journalPhotos.provider,
+			mimeType: schema.journalPhotos.mimeType,
+			attempts: schema.journalPhotos.transcodeAttempts
+		});
+
+	if (claimed.length === 0) return null; // lost the race; try again
+
+	const row = claimed[0];
+	if (!row.storageKey) {
+		// A video row always has a storage key; if not, it cannot be transcoded.
+		await markFailed(row.id);
+		return null;
+	}
+	return {
+		id: row.id,
+		storageKey: row.storageKey,
+		provider: row.provider,
+		mimeType: row.mimeType,
+		attempts: row.attempts
+	};
+}
+
+async function markFailed(id: string): Promise<void> {
+	// Leave filename/storageKey untouched: the row remains a valid raw-video row
+	// pointing at the original upload, so the UI's can't-play fallback works.
+	await db
+		.update(schema.journalPhotos)
+		.set({ status: 'failed' })
+		.where(eq(schema.journalPhotos.id, id));
+}
+
+/** Process one claimed job end to end. Throws on any failure. */
+async function processJob(job: ClaimedJob): Promise<void> {
+	const backend = getStorage(job.provider);
+	const sourceKey = job.storageKey;
+	const dir = sourceKey.slice(0, sourceKey.lastIndexOf('/'));
+	const mp4Filename = `${job.id}.mp4`;
+	const posterFilename = `${job.id}.poster.jpg`;
+	const mp4Key = `${dir}/${mp4Filename}`;
+	const posterKey = `${dir}/${posterFilename}`;
+
+	await ensureTmpBase();
+	const jobDir = await mkdtemp(join(VIDEO_TRANSCODE.tmpDir, TMP_PREFIX));
+	try {
+		// Download source -> temp file (ffmpeg reads the file, not a buffer).
+		const srcBuf = await downloadObject(job.provider, sourceKey);
+		const srcPath = join(jobDir, `source.${videoExtFromMime(job.mimeType)}`);
+		await writeFile(srcPath, srcBuf);
+
+		// Transcode (probe + cap-check happen inside).
+		const { mp4Path, posterPath } = await transcodeToWebProfile(srcPath, jobDir, job.mimeType);
+		const mp4Buf = await readFile(mp4Path);
+		const posterBuf = await readFile(posterPath);
+
+		// Upload outputs BEFORE repointing the row, so a crash here leaves the row
+		// pointing at the still-present original (it gets retried).
+		await backend.put({ key: mp4Key, body: mp4Buf, contentType: 'video/mp4' });
+		await backend.put({ key: posterKey, body: posterBuf, contentType: 'image/jpeg' });
+
+		const keepOriginal = VIDEO_TRANSCODE.keepOriginal;
+		await db
+			.update(schema.journalPhotos)
+			.set({
+				filename: mp4Filename,
+				storageKey: mp4Key,
+				posterKey,
+				originalKey: keepOriginal ? sourceKey : null,
+				mimeType: 'video/mp4',
+				sizeBytes: mp4Buf.length,
+				status: 'ready'
+			})
+			.where(eq(schema.journalPhotos.id, job.id));
+
+		// Discard the source only after the row no longer references it.
+		if (!keepOriginal) {
+			await backend.delete(sourceKey).catch((err) => {
+				console.warn(`[video] failed to delete original ${sourceKey}:`, err);
+			});
+		}
+	} finally {
+		await rm(jobDir, { recursive: true, force: true }).catch(() => {});
+	}
+}
+
+/** Drain the queue until empty. Single-flight via the `draining` guard. */
+async function drain(): Promise<void> {
+	if (draining) return;
+	draining = true;
+	try {
+		for (;;) {
+			const job = await claimNext();
+			if (!job) break;
+			if (job.attempts > MAX_ATTEMPTS) {
+				console.warn(`[video] job ${job.id} exhausted ${MAX_ATTEMPTS} attempts, marking failed`);
+				await markFailed(job.id);
+				continue;
+			}
+			try {
+				await processJob(job);
+				console.info(`[video] transcoded ${job.id}`);
+			} catch (err) {
+				console.error(`[video] transcode failed for ${job.id} (attempt ${job.attempts}):`, err);
+				await markFailed(job.id);
+			}
+		}
+	} finally {
+		draining = false;
+	}
+}
+
+/**
+ * Enqueue-side trigger: kick the drain loop. Safe to call after every upload;
+ * a no-op if a drain is already running or the feature is unavailable. Fire and
+ * forget — errors are logged, never thrown to the caller.
+ */
+export function kickWorker(): void {
+	transcodeAvailable()
+		.then((ok) => {
+			if (ok) return drain();
+		})
+		.catch((err) => console.error('[video] worker drain error:', err));
+}
+
+/**
+ * Remove orphaned per-job temp dirs left by a crash/SIGKILL. Best-effort.
+ */
+async function purgeOrphanTempDirs(): Promise<void> {
+	let entries: string[];
+	try {
+		entries = await readdir(VIDEO_TRANSCODE.tmpDir);
+	} catch {
+		return; // dir doesn't exist yet — nothing to purge
+	}
+	await Promise.all(
+		entries
+			.filter((name) => name.startsWith(TMP_PREFIX))
+			.map((name) =>
+				rm(join(VIDEO_TRANSCODE.tmpDir, name), { recursive: true, force: true }).catch(() => {})
+			)
+	);
+}
+
+/**
+ * Boot-time recovery. Resets jobs orphaned mid-transcode by a crash ('claimed'
+ * back to 'processing'; the per-attempt cap caps total retries), purges leftover
+ * temp dirs, then kicks the worker to drain anything pending. No-op when
+ * transcoding is unavailable. Fire and forget.
+ */
+export function recoverAndStart(): void {
+	transcodeAvailable()
+		.then(async (ok) => {
+			if (!ok) return;
+			const reset = await db
+				.update(schema.journalPhotos)
+				.set({ status: 'processing' })
+				.where(eq(schema.journalPhotos.status, 'claimed'))
+				.returning({ id: schema.journalPhotos.id });
+			if (reset.length > 0) {
+				console.info(`[video] recovered ${reset.length} interrupted transcode job(s)`);
+			}
+			await purgeOrphanTempDirs();
+			await drain();
+		})
+		.catch((err) => console.error('[video] worker recovery error:', err));
+}

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -80,6 +80,10 @@
 		return `/api/photos/journal/${companion.id}/${date}/${photo.filename}`;
 	}
 
+	function posterUrl(photo: Entry['photos'][0], date: string) {
+		return photo.posterKey ? `${photoUrl(photo, date)}?poster` : null;
+	}
+
 	function monthKey(date: string) {
 		return date.slice(0, 7);
 	}
@@ -250,6 +254,8 @@
 				{#if lightboxPhoto.mediaType === 'video'}
 					<JournalVideo
 						src={photoUrl(lightboxPhoto, lightboxDate)}
+						poster={posterUrl(lightboxPhoto, lightboxDate)}
+						status={lightboxPhoto.status}
 						downloadName={lightboxPhoto.originalName}
 						label={lightboxPhoto.originalName ?? undefined}
 						autoplay
@@ -509,13 +515,22 @@
 										)}
 								>
 									{#if photo.mediaType === 'video'}
-										<video
-											src={photoUrl(photo, entry.date)}
-											preload="metadata"
-											muted
-											playsinline
-											class="w-full h-full object-cover pointer-events-none"
-										></video>
+										{#if photo.posterKey}
+											<img
+												src={posterUrl(photo, entry.date)}
+												alt={photo.originalName ?? ''}
+												class="w-full h-full object-cover pointer-events-none"
+												loading="lazy"
+											/>
+										{:else}
+											<video
+												src={photoUrl(photo, entry.date)}
+												preload="metadata"
+												muted
+												playsinline
+												class="w-full h-full object-cover pointer-events-none"
+											></video>
+										{/if}
 										<span
 											class="absolute inset-0 flex items-center justify-center bg-black/20"
 											aria-hidden="true"

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -136,7 +136,8 @@
 				setUploadError(err.message ?? 'Upload failed');
 				return;
 			}
-			const { id, filename, provider, storageKey, loggedBy, logger } = await res.json();
+			const { id, filename, provider, storageKey, status, posterKey, mimeType, loggedBy, logger } =
+				await res.json();
 			photos = [
 				...photos,
 				{
@@ -147,12 +148,12 @@
 					entryId: data.entry?.id ?? '',
 					originalName: file.name,
 					mediaType: isVideoMime(file.type) ? 'video' : 'photo',
-					mimeType: file.type,
+					mimeType: mimeType ?? file.type,
 					sizeBytes: file.size,
 					notes: null,
-					status: 'ready',
+					status: status ?? 'ready',
 					originalKey: null,
-					posterKey: null,
+					posterKey: posterKey ?? null,
 					transcodeAttempts: 0,
 					createdAt: new Date(),
 					loggedBy,

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -150,6 +150,10 @@
 					mimeType: file.type,
 					sizeBytes: file.size,
 					notes: null,
+					status: 'ready',
+					originalKey: null,
+					posterKey: null,
+					transcodeAttempts: 0,
 					createdAt: new Date(),
 					loggedBy,
 					logger
@@ -234,6 +238,44 @@
 	function photoUrl(photo: (typeof photos)[0]) {
 		return `/api/photos/journal/${companion.id}/${data.date}/${photo.filename}`;
 	}
+
+	function posterUrl(photo: (typeof photos)[0]) {
+		return photo.posterKey ? `${photoUrl(photo)}?poster` : null;
+	}
+
+	// While any video is still transcoding, poll its status and swap in the
+	// transcoded MP4 (filename/mimeType/poster change) without a full reload —
+	// invalidateAll would clobber the in-progress journal text. Patches only the
+	// transcode-relevant fields of the matching rows.
+	$effect(() => {
+		const pending = photos.some((p) => p.status === 'processing' || p.status === 'claimed');
+		if (!pending) return;
+		const interval = setInterval(async () => {
+			try {
+				const res = await fetch(`/api/companions/${companion.id}/journal/${data.date}/photos`);
+				if (!res.ok) return;
+				const { photos: statuses } = await res.json();
+				const byId = new Map<string, (typeof statuses)[number]>(
+					statuses.map((s: { id: string }) => [s.id, s])
+				);
+				photos = photos.map((p) => {
+					const s = byId.get(p.id);
+					return s
+						? {
+								...p,
+								status: s.status,
+								filename: s.filename,
+								mimeType: s.mimeType,
+								posterKey: s.posterKey
+							}
+						: p;
+				});
+			} catch {
+				// transient; next tick retries
+			}
+		}, 3000);
+		return () => clearInterval(interval);
+	});
 
 	function handleKeydown(e: KeyboardEvent) {
 		if (e.key === 'Escape' && detailEvent) {
@@ -730,6 +772,8 @@
 								{#if photo.mediaType === 'video'}
 									<JournalVideo
 										src={photoUrl(photo)}
+										poster={posterUrl(photo)}
+										status={photo.status}
 										downloadName={photo.originalName}
 										label={photo.originalName ?? undefined}
 										class="w-full h-full object-cover"

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -39,6 +39,15 @@
 	let { data }: { data: PageData } = $props();
 	const locale = getLocale();
 
+	// Shape of the transcode status poll response (GET .../photos).
+	type VideoStatus = {
+		id: string;
+		status: 'ready' | 'processing' | 'claimed' | 'failed';
+		filename: string;
+		mimeType: string;
+		posterKey: string | null;
+	};
+
 	let photos = $state<typeof data.photos>([]);
 	let companion = $derived(data.companion);
 
@@ -244,35 +253,45 @@
 		return photo.posterKey ? `${photoUrl(photo)}?poster` : null;
 	}
 
-	// While any video is still transcoding, poll its status and swap in the
-	// transcoded MP4 (filename/mimeType/poster change) without a full reload —
-	// invalidateAll would clobber the in-progress journal text. Patches only the
-	// transcode-relevant fields of the matching rows.
+	// True while any video is still transcoding. Derived so the poll effect starts
+	// once when work appears and stops once when it finishes — not on every edit to
+	// the photos array.
+	const hasPendingTranscode = $derived(
+		photos.some((p) => p.status === 'processing' || p.status === 'claimed')
+	);
+
+	// Poll the transcode status and swap in the MP4 (filename/mimeType/poster
+	// change) without a full reload — invalidateAll would clobber the in-progress
+	// journal text. Patches only the transcode-relevant fields of changed rows.
 	$effect(() => {
-		const pending = photos.some((p) => p.status === 'processing' || p.status === 'claimed');
-		if (!pending) return;
+		if (!hasPendingTranscode) return;
+		let inFlight = false;
 		const interval = setInterval(async () => {
+			if (inFlight) return; // don't stack requests if one poll is slow
+			inFlight = true;
 			try {
 				const res = await fetch(`/api/companions/${companion.id}/journal/${data.date}/photos`);
 				if (!res.ok) return;
-				const { photos: statuses } = await res.json();
-				const byId = new Map<string, (typeof statuses)[number]>(
-					statuses.map((s: { id: string }) => [s.id, s])
-				);
-				photos = photos.map((p) => {
+				const { photos: statuses }: { photos: VideoStatus[] } = await res.json();
+				const byId = new Map(statuses.map((s) => [s.id, s]));
+				let changed = false;
+				const next = photos.map((p) => {
 					const s = byId.get(p.id);
-					return s
-						? {
-								...p,
-								status: s.status,
-								filename: s.filename,
-								mimeType: s.mimeType,
-								posterKey: s.posterKey
-							}
-						: p;
+					if (!s || s.status === p.status) return p;
+					changed = true;
+					return {
+						...p,
+						status: s.status,
+						filename: s.filename,
+						mimeType: s.mimeType,
+						posterKey: s.posterKey
+					};
 				});
+				if (changed) photos = next;
 			} catch {
 				// transient; next tick retries
+			} finally {
+				inFlight = false;
 			}
 		}, 3000);
 		return () => clearInterval(interval);

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -16,6 +16,15 @@
 	let { data }: { data: PageData } = $props();
 	const locale = getLocale();
 
+	// Shape of the transcode status poll response (GET .../photos).
+	type VideoStatus = {
+		id: string;
+		status: 'ready' | 'processing' | 'claimed' | 'failed';
+		filename: string;
+		mimeType: string;
+		posterKey: string | null;
+	};
+
 	let body = $state(untrack(() => data.todayEntry?.body ?? ''));
 	let mood = $state(untrack(() => data.todayEntry?.mood ?? ''));
 	let saveStatus = $state<'idle' | 'saving' | 'saved' | 'error'>('idle');
@@ -165,35 +174,46 @@
 		return photo.posterKey ? `${photoUrl(photo)}?poster` : null;
 	}
 
+	// True while any video is still transcoding. Derived so the poll effect starts
+	// once when work appears and stops once when it finishes.
+	const hasPendingTranscode = $derived(
+		photos.some((p) => p.status === 'processing' || p.status === 'claimed')
+	);
+
 	// Poll transcoding videos and swap in the MP4 once ready, without a full
-	// reload (which would clobber the in-progress journal text).
+	// reload (which would clobber the in-progress journal text). Patches only the
+	// transcode-relevant fields of changed rows.
 	$effect(() => {
-		const pending = photos.some((p) => p.status === 'processing' || p.status === 'claimed');
-		if (!pending) return;
+		if (!hasPendingTranscode) return;
+		let inFlight = false;
 		const interval = setInterval(async () => {
+			if (inFlight) return; // don't stack requests if one poll is slow
+			inFlight = true;
 			try {
 				const res = await fetch(
 					`/api/companions/${data.companion.id}/journal/${data.today}/photos`
 				);
 				if (!res.ok) return;
-				const { photos: statuses } = await res.json();
-				const byId = new Map<string, (typeof statuses)[number]>(
-					statuses.map((s: { id: string }) => [s.id, s])
-				);
-				photos = photos.map((p) => {
+				const { photos: statuses }: { photos: VideoStatus[] } = await res.json();
+				const byId = new Map(statuses.map((s) => [s.id, s]));
+				let changed = false;
+				const next = photos.map((p) => {
 					const s = byId.get(p.id);
-					return s
-						? {
-								...p,
-								status: s.status,
-								filename: s.filename,
-								mimeType: s.mimeType,
-								posterKey: s.posterKey
-							}
-						: p;
+					if (!s || s.status === p.status) return p;
+					changed = true;
+					return {
+						...p,
+						status: s.status,
+						filename: s.filename,
+						mimeType: s.mimeType,
+						posterKey: s.posterKey
+					};
 				});
+				if (changed) photos = next;
 			} catch {
 				// transient; next tick retries
+			} finally {
+				inFlight = false;
 			}
 		}, 3000);
 		return () => clearInterval(interval);

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -87,7 +87,8 @@
 				setUploadError(err.message ?? 'Upload failed');
 				return;
 			}
-			const { id, filename, provider, storageKey, loggedBy, logger } = await res.json();
+			const { id, filename, provider, storageKey, status, posterKey, mimeType, loggedBy, logger } =
+				await res.json();
 			photos = [
 				...photos,
 				{
@@ -98,12 +99,12 @@
 					entryId: data.todayEntry?.id ?? '',
 					originalName: file.name,
 					mediaType: isVideoMime(file.type) ? 'video' : 'photo',
-					mimeType: file.type,
+					mimeType: mimeType ?? file.type,
 					sizeBytes: file.size,
 					notes: null,
-					status: 'ready',
+					status: status ?? 'ready',
 					originalKey: null,
-					posterKey: null,
+					posterKey: posterKey ?? null,
 					transcodeAttempts: 0,
 					createdAt: new Date(),
 					loggedBy,

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -101,6 +101,10 @@
 					mimeType: file.type,
 					sizeBytes: file.size,
 					notes: null,
+					status: 'ready',
+					originalKey: null,
+					posterKey: null,
+					transcodeAttempts: 0,
 					createdAt: new Date(),
 					loggedBy,
 					logger
@@ -155,6 +159,44 @@
 	function photoUrl(photo: (typeof photos)[0]) {
 		return `/api/photos/journal/${data.companion.id}/${data.today}/${photo.filename}`;
 	}
+
+	function posterUrl(photo: (typeof photos)[0]) {
+		return photo.posterKey ? `${photoUrl(photo)}?poster` : null;
+	}
+
+	// Poll transcoding videos and swap in the MP4 once ready, without a full
+	// reload (which would clobber the in-progress journal text).
+	$effect(() => {
+		const pending = photos.some((p) => p.status === 'processing' || p.status === 'claimed');
+		if (!pending) return;
+		const interval = setInterval(async () => {
+			try {
+				const res = await fetch(
+					`/api/companions/${data.companion.id}/journal/${data.today}/photos`
+				);
+				if (!res.ok) return;
+				const { photos: statuses } = await res.json();
+				const byId = new Map<string, (typeof statuses)[number]>(
+					statuses.map((s: { id: string }) => [s.id, s])
+				);
+				photos = photos.map((p) => {
+					const s = byId.get(p.id);
+					return s
+						? {
+								...p,
+								status: s.status,
+								filename: s.filename,
+								mimeType: s.mimeType,
+								posterKey: s.posterKey
+							}
+						: p;
+				});
+			} catch {
+				// transient; next tick retries
+			}
+		}, 3000);
+		return () => clearInterval(interval);
+	});
 
 	function formatDate(dateStr: string): string {
 		return new Date(dateStr + 'T00:00:00').toLocaleDateString(undefined, {
@@ -333,6 +375,8 @@
 									{#if photo.mediaType === 'video'}
 										<JournalVideo
 											src={photoUrl(photo)}
+											poster={posterUrl(photo)}
+											status={photo.status}
 											downloadName={photo.originalName}
 											label={photo.originalName ?? undefined}
 											class="w-full h-full object-cover"

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -270,12 +270,21 @@ export const DELETE: RequestHandler = async ({ url, params, locals }) => {
 	// Remove every object this row owns: the primary file plus, for a transcoded
 	// video, the kept original and the generated poster. Missing keys are no-ops
 	// in the backend delete, so deleting all three is safe regardless of status.
+	// Use allSettled and delete the DB row unconditionally: the row is the source
+	// of truth, so a transient backend failure on one key must not abort the
+	// others or leave an undeletable row (an orphaned object is recoverable; a
+	// stuck row is not).
 	const backend = getStorage(photo.provider);
 	const key = photo.storageKey ?? journalKey(params.companionId, params.date, photo.filename);
 	const keys = [key, photo.originalKey, photo.posterKey].filter(
 		(k): k is string => typeof k === 'string' && k.length > 0
 	);
-	await Promise.all(keys.map((k) => backend.delete(k)));
+	const results = await Promise.allSettled(keys.map((k) => backend.delete(k)));
+	results.forEach((r, i) => {
+		if (r.status === 'rejected') {
+			console.warn(`[journal-photo] failed to delete object ${keys[i]}:`, r.reason);
+		}
+	});
 
 	await db.delete(schema.journalPhotos).where(eq(schema.journalPhotos.id, photoId));
 

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -6,8 +6,10 @@ import { eq, and, count } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 import sharp from 'sharp';
 import { getStorage, STORAGE_BACKEND } from '$lib/server/storage';
-import { MAX_DAILY_MEDIA, UPLOAD_MAX_MB, VIDEO_MAX_MB } from '$lib/server/env';
+import { MAX_DAILY_MEDIA, UPLOAD_MAX_MB, VIDEO_MAX_MB, VIDEO_TRANSCODE } from '$lib/server/env';
 import { isAllowedVideoMime, looksLikeVideo, videoExtFromMime } from '$lib/server/storage/mime';
+import { demuxerForMime, transcodeAvailable } from '$lib/server/video/transcode';
+import { kickWorker } from '$lib/server/video/worker';
 import { canModifyPhoto } from '$lib/permissions';
 import { isValidDate } from '$lib/server/validation';
 
@@ -18,6 +20,50 @@ const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif
 function journalKey(companionId: string, date: string, filename: string): string {
 	return `journal/${companionId}/${date}/${filename}`;
 }
+
+// Lightweight status poll for the journal UI. Returns just the transcode-relevant
+// fields so the client can update a 'processing' video to its transcoded MP4
+// (filename/mimeType change, poster appears) without reloading the page and
+// clobbering an in-progress journal edit. Scoped like the other handlers:
+// caretakers may only read their assigned companions.
+export const GET: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+
+	const { companionId, date } = params;
+	if (!isValidDate(date)) error(400, t(locals.locale, 'error.invalidDate'));
+
+	if (locals.user.role === 'caretaker') {
+		const assignment = await db.query.companionCaretakers.findFirst({
+			where: and(
+				eq(schema.companionCaretakers.companionId, companionId),
+				eq(schema.companionCaretakers.userId, locals.user.id)
+			)
+		});
+		if (!assignment) error(403, t(locals.locale, 'error.forbidden'));
+	}
+
+	const entry = await db.query.journalEntries.findFirst({
+		where: and(
+			eq(schema.journalEntries.companionId, companionId),
+			eq(schema.journalEntries.date, date)
+		),
+		columns: { id: true }
+	});
+	if (!entry) return json({ photos: [] });
+
+	const rows = await db
+		.select({
+			id: schema.journalPhotos.id,
+			status: schema.journalPhotos.status,
+			filename: schema.journalPhotos.filename,
+			mimeType: schema.journalPhotos.mimeType,
+			posterKey: schema.journalPhotos.posterKey
+		})
+		.from(schema.journalPhotos)
+		.where(eq(schema.journalPhotos.entryId, entry.id));
+
+	return json({ photos: rows });
+};
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
@@ -113,7 +159,23 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		mimeType = 'image/jpeg';
 	}
 
-	const filename = `${photoId}.${ext}`;
+	// Queue this video for background transcoding when the feature is enabled,
+	// ffmpeg is present, the container is supported, and the clip is within the
+	// transcode size cap. The row is stored as a normal raw-video row and flipped
+	// to 'processing'; the worker repoints it at the transcoded MP4 when done.
+	// Anything that doesn't qualify is stored as-is (status defaults to 'ready').
+	const willTranscode =
+		isVideo &&
+		demuxerForMime(mimeType) !== null &&
+		processed.length <= VIDEO_TRANSCODE.maxMb * 1024 * 1024 &&
+		(await transcodeAvailable());
+
+	// A to-be-transcoded source is stored under a sentinel '.orig.' name so its
+	// key can never collide with the worker's output ('{photoId}.mp4'). Without
+	// this, an mp4-container source (e.g. Apple HEVC) would share the output key:
+	// the transcode would overwrite the kept original, or — with KEEP_ORIGINAL
+	// off — the post-transcode cleanup would delete the output itself.
+	const filename = willTranscode ? `${photoId}.orig.${ext}` : `${photoId}.${ext}`;
 	const key = journalKey(companionId, date, filename);
 	try {
 		await getStorage().put({
@@ -136,8 +198,11 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		mediaType,
 		mimeType,
 		sizeBytes: processed.length,
+		status: willTranscode ? 'processing' : 'ready',
 		loggedBy: locals.user.id
 	});
+
+	if (willTranscode) kickWorker();
 
 	const created = await db.query.journalPhotos.findFirst({
 		where: eq(schema.journalPhotos.id, photoId),
@@ -202,8 +267,15 @@ export const DELETE: RequestHandler = async ({ url, params, locals }) => {
 
 	if (!canModifyPhoto(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
 
+	// Remove every object this row owns: the primary file plus, for a transcoded
+	// video, the kept original and the generated poster. Missing keys are no-ops
+	// in the backend delete, so deleting all three is safe regardless of status.
+	const backend = getStorage(photo.provider);
 	const key = photo.storageKey ?? journalKey(params.companionId, params.date, photo.filename);
-	await getStorage(photo.provider).delete(key);
+	const keys = [key, photo.originalKey, photo.posterKey].filter(
+		(k): k is string => typeof k === 'string' && k.length > 0
+	);
+	await Promise.all(keys.map((k) => backend.delete(k)));
 
 	await db.delete(schema.journalPhotos).where(eq(schema.journalPhotos.id, photoId));
 

--- a/src/routes/api/photos/[...path]/+server.ts
+++ b/src/routes/api/photos/[...path]/+server.ts
@@ -8,7 +8,7 @@ import { getStorage, type GetResult } from '$lib/server/storage';
 // URL shape: /api/photos/journal/{companionId}/{date}/{filename}
 const JOURNAL_PREFIX = 'journal';
 
-export const GET: RequestHandler = async ({ params, locals, request }) => {
+export const GET: RequestHandler = async ({ params, url, locals, request }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
 
 	const requestedPath = params.path ?? '';
@@ -42,9 +42,24 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 		if (!assignment) error(403, t(locals.locale, 'error.forbidden'));
 	}
 
-	// For local rows the URL path IS the storage key. For S3 / Immich rows we
-	// use the row's storage_key column instead.
-	const key = photo.storageKey ?? requestedPath;
+	// `?poster` serves the transcoded video's generated poster JPEG instead of the
+	// media itself. The poster key comes from the row (resolved after the same
+	// companion/date/caretaker scoping above), never from the client, so it can't
+	// be used to read another companion's object. The kept original (originalKey)
+	// is deliberately never served by any route.
+	const wantPoster = url.searchParams.has('poster');
+	let key: string;
+	let contentType: string;
+	if (wantPoster) {
+		if (!photo.posterKey) error(404, t(locals.locale, 'error.notFound'));
+		key = photo.posterKey;
+		contentType = 'image/jpeg';
+	} else {
+		// For local rows the URL path IS the storage key. For S3 / Immich rows we
+		// use the row's storage_key column instead.
+		key = photo.storageKey ?? requestedPath;
+		contentType = photo.mimeType;
+	}
 	const ifNoneMatch = request.headers.get('if-none-match');
 	const range = request.headers.get('range');
 
@@ -82,7 +97,7 @@ export const GET: RequestHandler = async ({ params, locals, request }) => {
 		photo.provider === 'immich' ? 'private, max-age=300' : 'private, max-age=31536000, immutable';
 
 	const headers: Record<string, string> = {
-		'Content-Type': photo.mimeType,
+		'Content-Type': contentType,
 		'Cache-Control': cacheControl,
 		ETag: res.stat.etag,
 		'X-Content-Type-Options': 'nosniff',


### PR DESCRIPTION
Closes #86.

Adds optional server-side transcoding of journal videos to a universal web profile (H.264 + AAC MP4 with `+faststart`) plus a generated poster, so clips a browser can't decode natively (e.g. Apple HEVC in Firefox) play in-browser instead of falling back to a download link.

## Behavior
- Off by default behind `VIDEO_TRANSCODE`. `ffmpeg`/`ffprobe` ship in the Docker image (HEVC decode + libx264). If the binaries aren't found, the feature self-disables and videos are stored as-is, exactly as before.
- Transcoding runs in a single in-process background worker. The upload returns immediately with a `processing` row; the worker converts the source, uploads the MP4 + poster, and repoints the row. The journal pages poll a lightweight status endpoint and swap in the player without a full reload.
- Interrupted jobs are reset on boot; an attempt counter caps retries so a poison input can't requeue forever.
- `VIDEO_KEEP_ORIGINAL` (default true) keeps the source alongside the transcode; the original is never served, only retained for re-encode/backup.
- Cost caps (`VIDEO_TRANSCODE_MAX_MB`/`_MAX_SECONDS`/`_MAX_WIDTH`/`_MAX_HEIGHT`) and pinned binary paths are configurable. Full env table in the README.

## Security
Untrusted media is decoded with a hardened ffmpeg invocation:
- `spawn` with argv arrays (no shell), pinned absolute binary paths, and an assert that input/output paths are absolute.
- `-protocol_whitelist file,crypto` plus a forced input demuxer derived from our MIME allowlist — blocks SSRF, `file://` reads, and playlist/concat tricks embedded in crafted inputs.
- ffprobe gates resolution/duration/stream-count before a full decode; per-process wall-clock timeouts with SIGKILL; capped stdout/stderr buffers; ffmpeg stderr never reaches the client.
- Random `mkdtemp` scratch dirs under a disk-backed `VIDEO_TMP_DIR` (not the in-memory `/tmp`), cleaned up on every exit path, with boot-time orphan purge.
- The poster endpoint reuses the existing per-companion/date/caretaker scoping and resolves the poster key from the row, never the client. Delete removes all three keys. To-be-transcoded sources are stored under an `.orig.` name so their key can't collide with the transcoded output.

Container-level isolation (read-only rootfs, dropped caps, no-new-privileges) is already provided by the shipped compose files and documented as deploy guidance.

## Schema
Migration `0014` adds `status`, `original_key`, `poster_key`, `transcode_attempts` to `journal_photos`. Existing rows default to `ready` (unchanged behavior).

## Testing
End-to-end verified in the Docker image with a real libx265/HEVC clip: setup → companion → upload → background transcode → poll → serve. Confirmed H.264 output, faststart (moov before mdat), 320×240 poster, the processing→ready lifecycle, and original retention/discard in both `VIDEO_KEEP_ORIGINAL` modes. `npm run check` and `npm run lint` are clean.