### PR TITLE
Email notifications, forgot password, and ntfy push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,7 +222,6 @@ ORIGIN=https://einvault.yourdomain.com
 # SMTP_SECURE=false
 
 # Credentials. Leave unset for unauthenticated relays.
-# Gmail requires an app password: https://support.google.com/accounts/answer/185833
 # SMTP_USER=
 # SMTP_PASS=
 

--- a/.env.example
+++ b/.env.example
@@ -205,3 +205,26 @@ ORIGIN=https://einvault.yourdomain.com
 # If absent, an ephemeral key is generated at startup — in-flight logins will
 # break across server restarts. Pin this value for stable behaviour.
 # OIDC_STATE_SECRET=a-long-random-string-here
+
+# Optional: SMTP email (issue #12)
+#
+# Enables outbound email and, with it, the self-service "Forgot password?"
+# flow on the login page. Disabled unless SMTP_HOST and SMTP_FROM are both
+# set. ORIGIN must be correct: password reset links are built from it.
+
+# SMTP server hostname.
+# SMTP_HOST=smtp.example.com
+
+# SMTP port (default: 587).
+# SMTP_PORT=587
+
+# true = implicit TLS, typically port 465. false (default) = STARTTLS on 587.
+# SMTP_SECURE=false
+
+# Credentials. Leave unset for unauthenticated relays.
+# Gmail requires an app password: https://support.google.com/accounts/answer/185833
+# SMTP_USER=
+# SMTP_PASS=
+
+# From address shown to recipients, e.g. 'EinVault <einvault@example.com>'.
+# SMTP_FROM=EinVault <einvault@example.com>

--- a/.env.example
+++ b/.env.example
@@ -227,3 +227,18 @@ ORIGIN=https://einvault.yourdomain.com
 
 # From address shown to recipients, e.g. 'EinVault <einvault@example.com>'.
 # SMTP_FROM=EinVault <einvault@example.com>
+
+# Optional: ntfy push notifications (issue #12)
+#
+# Configures the ntfy SERVER only. Each user sets their own topic name under
+# Settings -> Notifications; a non-empty topic is that user's opt-in for
+# pushes (reminders due, shift alerts) scoped to what they can see in the
+# app. On public servers like ntfy.sh, a topic name is the only access
+# control - users should pick long random topic names.
+
+# ntfy server base URL (no topic).
+# NTFY_URL=https://ntfy.sh
+
+# Access token, for self-hosted ntfy servers with auth enabled. Used for
+# every publish regardless of topic.
+# NTFY_TOKEN=

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ When `SMTP_HOST` and `SMTP_FROM` are both set, EinVault enables outbound email a
 | `SMTP_HOST`   | —       | SMTP server hostname. Required (with `SMTP_FROM`) to enable email.                                                              |
 | `SMTP_PORT`   | `587`   | SMTP port. Use `465` with `SMTP_SECURE=true` for implicit TLS, or `587` (default) for STARTTLS.                                 |
 | `SMTP_SECURE` | `false` | `true` = implicit TLS (port 465). `false` = STARTTLS upgrade on connect.                                                        |
-| `SMTP_USER`   | —       | SMTP username. Leave unset for unauthenticated relays. Gmail requires an app password.                                          |
+| `SMTP_USER`   | —       | SMTP username. Leave unset for unauthenticated relays.                                                                          |
 | `SMTP_PASS`   | —       | SMTP password. Leave unset for unauthenticated relays.                                                                          |
 | `SMTP_FROM`   | —       | RFC 5322 From address shown to recipients, e.g. `EinVault <einvault@example.com>`. Required (with `SMTP_HOST`) to enable email. |
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ When `SMTP_HOST` and `SMTP_FROM` are both set, EinVault enables outbound email a
 | `SMTP_PASS`   | —       | SMTP password. Leave unset for unauthenticated relays.                                                                          |
 | `SMTP_FROM`   | —       | RFC 5322 From address shown to recipients, e.g. `EinVault <einvault@example.com>`. Required (with `SMTP_HOST`) to enable email. |
 
+### ntfy push notifications (optional)
+
+When `NTFY_URL` is set, EinVault can publish push notifications via [ntfy](https://ntfy.sh). This configures the server only (base URL and optional access token). Each user sets their own topic name under Settings -> Notifications; a non-empty topic is that user's opt-in for pushes scoped to what they can see in the app (reminders due, shift alerts). The notification scheduler runs when either SMTP or ntfy is configured. The forgot-password flow remains email-only.
+
+On public servers like ntfy.sh, the topic name is the only access control. Users should pick long, random topic names that are hard to guess.
+
+|              | Default | Description                                                                                              |
+| ------------ | ------- | -------------------------------------------------------------------------------------------------------- |
+| `NTFY_URL`   | —       | ntfy server base URL, e.g. `https://ntfy.sh` or a self-hosted instance. No topic in the URL.             |
+| `NTFY_TOKEN` | —       | Bearer token for self-hosted ntfy servers with auth enabled. Used for every publish regardless of topic. |
+
 ### Data and backup
 
 Data lives in `./data` next to the compose file. Stop the container first so SQLite isn't mid-write, then copy the directory:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ EinVault is a private, self-hosted companion health and care tracker built for h
   - [Video transcoding (optional)](#video-transcoding-optional)
   - [External image storage (optional)](#external-image-storage-optional)
   - [Immich integration (optional)](#immich-integration-optional)
+  - [SMTP email (optional)](#smtp-email-optional)
+  - [ntfy push notifications (optional)](#ntfy-push-notifications-optional)
   - [Data and backup](#data-and-backup)
   - [Container hardening](#container-hardening)
   - [Image tags](#image-tags)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ When `IMMICH_URL` and `IMMICH_API_KEY` are set, members and admins get a "Pick f
 | `IMMICH_API_KEY`  | —       | API key. Required permissions: `asset.read`, `asset.view`, plus `album.read` if `IMMICH_ALBUM_ID` is set. Generate in Immich → Account Settings → API Keys. Required if `IMMICH_URL` is set. |
 | `IMMICH_ALBUM_ID` | —       | If set, the picker only shows assets in this album. If unset, the picker shows the user's most recent assets across the whole library.                                                       |
 
+### SMTP email (optional)
+
+When `SMTP_HOST` and `SMTP_FROM` are both set, EinVault enables outbound email and adds a self-service "Forgot password?" link on the login page. Both variables must be set together; setting only one disables email and logs a warning at startup.
+
+`ORIGIN` must be set correctly: password reset links are built from it. Behind a reverse proxy, make sure `ORIGIN` matches the public URL users see.
+
+|               | Default | Description                                                                                                                     |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `SMTP_HOST`   | —       | SMTP server hostname. Required (with `SMTP_FROM`) to enable email.                                                              |
+| `SMTP_PORT`   | `587`   | SMTP port. Use `465` with `SMTP_SECURE=true` for implicit TLS, or `587` (default) for STARTTLS.                                 |
+| `SMTP_SECURE` | `false` | `true` = implicit TLS (port 465). `false` = STARTTLS upgrade on connect.                                                        |
+| `SMTP_USER`   | —       | SMTP username. Leave unset for unauthenticated relays. Gmail requires an app password.                                          |
+| `SMTP_PASS`   | —       | SMTP password. Leave unset for unauthenticated relays.                                                                          |
+| `SMTP_FROM`   | —       | RFC 5322 From address shown to recipients, e.g. `EinVault <einvault@example.com>`. Required (with `SMTP_HOST`) to enable email. |
+
 ### Data and backup
 
 Data lives in `./data` next to the compose file. Stop the container first so SQLite isn't mid-write, then copy the directory:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ When `IMMICH_URL` and `IMMICH_API_KEY` are set, members and admins get a "Pick f
 
 ### SMTP email (optional)
 
-When `SMTP_HOST` and `SMTP_FROM` are both set, EinVault enables outbound email and adds a self-service "Forgot password?" link on the login page. Both variables must be set together; setting only one disables email and logs a warning at startup.
+When `SMTP_HOST` and `SMTP_FROM` are both set, EinVault enables outbound email and adds a self-service "Forgot password?" link on the login page. When SMTP is configured, users can also opt in (Settings -> Notifications) to an email when a reminder comes due, and to an email 24 hours before a caretaker shift starts or ends. Caretakers only receive reminder emails for companions assigned to them, and shift emails for their own shifts. Both variables must be set together; setting only one disables email and logs a warning at startup.
 
 `ORIGIN` must be set correctly: password reset links are built from it. Behind a reverse proxy, make sure `ORIGIN` matches the public URL users see.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -79,6 +79,11 @@ services:
       SMTP_PASS: ${SMTP_PASS:-}
       SMTP_FROM: ${SMTP_FROM:-}
 
+      # Optional: ntfy push notifications. Server config only; users set
+      # their own topic in Settings. Disabled unless NTFY_URL is set.
+      NTFY_URL: ${NTFY_URL:-}
+      NTFY_TOKEN: ${NTFY_TOKEN:-}
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -70,6 +70,15 @@ services:
       IMMICH_API_KEY: ${IMMICH_API_KEY:-}
       IMMICH_ALBUM_ID: ${IMMICH_ALBUM_ID:-}
 
+      # Optional: SMTP email. Enables outbound mail and the "Forgot password?"
+      # flow. Disabled unless SMTP_HOST and SMTP_FROM are both set.
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_SECURE: ${SMTP_SECURE:-false}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      SMTP_FROM: ${SMTP_FROM:-}
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -83,6 +83,19 @@ services:
       # Optional: restrict picker to a single Immich album.
       # IMMICH_ALBUM_ID:
 
+      # Optional: SMTP email
+      # Enables outbound mail and the self-service "Forgot password?" flow on
+      # the login page. Disabled unless SMTP_HOST and SMTP_FROM are both set.
+      # ORIGIN above must be correct: password reset links are built from it.
+      # SMTP_HOST: smtp.example.com
+      # SMTP_PORT: 587
+      # true = implicit TLS (465). false (default) = STARTTLS on 587.
+      # SMTP_SECURE: 'false'
+      # Leave unset for unauthenticated LAN relays.
+      # SMTP_USER:
+      # SMTP_PASS:
+      # SMTP_FROM: EinVault <einvault@example.com>
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -96,6 +96,12 @@ services:
       # SMTP_PASS:
       # SMTP_FROM: 'EinVault <einvault@example.com>'
 
+      # Optional: ntfy push notifications
+      # Configures the ntfy server only; each user sets their own topic under
+      # Settings -> Notifications. Disabled unless NTFY_URL is set.
+      # NTFY_URL: https://ntfy.sh
+      # NTFY_TOKEN:
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -89,12 +89,12 @@ services:
       # ORIGIN above must be correct: password reset links are built from it.
       # SMTP_HOST: smtp.example.com
       # SMTP_PORT: 587
-      # true = implicit TLS (465). false (default) = STARTTLS on 587.
-      # SMTP_SECURE: 'false'
+      # Set true for implicit TLS (465). Default is STARTTLS on 587.
+      # SMTP_SECURE: 'true'
       # Leave unset for unauthenticated LAN relays.
       # SMTP_USER:
       # SMTP_PASS:
-      # SMTP_FROM: EinVault <einvault@example.com>
+      # SMTP_FROM: 'EinVault <einvault@example.com>'
 
     security_opt:
       - no-new-privileges:true

--- a/drizzle/0015_fantastic_captain_america.sql
+++ b/drizzle/0015_fantastic_captain_america.sql
@@ -1,0 +1,9 @@
+UPDATE `users` SET `email` = lower(trim(`email`)) WHERE `email` IS NOT NULL;--> statement-breakpoint
+UPDATE `users` SET `email` = NULL WHERE `email` = '';--> statement-breakpoint
+UPDATE `users` SET `email` = NULL WHERE `email` IS NOT NULL AND `id` NOT IN (
+	SELECT `id` FROM (
+		SELECT `id`, ROW_NUMBER() OVER (PARTITION BY `email` ORDER BY `created_at`, `id`) AS `rn`
+		FROM `users` WHERE `email` IS NOT NULL
+	) WHERE `rn` = 1
+);--> statement-breakpoint
+CREATE UNIQUE INDEX `users_email_idx` ON `users` (`email`);

--- a/drizzle/0016_public_miek.sql
+++ b/drizzle/0016_public_miek.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `password_reset_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `password_reset_user_idx` ON `password_reset_tokens` (`user_id`);

--- a/drizzle/0017_nostalgic_longshot.sql
+++ b/drizzle/0017_nostalgic_longshot.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `notification_outbox` (
+	`id` text PRIMARY KEY NOT NULL,
+	`dedupe_key` text NOT NULL,
+	`user_id` text NOT NULL,
+	`channel` text NOT NULL,
+	`payload` text NOT NULL,
+	`status` text DEFAULT 'queued' NOT NULL,
+	`attempts` integer DEFAULT 0 NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`sent_at` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `outbox_dedupe_idx` ON `notification_outbox` (`dedupe_key`);--> statement-breakpoint
+CREATE INDEX `outbox_status_idx` ON `notification_outbox` (`status`);--> statement-breakpoint
+ALTER TABLE `users` ADD `notify_reminder_email` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `users` ADD `notify_shift_email` integer DEFAULT false NOT NULL;

--- a/drizzle/0018_lucky_carlie_cooper.sql
+++ b/drizzle/0018_lucky_carlie_cooper.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `ntfy_topic` text;

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1370 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8e8e62f7-5926-4668-8fe7-b7c85a2541ee",
+  "prevId": "ee4808c4-a138-44de-8705-61f45a925d36",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'photo'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_key": {
+          "name": "poster_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_attempts": {
+          "name": "transcode_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        },
+        "photo_status_idx": {
+          "name": "photo_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1431 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3888503b-c1d8-4a31-94e7-9ccbf1092f4e",
+  "prevId": "8e8e62f7-5926-4668-8fe7-b7c85a2541ee",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'photo'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_key": {
+          "name": "poster_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_attempts": {
+          "name": "transcode_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        },
+        "photo_status_idx": {
+          "name": "photo_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "password_reset_user_idx": {
+          "name": "password_reset_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1552 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "334c75f3-a67a-4fcb-aa23-282a439700e5",
+  "prevId": "3888503b-c1d8-4a31-94e7-9ccbf1092f4e",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'photo'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_key": {
+          "name": "poster_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_attempts": {
+          "name": "transcode_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        },
+        "photo_status_idx": {
+          "name": "photo_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_outbox": {
+      "name": "notification_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "outbox_dedupe_idx": {
+          "name": "outbox_dedupe_idx",
+          "columns": [
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_outbox_user_id_users_id_fk": {
+          "name": "notification_outbox_user_id_users_id_fk",
+          "tableFrom": "notification_outbox",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "password_reset_user_idx": {
+          "name": "password_reset_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_reminder_email": {
+          "name": "notify_reminder_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_shift_email": {
+          "name": "notify_shift_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1559 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f7fad1fb-9066-49a4-aec3-e494e1a134df",
+  "prevId": "334c75f3-a67a-4fcb-aa23-282a439700e5",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'photo'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_key": {
+          "name": "poster_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_attempts": {
+          "name": "transcode_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        },
+        "photo_status_idx": {
+          "name": "photo_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_outbox": {
+      "name": "notification_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "outbox_dedupe_idx": {
+          "name": "outbox_dedupe_idx",
+          "columns": [
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_outbox_user_id_users_id_fk": {
+          "name": "notification_outbox_user_id_users_id_fk",
+          "tableFrom": "notification_outbox",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "password_reset_user_idx": {
+          "name": "password_reset_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_reminder_email": {
+          "name": "notify_reminder_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_shift_email": {
+          "name": "notify_shift_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "ntfy_topic": {
+          "name": "ntfy_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1780662158002,
       "tag": "0014_low_the_liberteens",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1780751281276,
+      "tag": "0015_fantastic_captain_america",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1780778399941,
       "tag": "0017_nostalgic_longshot",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1780832729465,
+      "tag": "0018_lucky_carlie_cooper",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1780751281276,
       "tag": "0015_fantastic_captain_america",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1780753898397,
+      "tag": "0016_public_miek",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1780753898397,
       "tag": "0016_public_miek",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1780778399941,
+      "tag": "0017_nostalgic_longshot",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"drizzle-orm": "^0.45.2",
 				"isomorphic-dompurify": "^3.9.0",
 				"marked": "^18.0.3",
+				"nodemailer": "^8.0.10",
 				"openid-client": "^6.8.4",
 				"sharp": "^0.34.5",
 				"tailwind-merge": "^3.5.0"
@@ -35,6 +36,7 @@
 				"@tailwindcss/vite": "^4.2.2",
 				"@types/better-sqlite3": "^7.6.13",
 				"@types/node": "^25.9.0",
+				"@types/nodemailer": "^8.0.0",
 				"@typescript-eslint/parser": "^8.57.2",
 				"drizzle-kit": "^0.31.10",
 				"eslint": "^10.1.0",
@@ -2771,6 +2773,16 @@
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
 		},
+		"node_modules/@types/nodemailer": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+			"integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -4777,6 +4789,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/nodemailer": {
+			"version": "8.0.10",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+			"integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/oauth4webapi": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@tailwindcss/vite": "^4.2.2",
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/node": "^25.9.0",
+		"@types/nodemailer": "^8.0.0",
 		"@typescript-eslint/parser": "^8.57.2",
 		"drizzle-kit": "^0.31.10",
 		"eslint": "^10.1.0",
@@ -53,6 +54,7 @@
 		"drizzle-orm": "^0.45.2",
 		"isomorphic-dompurify": "^3.9.0",
 		"marked": "^18.0.3",
+		"nodemailer": "^8.0.10",
 		"openid-client": "^6.8.4",
 		"sharp": "^0.34.5",
 		"tailwind-merge": "^3.5.0"

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -16,6 +16,8 @@ declare global {
 				phone: string | null;
 				reminderUndoSeconds: number | null;
 				defaultRecurrenceUnit: RecurrenceUnit | null;
+				notifyReminderEmail: boolean;
+				notifyShiftEmail: boolean;
 			} | null;
 			session: {
 				id: string;

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -18,6 +18,7 @@ declare global {
 				defaultRecurrenceUnit: RecurrenceUnit | null;
 				notifyReminderEmail: boolean;
 				notifyShiftEmail: boolean;
+				ntfyTopic: string | null;
 			} | null;
 			session: {
 				id: string;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -9,7 +9,8 @@ import {
 	logImmichBootStatus,
 	logStorageBootStatus,
 	logDeprecatedEnvWarnings,
-	logVideoTranscodeBootStatus
+	logVideoTranscodeBootStatus,
+	logSmtpBootStatus
 } from '$lib/server/env';
 import { recoverAndStart } from '$lib/server/video/worker';
 
@@ -18,6 +19,7 @@ logStorageBootStatus();
 logImmichBootStatus();
 logDeprecatedEnvWarnings();
 logVideoTranscodeBootStatus();
+logSmtpBootStatus();
 
 // Resume any transcode jobs interrupted by a restart and drain the queue. No-op
 // unless VIDEO_TRANSCODE is enabled and ffmpeg is present. Fire and forget.

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -13,6 +13,7 @@ import {
 	logSmtpBootStatus
 } from '$lib/server/env';
 import { recoverAndStart } from '$lib/server/video/worker';
+import { startNotifyScheduler } from '$lib/server/notify/scheduler';
 
 logOidcBootStatus();
 logStorageBootStatus();
@@ -24,6 +25,7 @@ logSmtpBootStatus();
 // Resume any transcode jobs interrupted by a restart and drain the queue. No-op
 // unless VIDEO_TRANSCODE is enabled and ffmpeg is present. Fire and forget.
 recoverAndStart();
+startNotifyScheduler();
 
 // When S3 storage is configured, /api/photos and /api/avatars 302 to the S3
 // host. CSP is enforced on the final navigation target after redirects, so the

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,7 +10,8 @@ import {
 	logStorageBootStatus,
 	logDeprecatedEnvWarnings,
 	logVideoTranscodeBootStatus,
-	logSmtpBootStatus
+	logSmtpBootStatus,
+	logNtfyBootStatus
 } from '$lib/server/env';
 import { recoverAndStart } from '$lib/server/video/worker';
 import { startNotifyScheduler } from '$lib/server/notify/scheduler';
@@ -21,6 +22,7 @@ logImmichBootStatus();
 logDeprecatedEnvWarnings();
 logVideoTranscodeBootStatus();
 logSmtpBootStatus();
+logNtfyBootStatus();
 
 // Resume any transcode jobs interrupted by a restart and drain the queue. No-op
 // unless VIDEO_TRANSCODE is enabled and ffmpeg is present. Fire and forget.

--- a/src/lib/components/settings/NotificationsCard.svelte
+++ b/src/lib/components/settings/NotificationsCard.svelte
@@ -3,6 +3,7 @@
 	import type { SubmitFunction } from '@sveltejs/kit';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { t, getLocale } from '$lib/i18n';
@@ -15,7 +16,9 @@
 		ntfyEnabled,
 		ntfyTopic,
 		successMessage,
-		errorMessage
+		errorMessage,
+		testSuccessMessage,
+		testErrorMessage
 	}: {
 		reminderEnabled: boolean;
 		shiftEnabled: boolean;
@@ -25,6 +28,8 @@
 		ntfyTopic: string | null;
 		successMessage: string | undefined;
 		errorMessage: string | undefined;
+		testSuccessMessage: string | undefined;
+		testErrorMessage: string | undefined;
 	} = $props();
 
 	const locale = getLocale();
@@ -141,5 +146,33 @@
 				<input type="hidden" name="ntfyTopic" value={ntfyTopic ?? ''} />
 			{/if}
 		</form>
+		{#if testSuccessMessage}
+			<Alert variant="success" class="mt-3">
+				<AlertDescription>{testSuccessMessage}</AlertDescription>
+			</Alert>
+		{/if}
+		{#if testErrorMessage}
+			<Alert variant="destructive" class="mt-3">
+				<AlertDescription>{testErrorMessage}</AlertDescription>
+			</Alert>
+		{/if}
+		{#if mailEnabled || ntfyEnabled}
+			<div class="flex flex-wrap gap-2 pt-3">
+				{#if mailEnabled}
+					<form method="POST" action="?/testEmail" use:enhance={handleSubmit}>
+						<Button type="submit" size="sm" variant="outline" disabled={!hasEmail || submitting}>
+							{t(locale, 'page.settings.testEmail')}
+						</Button>
+					</form>
+				{/if}
+				{#if ntfyEnabled}
+					<form method="POST" action="?/testNtfy" use:enhance={handleSubmit}>
+						<Button type="submit" size="sm" variant="outline" disabled={!ntfyTopic || submitting}>
+							{t(locale, 'page.settings.testNtfy')}
+						</Button>
+					</form>
+				{/if}
+			</div>
+		{/if}
 	</CardContent>
 </Card>

--- a/src/lib/components/settings/NotificationsCard.svelte
+++ b/src/lib/components/settings/NotificationsCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { t, getLocale } from '$lib/i18n';
@@ -9,12 +10,18 @@
 		reminderEnabled,
 		shiftEnabled,
 		hasEmail,
-		successMessage
+		ntfyEnabled,
+		ntfyTopic,
+		successMessage,
+		errorMessage
 	}: {
 		reminderEnabled: boolean;
 		shiftEnabled: boolean;
 		hasEmail: boolean;
+		ntfyEnabled: boolean;
+		ntfyTopic: string | null;
 		successMessage: string | undefined;
+		errorMessage: string | undefined;
 	} = $props();
 
 	const locale = getLocale();
@@ -32,6 +39,11 @@
 		{#if successMessage}
 			<Alert variant="success" class="mb-3">
 				<AlertDescription>{successMessage}</AlertDescription>
+			</Alert>
+		{/if}
+		{#if errorMessage}
+			<Alert variant="destructive" class="mb-3">
+				<AlertDescription>{errorMessage}</AlertDescription>
 			</Alert>
 		{/if}
 		{#if !hasEmail}
@@ -62,6 +74,24 @@
 				/>
 				<Label class="cursor-pointer">{t(locale, 'page.settings.notifyShiftEmailLabel')}</Label>
 			</label>
+			{#if ntfyEnabled}
+				<div class="space-y-1.5 pt-2">
+					<Label for="ntfyTopic">{t(locale, 'page.settings.ntfyTopicLabel')}</Label>
+					<Input
+						id="ntfyTopic"
+						name="ntfyTopic"
+						type="text"
+						value={ntfyTopic ?? ''}
+						maxlength={64}
+						onchange={() => formEl.requestSubmit()}
+					/>
+					<p class="text-xs text-muted-foreground">
+						{t(locale, 'page.settings.ntfyTopicHint')}
+					</p>
+				</div>
+			{:else}
+				<input type="hidden" name="ntfyTopic" value={ntfyTopic ?? ''} />
+			{/if}
 		</form>
 	</CardContent>
 </Card>

--- a/src/lib/components/settings/NotificationsCard.svelte
+++ b/src/lib/components/settings/NotificationsCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import type { SubmitFunction } from '@sveltejs/kit';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
@@ -28,6 +29,23 @@
 
 	const locale = getLocale();
 	let formEl: HTMLFormElement;
+	let submitting = $state(false);
+
+	// Default enhance resets the form on success, snapping every control back
+	// to its server-rendered attribute value before the invalidated data
+	// arrives -- the checkbox flicker and the "topic field reverts" bug.
+	// reset: false keeps the user's input; invalidation then syncs props.
+	// The submitting flag disables controls so a second change cannot race an
+	// in-flight save.
+	const handleSubmit: SubmitFunction = () => {
+		submitting = true;
+		return async ({ update }) => {
+			await update({ reset: false });
+			submitting = false;
+		};
+	};
+
+	const emailControlsDisabled = $derived(!hasEmail || submitting);
 </script>
 
 <Card>
@@ -53,30 +71,45 @@
 				{t(locale, 'page.settings.notificationsNeedEmail')}
 			</p>
 		{/if}
-		<form method="POST" action="?/notifications" bind:this={formEl} use:enhance class="space-y-2.5">
+		<form
+			method="POST"
+			action="?/notifications"
+			bind:this={formEl}
+			use:enhance={handleSubmit}
+			class="space-y-2.5"
+		>
 			{#if mailEnabled}
-				<label class="flex items-center gap-2.5">
+				<label
+					class="flex items-center gap-2.5 {!hasEmail ? 'opacity-50' : ''}"
+					class:cursor-not-allowed={!hasEmail}
+				>
 					<input
 						type="checkbox"
 						name="notifyReminderEmail"
 						checked={reminderEnabled}
-						disabled={!hasEmail}
+						disabled={emailControlsDisabled}
 						onchange={() => formEl.requestSubmit()}
-						class="h-4 w-4 rounded border-input accent-primary"
+						class="h-4 w-4 rounded border-input accent-primary disabled:cursor-not-allowed"
 					/>
-					<Label class="cursor-pointer">{t(locale, 'page.settings.notifyReminderEmailLabel')}</Label
+					<Label class={hasEmail ? 'cursor-pointer' : 'cursor-not-allowed'}
+						>{t(locale, 'page.settings.notifyReminderEmailLabel')}</Label
 					>
 				</label>
-				<label class="flex items-center gap-2.5">
+				<label
+					class="flex items-center gap-2.5 {!hasEmail ? 'opacity-50' : ''}"
+					class:cursor-not-allowed={!hasEmail}
+				>
 					<input
 						type="checkbox"
 						name="notifyShiftEmail"
 						checked={shiftEnabled}
-						disabled={!hasEmail}
+						disabled={emailControlsDisabled}
 						onchange={() => formEl.requestSubmit()}
-						class="h-4 w-4 rounded border-input accent-primary"
+						class="h-4 w-4 rounded border-input accent-primary disabled:cursor-not-allowed"
 					/>
-					<Label class="cursor-pointer">{t(locale, 'page.settings.notifyShiftEmailLabel')}</Label>
+					<Label class={hasEmail ? 'cursor-pointer' : 'cursor-not-allowed'}
+						>{t(locale, 'page.settings.notifyShiftEmailLabel')}</Label
+					>
 				</label>
 				{#if !hasEmail}
 					<!-- Disabled checkboxes do not submit; preserve stored flags. -->
@@ -97,6 +130,7 @@
 						type="text"
 						value={ntfyTopic ?? ''}
 						maxlength={64}
+						disabled={submitting}
 						onchange={() => formEl.requestSubmit()}
 					/>
 					<p class="text-xs text-muted-foreground">

--- a/src/lib/components/settings/NotificationsCard.svelte
+++ b/src/lib/components/settings/NotificationsCard.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import { t, getLocale } from '$lib/i18n';
+
+	let {
+		reminderEnabled,
+		shiftEnabled,
+		hasEmail,
+		successMessage
+	}: {
+		reminderEnabled: boolean;
+		shiftEnabled: boolean;
+		hasEmail: boolean;
+		successMessage: string | undefined;
+	} = $props();
+
+	const locale = getLocale();
+	let formEl: HTMLFormElement;
+</script>
+
+<Card>
+	<CardHeader>
+		<CardTitle>{t(locale, 'page.settings.notificationsCard')}</CardTitle>
+	</CardHeader>
+	<CardContent>
+		<p class="text-sm text-muted-foreground mb-3">
+			{t(locale, 'page.settings.notificationsDescription')}
+		</p>
+		{#if successMessage}
+			<Alert variant="success" class="mb-3">
+				<AlertDescription>{successMessage}</AlertDescription>
+			</Alert>
+		{/if}
+		{#if !hasEmail}
+			<p class="text-sm text-muted-foreground mb-3">
+				{t(locale, 'page.settings.notificationsNeedEmail')}
+			</p>
+		{/if}
+		<form method="POST" action="?/notifications" bind:this={formEl} use:enhance class="space-y-2.5">
+			<label class="flex items-center gap-2.5">
+				<input
+					type="checkbox"
+					name="notifyReminderEmail"
+					checked={reminderEnabled}
+					disabled={!hasEmail}
+					onchange={() => formEl.requestSubmit()}
+					class="h-4 w-4 rounded border-input accent-primary"
+				/>
+				<Label class="cursor-pointer">{t(locale, 'page.settings.notifyReminderEmailLabel')}</Label>
+			</label>
+			<label class="flex items-center gap-2.5">
+				<input
+					type="checkbox"
+					name="notifyShiftEmail"
+					checked={shiftEnabled}
+					disabled={!hasEmail}
+					onchange={() => formEl.requestSubmit()}
+					class="h-4 w-4 rounded border-input accent-primary"
+				/>
+				<Label class="cursor-pointer">{t(locale, 'page.settings.notifyShiftEmailLabel')}</Label>
+			</label>
+		</form>
+	</CardContent>
+</Card>

--- a/src/lib/components/settings/NotificationsCard.svelte
+++ b/src/lib/components/settings/NotificationsCard.svelte
@@ -45,8 +45,11 @@
 	const handleSubmit: SubmitFunction = () => {
 		submitting = true;
 		return async ({ update }) => {
-			await update({ reset: false });
-			submitting = false;
+			try {
+				await update({ reset: false });
+			} finally {
+				submitting = false;
+			}
 		};
 	};
 

--- a/src/lib/components/settings/NotificationsCard.svelte
+++ b/src/lib/components/settings/NotificationsCard.svelte
@@ -10,6 +10,7 @@
 		reminderEnabled,
 		shiftEnabled,
 		hasEmail,
+		mailEnabled,
 		ntfyEnabled,
 		ntfyTopic,
 		successMessage,
@@ -18,6 +19,7 @@
 		reminderEnabled: boolean;
 		shiftEnabled: boolean;
 		hasEmail: boolean;
+		mailEnabled: boolean;
 		ntfyEnabled: boolean;
 		ntfyTopic: string | null;
 		successMessage: string | undefined;
@@ -46,34 +48,46 @@
 				<AlertDescription>{errorMessage}</AlertDescription>
 			</Alert>
 		{/if}
-		{#if !hasEmail}
+		{#if mailEnabled && !hasEmail}
 			<p class="text-sm text-muted-foreground mb-3">
 				{t(locale, 'page.settings.notificationsNeedEmail')}
 			</p>
 		{/if}
 		<form method="POST" action="?/notifications" bind:this={formEl} use:enhance class="space-y-2.5">
-			<label class="flex items-center gap-2.5">
-				<input
-					type="checkbox"
-					name="notifyReminderEmail"
-					checked={reminderEnabled}
-					disabled={!hasEmail}
-					onchange={() => formEl.requestSubmit()}
-					class="h-4 w-4 rounded border-input accent-primary"
-				/>
-				<Label class="cursor-pointer">{t(locale, 'page.settings.notifyReminderEmailLabel')}</Label>
-			</label>
-			<label class="flex items-center gap-2.5">
-				<input
-					type="checkbox"
-					name="notifyShiftEmail"
-					checked={shiftEnabled}
-					disabled={!hasEmail}
-					onchange={() => formEl.requestSubmit()}
-					class="h-4 w-4 rounded border-input accent-primary"
-				/>
-				<Label class="cursor-pointer">{t(locale, 'page.settings.notifyShiftEmailLabel')}</Label>
-			</label>
+			{#if mailEnabled}
+				<label class="flex items-center gap-2.5">
+					<input
+						type="checkbox"
+						name="notifyReminderEmail"
+						checked={reminderEnabled}
+						disabled={!hasEmail}
+						onchange={() => formEl.requestSubmit()}
+						class="h-4 w-4 rounded border-input accent-primary"
+					/>
+					<Label class="cursor-pointer">{t(locale, 'page.settings.notifyReminderEmailLabel')}</Label
+					>
+				</label>
+				<label class="flex items-center gap-2.5">
+					<input
+						type="checkbox"
+						name="notifyShiftEmail"
+						checked={shiftEnabled}
+						disabled={!hasEmail}
+						onchange={() => formEl.requestSubmit()}
+						class="h-4 w-4 rounded border-input accent-primary"
+					/>
+					<Label class="cursor-pointer">{t(locale, 'page.settings.notifyShiftEmailLabel')}</Label>
+				</label>
+				{#if !hasEmail}
+					<!-- Disabled checkboxes do not submit; preserve stored flags. -->
+					{#if reminderEnabled}<input type="hidden" name="notifyReminderEmail" value="on" />{/if}
+					{#if shiftEnabled}<input type="hidden" name="notifyShiftEmail" value="on" />{/if}
+				{/if}
+			{:else}
+				<!-- Email unconfigured: keep stored flags intact across topic edits. -->
+				{#if reminderEnabled}<input type="hidden" name="notifyReminderEmail" value="on" />{/if}
+				{#if shiftEnabled}<input type="hidden" name="notifyShiftEmail" value="on" />{/if}
+			{/if}
 			{#if ntfyEnabled}
 				<div class="space-y-1.5 pt-2">
 					<Label for="ntfyTopic">{t(locale, 'page.settings.ntfyTopicLabel')}</Label>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -238,6 +238,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.defaultRecurrenceLabel': 'Standardeinheit',
 	'page.settings.defaultRecurrenceSystem': 'System-Standard verwenden (Tage)',
 	'page.settings.defaultRecurrenceUpdated': '✓ Standard-Wiederholung aktualisiert.',
+	'page.settings.notificationsCard': 'Benachrichtigungen',
+	'page.settings.notificationsDescription':
+		'Erhalte E-Mails von EinVault. Betreuer werden nur über Erinnerungen für zugewiesene Gefährten benachrichtigt.',
+	'page.settings.notifyReminderEmailLabel': 'E-Mail senden, wenn eine Erinnerung fällig ist',
+	'page.settings.notifyShiftEmailLabel':
+		'E-Mail senden, 24 Stunden bevor eine Schicht beginnt oder endet',
+	'page.settings.notificationsUpdated': 'Benachrichtigungseinstellungen aktualisiert.',
+	'page.settings.notificationsNeedEmail':
+		'Füge deinem Konto eine E-Mail-Adresse hinzu, um Benachrichtigungen zu erhalten.',
 
 	// Page: Login
 	'page.login.title': 'Anmelden',
@@ -742,6 +751,23 @@ const messages: Record<keyof Messages, string> = {
 		'Für dein EinVault-Konto ({username}) wurde ein Zurücksetzen des Passworts angefordert. Nutze den folgenden Link, um ein neues Passwort zu wählen. Der Link läuft in 30 Minuten ab.',
 	'email.reset.cta': 'Passwort zurücksetzen',
 	'email.reset.ignore': 'Falls du das nicht angefordert hast, kannst du diese E-Mail ignorieren.',
+
+	// Email: reminder due
+	'email.reminder.subject': 'Erinnerung: {title}',
+	'email.reminder.greeting': 'Hallo {name},',
+	'email.reminder.body': 'Für {companion} ist eine Erinnerung fällig: {title}',
+	'email.reminder.dueLine': 'Fällig: {due}',
+	'email.reminder.cta': 'EinVault öffnen',
+	'email.reminder.footer':
+		'Du erhältst diese E-Mail, weil Erinnerungs-Benachrichtigungen in deinen EinVault-Einstellungen aktiviert sind.',
+
+	// Email: caretaker shift alerts
+	'email.shift.startSubject': 'Schicht beginnt bald: {caretaker}',
+	'email.shift.endSubject': 'Schicht endet bald: {caretaker}',
+	'email.shift.startBody': '{caretaker} beginnt eine Betreuungsschicht am {start}.',
+	'email.shift.endBody': '{caretaker} beendet eine Betreuungsschicht am {end}.',
+	'email.shift.footer':
+		'Du erhältst diese E-Mail, weil Schicht-Benachrichtigungen in deinen EinVault-Einstellungen aktiviert sind.',
 
 	// Immich picker
 	'immich.picker.title': 'Aus Immich auswählen',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -251,7 +251,15 @@ const messages: Record<keyof Messages, string> = {
 		'Füge deinem Konto eine E-Mail-Adresse hinzu, um E-Mail-Benachrichtigungen zu erhalten.',
 	'page.settings.ntfyTopicLabel': 'ntfy-Thema',
 	'page.settings.ntfyTopicHint':
-		'Push-Nachrichten gehen an dieses Thema auf dem vom Admin konfigurierten ntfy-Server. Wähle einen langen zufälligen Namen; jeder, der ihn kennt, kann ihn abonnieren. Leer lassen, um Push zu deaktivieren.',
+		'Push-Nachrichten umfassen fällige Erinnerungen und Schichtmeldungen für das, was du in EinVault sehen kannst. Sie gehen an dieses Thema auf dem vom Admin konfigurierten ntfy-Server. Wähle einen langen zufälligen Namen; jeder, der ihn kennt, kann ihn abonnieren. Leer lassen, um Push zu deaktivieren.',
+	'page.settings.testEmail': 'Test-E-Mail senden',
+	'page.settings.testNtfy': 'Test-Push senden',
+	'page.settings.testSent': 'Testbenachrichtigung gesendet.',
+	'page.settings.testFailed': 'Test fehlgeschlagen: {error}',
+	'error.testCooldown': 'Warte ein paar Sekunden, bevor du einen weiteren Test sendest.',
+	'email.test.subject': 'EinVault-Testbenachrichtigung',
+	'email.test.body':
+		'Dies ist eine Testbenachrichtigung von EinVault. Wenn du das liest, funktionieren deine Benachrichtigungseinstellungen.',
 
 	// Page: Login
 	'page.login.title': 'Anmelden',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -248,7 +248,7 @@ const messages: Record<keyof Messages, string> = {
 		'E-Mail senden, 24 Stunden bevor eine Schicht beginnt oder endet',
 	'page.settings.notificationsUpdated': 'Benachrichtigungseinstellungen aktualisiert.',
 	'page.settings.notificationsNeedEmail':
-		'Füge deinem Konto eine E-Mail-Adresse hinzu, um Benachrichtigungen zu erhalten.',
+		'Füge deinem Konto eine E-Mail-Adresse hinzu, um E-Mail-Benachrichtigungen zu erhalten.',
 	'page.settings.ntfyTopicLabel': 'ntfy-Thema',
 	'page.settings.ntfyTopicHint':
 		'Push-Nachrichten gehen an dieses Thema auf dem vom Admin konfigurierten ntfy-Server. Wähle einen langen zufälligen Namen; jeder, der ihn kennt, kann ihn abonnieren. Leer lassen, um Push zu deaktivieren.',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -91,6 +91,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordTooLong': 'Das Passwort darf höchstens 128 Zeichen lang sein.',
 	'error.passwordsMismatch': 'Die Passwörter stimmen nicht überein.',
 	'error.usernameAlreadyTaken': 'Benutzername bereits vergeben.',
+	'error.emailAlreadyTaken': 'Diese E-Mail-Adresse wird bereits verwendet.',
 	'error.invalidTheme': 'Ungültiges Design.',
 	'error.invalidLocale': 'Ungültige Sprache.',
 	'error.invalidReminderUndo': 'Ungültiger Wert für Rückgängig-Fenster.',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -92,6 +92,9 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordsMismatch': 'Die Passwörter stimmen nicht überein.',
 	'error.usernameAlreadyTaken': 'Benutzername bereits vergeben.',
 	'error.emailAlreadyTaken': 'Diese E-Mail-Adresse wird bereits verwendet.',
+	'error.emailRequired': 'E-Mail-Adresse ist erforderlich.',
+	'error.emailInvalid': 'Gib eine gültige E-Mail-Adresse ein.',
+	'error.tooManyResetRequests': 'Zu viele Anfragen. Versuche es später erneut.',
 	'error.invalidTheme': 'Ungültiges Design.',
 	'error.invalidLocale': 'Ungültige Sprache.',
 	'error.invalidReminderUndo': 'Ungültiger Wert für Rückgängig-Fenster.',
@@ -245,6 +248,27 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.passwordLabel': 'Passwort',
 	'page.login.signIn': 'Anmelden',
 	'page.login.signingIn': 'Anmeldung…',
+	'page.login.forgotPassword': 'Passwort vergessen?',
+
+	// Page: Forgot password
+	'page.forgot.title': 'Passwort zurücksetzen',
+	'page.forgot.instruction':
+		'Gib die E-Mail-Adresse deines Kontos ein und wir senden dir einen Link zum Zurücksetzen deines Passworts.',
+	'page.forgot.emailLabel': 'E-Mail',
+	'page.forgot.submit': 'Link senden',
+	'page.forgot.sending': 'Wird gesendet…',
+	'page.forgot.success': 'Falls ein Konto mit dieser E-Mail existiert, wurde ein Link gesendet.',
+	'page.forgot.backToLogin': 'Zurück zur Anmeldung',
+
+	// Page: Reset password
+	'page.reset.title': 'Neues Passwort wählen',
+	'page.reset.newPasswordLabel': 'Neues Passwort',
+	'page.reset.confirmPasswordLabel': 'Neues Passwort bestätigen',
+	'page.reset.submit': 'Neues Passwort speichern',
+	'page.reset.saving': 'Wird gespeichert…',
+	'page.reset.success': 'Dein Passwort wurde aktualisiert. Du kannst dich jetzt anmelden.',
+	'page.reset.invalid': 'Dieser Link ist ungültig oder abgelaufen.',
+	'page.reset.requestNew': 'Neuen Link anfordern',
 
 	// Page: Setup
 	'page.setup.title': 'Einrichtung',
@@ -710,6 +734,14 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousMedia': 'Vorheriges Medium',
 	'aria.nextMedia': 'Nächstes Medium',
 	'aria.viewPhoto': '{name}s Foto anzeigen',
+
+	// Email: password reset
+	'email.reset.subject': 'Setze dein EinVault-Passwort zurück',
+	'email.reset.greeting': 'Hallo {name},',
+	'email.reset.body':
+		'Für dein EinVault-Konto ({username}) wurde ein Zurücksetzen des Passworts angefordert. Nutze den folgenden Link, um ein neues Passwort zu wählen. Der Link läuft in 30 Minuten ab.',
+	'email.reset.cta': 'Passwort zurücksetzen',
+	'email.reset.ignore': 'Falls du das nicht angefordert hast, kannst du diese E-Mail ignorieren.',
 
 	// Immich picker
 	'immich.picker.title': 'Aus Immich auswählen',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -101,6 +101,8 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidRecurrence': 'Ungültige Wiederholungskonfiguration.',
 	'error.invalidDefaultRecurrence': 'Ungültige Standard-Wiederholungseinheit.',
 	'error.invalidRole': 'Ungültige Rolle.',
+	'error.invalidNtfyTopic':
+		'Das Thema darf nur Buchstaben, Zahlen, Binde- und Unterstriche enthalten (max. 64).',
 	'error.invalidDate': 'Ungültiges Datum',
 	'error.invalidArchiveDate': 'Ungültiges Archivierungsdatum.',
 	'error.invalidCompanionIds': 'Eine oder mehrere Begleiter-IDs sind ungültig.',
@@ -247,6 +249,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsUpdated': 'Benachrichtigungseinstellungen aktualisiert.',
 	'page.settings.notificationsNeedEmail':
 		'Füge deinem Konto eine E-Mail-Adresse hinzu, um Benachrichtigungen zu erhalten.',
+	'page.settings.ntfyTopicLabel': 'ntfy-Thema',
+	'page.settings.ntfyTopicHint':
+		'Push-Nachrichten gehen an dieses Thema auf dem vom Admin konfigurierten ntfy-Server. Wähle einen langen zufälligen Namen; jeder, der ihn kennt, kann ihn abonnieren. Leer lassen, um Push zu deaktivieren.',
 
 	// Page: Login
 	'page.login.title': 'Anmelden',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -745,6 +745,7 @@ const messages = {
 
 	// Email: reminder due
 	'email.reminder.subject': 'Reminder: {title}',
+	// greeting + cta are shared by reminder AND shift emails (see templates.ts)
 	'email.reminder.greeting': 'Hi {name},',
 	'email.reminder.body': '{companion} has a reminder due: {title}',
 	'email.reminder.dueLine': 'Due: {due}',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -88,6 +88,7 @@ const messages = {
 	'error.passwordTooLong': 'Password must be 128 characters or fewer.',
 	'error.passwordsMismatch': 'Passwords do not match.',
 	'error.usernameAlreadyTaken': 'Username already taken.',
+	'error.emailAlreadyTaken': 'That email address is already in use.',
 	'error.invalidTheme': 'Invalid theme.',
 	'error.invalidLocale': 'Invalid locale.',
 	'error.invalidReminderUndo': 'Invalid undo window value.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -225,6 +225,14 @@ const messages = {
 	'page.settings.defaultRecurrenceLabel': 'Default unit',
 	'page.settings.defaultRecurrenceSystem': 'Use system default (days)',
 	'page.settings.defaultRecurrenceUpdated': '✓ Default recurrence updated.',
+	'page.settings.notificationsCard': 'Notifications',
+	'page.settings.notificationsDescription':
+		'Get emails from EinVault. Caretakers are only notified about reminders for companions assigned to them.',
+	'page.settings.notifyReminderEmailLabel': 'Email me when a reminder is due',
+	'page.settings.notifyShiftEmailLabel': 'Email me 24 hours before a shift starts or ends',
+	'page.settings.notificationsUpdated': 'Notification settings updated.',
+	'page.settings.notificationsNeedEmail':
+		'Add an email address to your account to receive notifications.',
 
 	// Errors: OIDC
 	'error.oidc.notProvisioned':
@@ -734,6 +742,23 @@ const messages = {
 		'A password reset was requested for your EinVault account ({username}). Use the link below to choose a new password. The link expires in 30 minutes.',
 	'email.reset.cta': 'Reset password',
 	'email.reset.ignore': 'If you did not request this, you can safely ignore this email.',
+
+	// Email: reminder due
+	'email.reminder.subject': 'Reminder: {title}',
+	'email.reminder.greeting': 'Hi {name},',
+	'email.reminder.body': '{companion} has a reminder due: {title}',
+	'email.reminder.dueLine': 'Due: {due}',
+	'email.reminder.cta': 'Open EinVault',
+	'email.reminder.footer':
+		'You are receiving this because reminder email notifications are enabled in your EinVault settings.',
+
+	// Email: caretaker shift alerts
+	'email.shift.startSubject': 'Shift starting soon: {caretaker}',
+	'email.shift.endSubject': 'Shift ending soon: {caretaker}',
+	'email.shift.startBody': '{caretaker} begins a care shift on {start}.',
+	'email.shift.endBody': '{caretaker} finishes a care shift on {end}.',
+	'email.shift.footer':
+		'You are receiving this because shift email notifications are enabled in your EinVault settings.',
 
 	// Immich picker
 	'immich.picker.title': 'Pick from Immich',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -98,6 +98,8 @@ const messages = {
 	'error.invalidRecurrence': 'Invalid recurrence configuration.',
 	'error.invalidDefaultRecurrence': 'Invalid default recurrence unit.',
 	'error.invalidRole': 'Invalid role.',
+	'error.invalidNtfyTopic':
+		'Topic may only contain letters, numbers, dashes and underscores (max 64).',
 	'error.invalidDate': 'Invalid date',
 	'error.invalidArchiveDate': 'Invalid archive date.',
 	'error.invalidCompanionIds': 'One or more companion IDs are invalid.',
@@ -233,6 +235,9 @@ const messages = {
 	'page.settings.notificationsUpdated': 'Notification settings updated.',
 	'page.settings.notificationsNeedEmail':
 		'Add an email address to your account to receive notifications.',
+	'page.settings.ntfyTopicLabel': 'ntfy topic',
+	'page.settings.ntfyTopicHint':
+		'Pushes go to this topic on the ntfy server configured by your admin. Pick a long random name; anyone who knows it can subscribe. Leave empty to disable pushes.',
 
 	// Errors: OIDC
 	'error.oidc.notProvisioned':

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -237,7 +237,15 @@ const messages = {
 		'Add an email address to your account to receive email notifications.',
 	'page.settings.ntfyTopicLabel': 'ntfy topic',
 	'page.settings.ntfyTopicHint':
-		'Pushes go to this topic on the ntfy server configured by your admin. Pick a long random name; anyone who knows it can subscribe. Leave empty to disable pushes.',
+		'Pushes cover due reminders and shift alerts for what you can see in EinVault. They go to this topic on the ntfy server configured by your admin. Pick a long random name; anyone who knows it can subscribe. Leave empty to disable pushes.',
+	'page.settings.testEmail': 'Send test email',
+	'page.settings.testNtfy': 'Send test push',
+	'page.settings.testSent': 'Test notification sent.',
+	'page.settings.testFailed': 'Test failed: {error}',
+	'error.testCooldown': 'Wait a few seconds before sending another test.',
+	'email.test.subject': 'EinVault test notification',
+	'email.test.body':
+		'This is a test notification from EinVault. If you are reading this, your notification settings work.',
 
 	// Errors: OIDC
 	'error.oidc.notProvisioned':

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -89,6 +89,9 @@ const messages = {
 	'error.passwordsMismatch': 'Passwords do not match.',
 	'error.usernameAlreadyTaken': 'Username already taken.',
 	'error.emailAlreadyTaken': 'That email address is already in use.',
+	'error.emailRequired': 'Email address is required.',
+	'error.emailInvalid': 'Enter a valid email address.',
+	'error.tooManyResetRequests': 'Too many reset requests. Try again later.',
 	'error.invalidTheme': 'Invalid theme.',
 	'error.invalidLocale': 'Invalid locale.',
 	'error.invalidReminderUndo': 'Invalid undo window value.',
@@ -239,6 +242,27 @@ const messages = {
 	'page.login.passwordLabel': 'Password',
 	'page.login.signIn': 'Sign in',
 	'page.login.signingIn': 'Signing in…',
+	'page.login.forgotPassword': 'Forgot password?',
+
+	// Page: Forgot password
+	'page.forgot.title': 'Reset your password',
+	'page.forgot.instruction':
+		'Enter the email address on your account and we will send you a link to reset your password.',
+	'page.forgot.emailLabel': 'Email',
+	'page.forgot.submit': 'Send reset link',
+	'page.forgot.sending': 'Sending…',
+	'page.forgot.success': 'If an account with that email exists, a reset link has been sent.',
+	'page.forgot.backToLogin': 'Back to sign in',
+
+	// Page: Reset password
+	'page.reset.title': 'Choose a new password',
+	'page.reset.newPasswordLabel': 'New password',
+	'page.reset.confirmPasswordLabel': 'Confirm new password',
+	'page.reset.submit': 'Set new password',
+	'page.reset.saving': 'Saving…',
+	'page.reset.success': 'Your password has been updated. You can now sign in.',
+	'page.reset.invalid': 'This reset link is invalid or has expired.',
+	'page.reset.requestNew': 'Request a new link',
 
 	// Page: Setup
 	'page.setup.title': 'Setup',
@@ -702,6 +726,14 @@ const messages = {
 	'aria.previousMedia': 'Previous media',
 	'aria.nextMedia': 'Next media',
 	'aria.viewPhoto': "View {name}'s photo",
+
+	// Email: password reset
+	'email.reset.subject': 'Reset your EinVault password',
+	'email.reset.greeting': 'Hi {name},',
+	'email.reset.body':
+		'A password reset was requested for your EinVault account ({username}). Use the link below to choose a new password. The link expires in 30 minutes.',
+	'email.reset.cta': 'Reset password',
+	'email.reset.ignore': 'If you did not request this, you can safely ignore this email.',
 
 	// Immich picker
 	'immich.picker.title': 'Pick from Immich',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -234,7 +234,7 @@ const messages = {
 	'page.settings.notifyShiftEmailLabel': 'Email me 24 hours before a shift starts or ends',
 	'page.settings.notificationsUpdated': 'Notification settings updated.',
 	'page.settings.notificationsNeedEmail':
-		'Add an email address to your account to receive notifications.',
+		'Add an email address to your account to receive email notifications.',
 	'page.settings.ntfyTopicLabel': 'ntfy topic',
 	'page.settings.ntfyTopicHint':
 		'Pushes go to this topic on the ntfy server configured by your admin. Pick a long random name; anyone who knows it can subscribe. Leave empty to disable pushes.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -251,7 +251,15 @@ const messages: Record<keyof Messages, string> = {
 		'Añade un correo electrónico a tu cuenta para recibir notificaciones por correo.',
 	'page.settings.ntfyTopicLabel': 'Tema de ntfy',
 	'page.settings.ntfyTopicHint':
-		'Las notificaciones push van a este tema en el servidor ntfy configurado por tu administrador. Elige un nombre largo y aleatorio; cualquiera que lo conozca puede suscribirse. Déjalo vacío para desactivar los push.',
+		'Las notificaciones push cubren recordatorios vencidos y avisos de turnos de lo que puedes ver en EinVault. Van a este tema en el servidor ntfy configurado por tu administrador. Elige un nombre largo y aleatorio; cualquiera que lo conozca puede suscribirse. Déjalo vacío para desactivar los push.',
+	'page.settings.testEmail': 'Enviar correo de prueba',
+	'page.settings.testNtfy': 'Enviar push de prueba',
+	'page.settings.testSent': 'Notificación de prueba enviada.',
+	'page.settings.testFailed': 'La prueba falló: {error}',
+	'error.testCooldown': 'Espera unos segundos antes de enviar otra prueba.',
+	'email.test.subject': 'Notificación de prueba de EinVault',
+	'email.test.body':
+		'Esta es una notificación de prueba de EinVault. Si estás leyendo esto, tus ajustes de notificaciones funcionan.',
 
 	// Page: Login
 	'page.login.title': 'Iniciar sesión',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -91,6 +91,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordTooLong': 'La contraseña debe tener 128 caracteres o menos.',
 	'error.passwordsMismatch': 'Las contraseñas no coinciden.',
 	'error.usernameAlreadyTaken': 'Nombre de usuario ya en uso.',
+	'error.emailAlreadyTaken': 'Ese correo electrónico ya está en uso.',
 	'error.invalidTheme': 'Tema no válido.',
 	'error.invalidLocale': 'Idioma no válido.',
 	'error.invalidReminderUndo': 'Valor de ventana de deshacer no válido.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -238,6 +238,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.defaultRecurrenceLabel': 'Unidad predeterminada',
 	'page.settings.defaultRecurrenceSystem': 'Usar predeterminado del sistema (días)',
 	'page.settings.defaultRecurrenceUpdated': '✓ Recurrencia predeterminada actualizada.',
+	'page.settings.notificationsCard': 'Notificaciones',
+	'page.settings.notificationsDescription':
+		'Recibe correos de EinVault. Los cuidadores solo reciben avisos de recordatorios de los compañeros que tienen asignados.',
+	'page.settings.notifyReminderEmailLabel': 'Enviarme un correo cuando venza un recordatorio',
+	'page.settings.notifyShiftEmailLabel':
+		'Enviarme un correo 24 horas antes de que un turno empiece o termine',
+	'page.settings.notificationsUpdated': 'Ajustes de notificaciones actualizados.',
+	'page.settings.notificationsNeedEmail':
+		'Añade un correo electrónico a tu cuenta para recibir notificaciones.',
 
 	// Page: Login
 	'page.login.title': 'Iniciar sesión',
@@ -742,6 +751,23 @@ const messages: Record<keyof Messages, string> = {
 		'Se ha solicitado un restablecimiento de contraseña para tu cuenta de EinVault ({username}). Usa el siguiente enlace para elegir una nueva contraseña. El enlace caduca en 30 minutos.',
 	'email.reset.cta': 'Restablecer contraseña',
 	'email.reset.ignore': 'Si no lo has solicitado, puedes ignorar este correo.',
+
+	// Email: reminder due
+	'email.reminder.subject': 'Recordatorio: {title}',
+	'email.reminder.greeting': 'Hola {name}:',
+	'email.reminder.body': '{companion} tiene un recordatorio pendiente: {title}',
+	'email.reminder.dueLine': 'Vence: {due}',
+	'email.reminder.cta': 'Abrir EinVault',
+	'email.reminder.footer':
+		'Recibes este correo porque las notificaciones de recordatorios están activadas en tus ajustes de EinVault.',
+
+	// Email: caretaker shift alerts
+	'email.shift.startSubject': 'Turno a punto de empezar: {caretaker}',
+	'email.shift.endSubject': 'Turno a punto de terminar: {caretaker}',
+	'email.shift.startBody': '{caretaker} comienza un turno de cuidado el {start}.',
+	'email.shift.endBody': '{caretaker} termina un turno de cuidado el {end}.',
+	'email.shift.footer':
+		'Recibes este correo porque las notificaciones de turnos están activadas en tus ajustes de EinVault.',
 
 	// Immich picker
 	'immich.picker.title': 'Elegir desde Immich',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -101,6 +101,8 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidRecurrence': 'Configuración de recurrencia no válida.',
 	'error.invalidDefaultRecurrence': 'Unidad de recurrencia predeterminada no válida.',
 	'error.invalidRole': 'Rol no válido.',
+	'error.invalidNtfyTopic':
+		'El tema solo puede contener letras, números, guiones y guiones bajos (máx. 64).',
 	'error.invalidDate': 'Fecha no válida',
 	'error.invalidArchiveDate': 'Fecha de archivo no válida.',
 	'error.invalidCompanionIds': 'Uno o más IDs de compañero no son válidos.',
@@ -247,6 +249,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsUpdated': 'Ajustes de notificaciones actualizados.',
 	'page.settings.notificationsNeedEmail':
 		'Añade un correo electrónico a tu cuenta para recibir notificaciones.',
+	'page.settings.ntfyTopicLabel': 'Tema de ntfy',
+	'page.settings.ntfyTopicHint':
+		'Las notificaciones push van a este tema en el servidor ntfy configurado por tu administrador. Elige un nombre largo y aleatorio; cualquiera que lo conozca puede suscribirse. Déjalo vacío para desactivar los push.',
 
 	// Page: Login
 	'page.login.title': 'Iniciar sesión',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -248,7 +248,7 @@ const messages: Record<keyof Messages, string> = {
 		'Enviarme un correo 24 horas antes de que un turno empiece o termine',
 	'page.settings.notificationsUpdated': 'Ajustes de notificaciones actualizados.',
 	'page.settings.notificationsNeedEmail':
-		'Añade un correo electrónico a tu cuenta para recibir notificaciones.',
+		'Añade un correo electrónico a tu cuenta para recibir notificaciones por correo.',
 	'page.settings.ntfyTopicLabel': 'Tema de ntfy',
 	'page.settings.ntfyTopicHint':
 		'Las notificaciones push van a este tema en el servidor ntfy configurado por tu administrador. Elige un nombre largo y aleatorio; cualquiera que lo conozca puede suscribirse. Déjalo vacío para desactivar los push.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -92,6 +92,9 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordsMismatch': 'Las contraseñas no coinciden.',
 	'error.usernameAlreadyTaken': 'Nombre de usuario ya en uso.',
 	'error.emailAlreadyTaken': 'Ese correo electrónico ya está en uso.',
+	'error.emailRequired': 'El correo electrónico es obligatorio.',
+	'error.emailInvalid': 'Introduce un correo electrónico válido.',
+	'error.tooManyResetRequests': 'Demasiadas solicitudes. Inténtalo más tarde.',
 	'error.invalidTheme': 'Tema no válido.',
 	'error.invalidLocale': 'Idioma no válido.',
 	'error.invalidReminderUndo': 'Valor de ventana de deshacer no válido.',
@@ -245,6 +248,27 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.passwordLabel': 'Contraseña',
 	'page.login.signIn': 'Iniciar sesión',
 	'page.login.signingIn': 'Iniciando sesión…',
+	'page.login.forgotPassword': '¿Olvidaste tu contraseña?',
+
+	// Page: Forgot password
+	'page.forgot.title': 'Restablecer tu contraseña',
+	'page.forgot.instruction':
+		'Introduce el correo electrónico de tu cuenta y te enviaremos un enlace para restablecer tu contraseña.',
+	'page.forgot.emailLabel': 'Correo electrónico',
+	'page.forgot.submit': 'Enviar enlace',
+	'page.forgot.sending': 'Enviando…',
+	'page.forgot.success': 'Si existe una cuenta con ese correo, se ha enviado un enlace.',
+	'page.forgot.backToLogin': 'Volver a iniciar sesión',
+
+	// Page: Reset password
+	'page.reset.title': 'Elige una nueva contraseña',
+	'page.reset.newPasswordLabel': 'Nueva contraseña',
+	'page.reset.confirmPasswordLabel': 'Confirmar nueva contraseña',
+	'page.reset.submit': 'Guardar nueva contraseña',
+	'page.reset.saving': 'Guardando…',
+	'page.reset.success': 'Tu contraseña ha sido actualizada. Ya puedes iniciar sesión.',
+	'page.reset.invalid': 'Este enlace no es válido o ha caducado.',
+	'page.reset.requestNew': 'Solicitar un nuevo enlace',
 
 	// Page: Setup
 	'page.setup.title': 'Configuración',
@@ -710,6 +734,14 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousMedia': 'Contenido anterior',
 	'aria.nextMedia': 'Contenido siguiente',
 	'aria.viewPhoto': 'Ver foto de {name}',
+
+	// Email: password reset
+	'email.reset.subject': 'Restablece tu contraseña de EinVault',
+	'email.reset.greeting': 'Hola {name}:',
+	'email.reset.body':
+		'Se ha solicitado un restablecimiento de contraseña para tu cuenta de EinVault ({username}). Usa el siguiente enlace para elegir una nueva contraseña. El enlace caduca en 30 minutos.',
+	'email.reset.cta': 'Restablecer contraseña',
+	'email.reset.ignore': 'Si no lo has solicitado, puedes ignorar este correo.',
 
 	// Immich picker
 	'immich.picker.title': 'Elegir desde Immich',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -249,7 +249,15 @@ const messages: Record<keyof Messages, string> = {
 		'Ajoutez une adresse e-mail à votre compte pour recevoir des notifications par e-mail.',
 	'page.settings.ntfyTopicLabel': 'Sujet ntfy',
 	'page.settings.ntfyTopicHint':
-		"Les notifications push sont envoyées à ce sujet sur le serveur ntfy configuré par votre administrateur. Choisissez un nom long et aléatoire ; quiconque le connaît peut s'y abonner. Laissez vide pour désactiver les push.",
+		"Les notifications push couvrent les rappels dus et les alertes de garde pour ce que vous pouvez voir dans EinVault. Elles sont envoyées à ce sujet sur le serveur ntfy configuré par votre administrateur. Choisissez un nom long et aléatoire ; quiconque le connaît peut s'y abonner. Laissez vide pour désactiver les push.",
+	'page.settings.testEmail': 'Envoyer un e-mail de test',
+	'page.settings.testNtfy': 'Envoyer un push de test',
+	'page.settings.testSent': 'Notification de test envoyée.',
+	'page.settings.testFailed': 'Échec du test : {error}',
+	'error.testCooldown': "Attendez quelques secondes avant d'envoyer un autre test.",
+	'email.test.subject': 'Notification de test EinVault',
+	'email.test.body':
+		"Ceci est une notification de test d'EinVault. Si vous lisez ceci, vos réglages de notification fonctionnent.",
 
 	// Page: Login
 	'page.login.title': 'Se connecter',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -246,7 +246,7 @@ const messages: Record<keyof Messages, string> = {
 		"M'envoyer un e-mail 24 heures avant le début ou la fin d'une garde",
 	'page.settings.notificationsUpdated': 'Réglages de notification mis à jour.',
 	'page.settings.notificationsNeedEmail':
-		'Ajoutez une adresse e-mail à votre compte pour recevoir des notifications.',
+		'Ajoutez une adresse e-mail à votre compte pour recevoir des notifications par e-mail.',
 	'page.settings.ntfyTopicLabel': 'Sujet ntfy',
 	'page.settings.ntfyTopicHint':
 		"Les notifications push sont envoyées à ce sujet sur le serveur ntfy configuré par votre administrateur. Choisissez un nom long et aléatoire ; quiconque le connaît peut s'y abonner. Laissez vide pour désactiver les push.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -236,6 +236,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.defaultRecurrenceLabel': 'Unité par défaut',
 	'page.settings.defaultRecurrenceSystem': 'Utiliser la valeur par défaut (jours)',
 	'page.settings.defaultRecurrenceUpdated': '✓ Récurrence par défaut mise à jour.',
+	'page.settings.notificationsCard': 'Notifications',
+	'page.settings.notificationsDescription':
+		"Recevez des e-mails d'EinVault. Les soignants ne sont notifiés que des rappels des compagnons qui leur sont assignés.",
+	'page.settings.notifyReminderEmailLabel': "M'envoyer un e-mail quand un rappel est dû",
+	'page.settings.notifyShiftEmailLabel':
+		"M'envoyer un e-mail 24 heures avant le début ou la fin d'une garde",
+	'page.settings.notificationsUpdated': 'Réglages de notification mis à jour.',
+	'page.settings.notificationsNeedEmail':
+		'Ajoutez une adresse e-mail à votre compte pour recevoir des notifications.',
 
 	// Page: Login
 	'page.login.title': 'Se connecter',
@@ -744,6 +753,23 @@ const messages: Record<keyof Messages, string> = {
 		'Une réinitialisation de mot de passe a été demandée pour votre compte EinVault ({username}). Utilisez le lien ci-dessous pour choisir un nouveau mot de passe. Le lien expire dans 30 minutes.',
 	'email.reset.cta': 'Réinitialiser le mot de passe',
 	'email.reset.ignore': "Si vous n'êtes pas à l'origine de cette demande, ignorez cet e-mail.",
+
+	// Email: reminder due
+	'email.reminder.subject': 'Rappel : {title}',
+	'email.reminder.greeting': 'Bonjour {name},',
+	'email.reminder.body': '{companion} a un rappel à échéance : {title}',
+	'email.reminder.dueLine': 'Échéance : {due}',
+	'email.reminder.cta': 'Ouvrir EinVault',
+	'email.reminder.footer':
+		'Vous recevez cet e-mail car les notifications de rappel sont activées dans vos réglages EinVault.',
+
+	// Email: caretaker shift alerts
+	'email.shift.startSubject': 'Garde bientôt commencée : {caretaker}',
+	'email.shift.endSubject': 'Garde bientôt terminée : {caretaker}',
+	'email.shift.startBody': '{caretaker} commence une garde le {start}.',
+	'email.shift.endBody': '{caretaker} termine une garde le {end}.',
+	'email.shift.footer':
+		'Vous recevez cet e-mail car les notifications de garde sont activées dans vos réglages EinVault.',
 
 	// Immich picker
 	'immich.picker.title': 'Choisir depuis Immich',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -101,6 +101,8 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidRecurrence': 'Configuration de récurrence invalide.',
 	'error.invalidDefaultRecurrence': 'Unité de récurrence par défaut invalide.',
 	'error.invalidRole': 'Rôle invalide.',
+	'error.invalidNtfyTopic':
+		'Le sujet ne peut contenir que des lettres, chiffres, tirets et tirets bas (max. 64).',
 	'error.invalidDate': 'Date invalide',
 	'error.invalidArchiveDate': "Date d'archivage invalide.",
 	'error.invalidCompanionIds': 'Un ou plusieurs identifiants de compagnon sont invalides.',
@@ -245,6 +247,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsUpdated': 'Réglages de notification mis à jour.',
 	'page.settings.notificationsNeedEmail':
 		'Ajoutez une adresse e-mail à votre compte pour recevoir des notifications.',
+	'page.settings.ntfyTopicLabel': 'Sujet ntfy',
+	'page.settings.ntfyTopicHint':
+		"Les notifications push sont envoyées à ce sujet sur le serveur ntfy configuré par votre administrateur. Choisissez un nom long et aléatoire ; quiconque le connaît peut s'y abonner. Laissez vide pour désactiver les push.",
 
 	// Page: Login
 	'page.login.title': 'Se connecter',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -91,6 +91,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordTooLong': 'Le mot de passe doit comporter au plus 128 caractères.',
 	'error.passwordsMismatch': 'Les mots de passe ne correspondent pas.',
 	'error.usernameAlreadyTaken': "Nom d'utilisateur déjà pris.",
+	'error.emailAlreadyTaken': 'Cette adresse e-mail est déjà utilisée.',
 	'error.invalidTheme': 'Thème invalide.',
 	'error.invalidLocale': 'Langue invalide.',
 	'error.invalidReminderUndo': "Valeur de fenêtre d'annulation invalide.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -92,6 +92,9 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordsMismatch': 'Les mots de passe ne correspondent pas.',
 	'error.usernameAlreadyTaken': "Nom d'utilisateur déjà pris.",
 	'error.emailAlreadyTaken': 'Cette adresse e-mail est déjà utilisée.',
+	'error.emailRequired': "L'adresse e-mail est requise.",
+	'error.emailInvalid': 'Saisissez une adresse e-mail valide.',
+	'error.tooManyResetRequests': 'Trop de demandes. Réessayez plus tard.',
 	'error.invalidTheme': 'Thème invalide.',
 	'error.invalidLocale': 'Langue invalide.',
 	'error.invalidReminderUndo': "Valeur de fenêtre d'annulation invalide.",
@@ -243,6 +246,28 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.passwordLabel': 'Mot de passe',
 	'page.login.signIn': 'Se connecter',
 	'page.login.signingIn': 'Connexion…',
+	'page.login.forgotPassword': 'Mot de passe oublié ?',
+
+	// Page: Forgot password
+	'page.forgot.title': 'Réinitialiser votre mot de passe',
+	'page.forgot.instruction':
+		'Saisissez l’adresse e-mail de votre compte et nous vous enverrons un lien pour réinitialiser votre mot de passe.',
+	'page.forgot.emailLabel': 'E-mail',
+	'page.forgot.submit': 'Envoyer le lien',
+	'page.forgot.sending': 'Envoi…',
+	'page.forgot.success': 'Si un compte existe avec cet e-mail, un lien a été envoyé.',
+	'page.forgot.backToLogin': 'Retour à la connexion',
+
+	// Page: Reset password
+	'page.reset.title': 'Choisir un nouveau mot de passe',
+	'page.reset.newPasswordLabel': 'Nouveau mot de passe',
+	'page.reset.confirmPasswordLabel': 'Confirmer le nouveau mot de passe',
+	'page.reset.submit': 'Enregistrer le nouveau mot de passe',
+	'page.reset.saving': 'Enregistrement…',
+	'page.reset.success':
+		'Votre mot de passe a été mis à jour. Vous pouvez maintenant vous connecter.',
+	'page.reset.invalid': 'Ce lien est invalide ou a expiré.',
+	'page.reset.requestNew': 'Demander un nouveau lien',
 
 	// Page: Setup
 	'page.setup.title': 'Configuration',
@@ -711,6 +736,14 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousMedia': 'Média précédent',
 	'aria.nextMedia': 'Média suivant',
 	'aria.viewPhoto': 'Voir la photo de {name}',
+
+	// Email: password reset
+	'email.reset.subject': 'Réinitialisez votre mot de passe EinVault',
+	'email.reset.greeting': 'Bonjour {name},',
+	'email.reset.body':
+		'Une réinitialisation de mot de passe a été demandée pour votre compte EinVault ({username}). Utilisez le lien ci-dessous pour choisir un nouveau mot de passe. Le lien expire dans 30 minutes.',
+	'email.reset.cta': 'Réinitialiser le mot de passe',
+	'email.reset.ignore': "Si vous n'êtes pas à l'origine de cette demande, ignorez cet e-mail.",
 
 	// Immich picker
 	'immich.picker.title': 'Choisir depuis Immich',

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -70,7 +70,7 @@ export function t(
 	let msg = catalog[key] ?? catalogs[DEFAULT_LOCALE][key] ?? key;
 	if (params) {
 		for (const [k, v] of Object.entries(params)) {
-			msg = msg.replaceAll(`{${k}}`, String(v));
+			msg = msg.replaceAll(`{${k}}`, () => String(v));
 		}
 	}
 	return msg;

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -244,7 +244,7 @@ const messages: Record<keyof Messages, string> = {
 		'Inviami una e-mail 24 ore prima che un turno inizi o finisca',
 	'page.settings.notificationsUpdated': 'Impostazioni delle notifiche aggiornate.',
 	'page.settings.notificationsNeedEmail':
-		'Aggiungi un indirizzo e-mail al tuo account per ricevere le notifiche.',
+		'Aggiungi un indirizzo e-mail al tuo account per ricevere le notifiche via e-mail.',
 	'page.settings.ntfyTopicLabel': 'Argomento ntfy',
 	'page.settings.ntfyTopicHint':
 		'Le notifiche push vanno a questo argomento sul server ntfy configurato dal tuo amministratore. Scegli un nome lungo e casuale; chiunque lo conosca può iscriversi. Lascia vuoto per disattivare i push.',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -100,6 +100,8 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidRecurrence': 'Configurazione ricorrenza non valida.',
 	'error.invalidDefaultRecurrence': 'Unità di ricorrenza predefinita non valida.',
 	'error.invalidRole': 'Ruolo non valido.',
+	'error.invalidNtfyTopic':
+		"L'argomento può contenere solo lettere, numeri, trattini e trattini bassi (max 64).",
 	'error.invalidDate': 'Data non valida',
 	'error.invalidArchiveDate': 'Data di archiviazione non valida.',
 	'error.invalidCompanionIds': 'Uno o più ID compagno non sono validi.',
@@ -243,6 +245,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsUpdated': 'Impostazioni delle notifiche aggiornate.',
 	'page.settings.notificationsNeedEmail':
 		'Aggiungi un indirizzo e-mail al tuo account per ricevere le notifiche.',
+	'page.settings.ntfyTopicLabel': 'Argomento ntfy',
+	'page.settings.ntfyTopicHint':
+		'Le notifiche push vanno a questo argomento sul server ntfy configurato dal tuo amministratore. Scegli un nome lungo e casuale; chiunque lo conosca può iscriversi. Lascia vuoto per disattivare i push.',
 
 	// Page: Login
 	'page.login.title': 'Accedi',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -91,6 +91,9 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordsMismatch': 'Le password non corrispondono.',
 	'error.usernameAlreadyTaken': 'Nome utente già in uso.',
 	'error.emailAlreadyTaken': 'Questo indirizzo e-mail è già in uso.',
+	'error.emailRequired': "L'indirizzo e-mail è obbligatorio.",
+	'error.emailInvalid': 'Inserisci un indirizzo e-mail valido.',
+	'error.tooManyResetRequests': 'Troppe richieste. Riprova più tardi.',
 	'error.invalidTheme': 'Tema non valido.',
 	'error.invalidLocale': 'Lingua non valida.',
 	'error.invalidReminderUndo': 'Valore finestra annulla non valido.',
@@ -241,6 +244,27 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.passwordLabel': 'Password',
 	'page.login.signIn': 'Accedi',
 	'page.login.signingIn': 'Accesso in corso…',
+	'page.login.forgotPassword': 'Password dimenticata?',
+
+	// Page: Forgot password
+	'page.forgot.title': 'Reimposta la tua password',
+	'page.forgot.instruction':
+		"Inserisci l'indirizzo e-mail del tuo account e ti invieremo un link per reimpostare la password.",
+	'page.forgot.emailLabel': 'E-mail',
+	'page.forgot.submit': 'Invia link',
+	'page.forgot.sending': 'Invio…',
+	'page.forgot.success': 'Se esiste un account con questa e-mail, è stato inviato un link.',
+	'page.forgot.backToLogin': "Torna all'accesso",
+
+	// Page: Reset password
+	'page.reset.title': 'Scegli una nuova password',
+	'page.reset.newPasswordLabel': 'Nuova password',
+	'page.reset.confirmPasswordLabel': 'Conferma nuova password',
+	'page.reset.submit': 'Salva nuova password',
+	'page.reset.saving': 'Salvataggio…',
+	'page.reset.success': 'La tua password è stata aggiornata. Ora puoi accedere.',
+	'page.reset.invalid': 'Questo link non è valido o è scaduto.',
+	'page.reset.requestNew': 'Richiedi un nuovo link',
 
 	// Page: Setup
 	'page.setup.title': 'Configurazione',
@@ -705,6 +729,14 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousMedia': 'Contenuto precedente',
 	'aria.nextMedia': 'Contenuto successivo',
 	'aria.viewPhoto': 'Vedi la foto di {name}',
+
+	// Email: password reset
+	'email.reset.subject': 'Reimposta la tua password di EinVault',
+	'email.reset.greeting': 'Ciao {name},',
+	'email.reset.body':
+		'È stata richiesta la reimpostazione della password per il tuo account EinVault ({username}). Usa il link qui sotto per scegliere una nuova password. Il link scade tra 30 minuti.',
+	'email.reset.cta': 'Reimposta password',
+	'email.reset.ignore': 'Se non hai richiesto tu questa operazione, ignora questa e-mail.',
 
 	// Immich picker
 	'immich.picker.title': 'Scegli da Immich',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -234,6 +234,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.defaultRecurrenceLabel': 'Unità predefinita',
 	'page.settings.defaultRecurrenceSystem': 'Usa predefinito di sistema (giorni)',
 	'page.settings.defaultRecurrenceUpdated': '✓ Ricorrenza predefinita aggiornata.',
+	'page.settings.notificationsCard': 'Notifiche',
+	'page.settings.notificationsDescription':
+		'Ricevi e-mail da EinVault. I custodi ricevono avvisi solo per i promemoria dei compagni a loro assegnati.',
+	'page.settings.notifyReminderEmailLabel': 'Inviami una e-mail quando un promemoria è in scadenza',
+	'page.settings.notifyShiftEmailLabel':
+		'Inviami una e-mail 24 ore prima che un turno inizi o finisca',
+	'page.settings.notificationsUpdated': 'Impostazioni delle notifiche aggiornate.',
+	'page.settings.notificationsNeedEmail':
+		'Aggiungi un indirizzo e-mail al tuo account per ricevere le notifiche.',
 
 	// Page: Login
 	'page.login.title': 'Accedi',
@@ -737,6 +746,23 @@ const messages: Record<keyof Messages, string> = {
 		'È stata richiesta la reimpostazione della password per il tuo account EinVault ({username}). Usa il link qui sotto per scegliere una nuova password. Il link scade tra 30 minuti.',
 	'email.reset.cta': 'Reimposta password',
 	'email.reset.ignore': 'Se non hai richiesto tu questa operazione, ignora questa e-mail.',
+
+	// Email: reminder due
+	'email.reminder.subject': 'Promemoria: {title}',
+	'email.reminder.greeting': 'Ciao {name},',
+	'email.reminder.body': '{companion} ha un promemoria in scadenza: {title}',
+	'email.reminder.dueLine': 'Scadenza: {due}',
+	'email.reminder.cta': 'Apri EinVault',
+	'email.reminder.footer':
+		'Ricevi questa e-mail perché le notifiche dei promemoria sono attive nelle tue impostazioni di EinVault.',
+
+	// Email: caretaker shift alerts
+	'email.shift.startSubject': 'Turno in arrivo: {caretaker}',
+	'email.shift.endSubject': 'Turno in conclusione: {caretaker}',
+	'email.shift.startBody': '{caretaker} inizia un turno di assistenza il {start}.',
+	'email.shift.endBody': '{caretaker} termina un turno di assistenza il {end}.',
+	'email.shift.footer':
+		'Ricevi questa e-mail perché le notifiche dei turni sono attive nelle tue impostazioni di EinVault.',
 
 	// Immich picker
 	'immich.picker.title': 'Scegli da Immich',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -90,6 +90,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordTooLong': 'La password deve contenere al massimo 128 caratteri.',
 	'error.passwordsMismatch': 'Le password non corrispondono.',
 	'error.usernameAlreadyTaken': 'Nome utente già in uso.',
+	'error.emailAlreadyTaken': 'Questo indirizzo e-mail è già in uso.',
 	'error.invalidTheme': 'Tema non valido.',
 	'error.invalidLocale': 'Lingua non valida.',
 	'error.invalidReminderUndo': 'Valore finestra annulla non valido.',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -247,7 +247,15 @@ const messages: Record<keyof Messages, string> = {
 		'Aggiungi un indirizzo e-mail al tuo account per ricevere le notifiche via e-mail.',
 	'page.settings.ntfyTopicLabel': 'Argomento ntfy',
 	'page.settings.ntfyTopicHint':
-		'Le notifiche push vanno a questo argomento sul server ntfy configurato dal tuo amministratore. Scegli un nome lungo e casuale; chiunque lo conosca può iscriversi. Lascia vuoto per disattivare i push.',
+		'Le notifiche push coprono i promemoria in scadenza e gli avvisi di turno per ciò che puoi vedere in EinVault. Vanno a questo argomento sul server ntfy configurato dal tuo amministratore. Scegli un nome lungo e casuale; chiunque lo conosca può iscriversi. Lascia vuoto per disattivare i push.',
+	'page.settings.testEmail': 'Invia e-mail di prova',
+	'page.settings.testNtfy': 'Invia push di prova',
+	'page.settings.testSent': 'Notifica di prova inviata.',
+	'page.settings.testFailed': 'Prova non riuscita: {error}',
+	'error.testCooldown': "Attendi qualche secondo prima di inviare un'altra prova.",
+	'email.test.subject': 'Notifica di prova di EinVault',
+	'email.test.body':
+		'Questa è una notifica di prova di EinVault. Se la stai leggendo, le tue impostazioni di notifica funzionano.',
 
 	// Page: Login
 	'page.login.title': 'Accedi',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -235,6 +235,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.defaultRecurrenceLabel': 'Unidade padrão',
 	'page.settings.defaultRecurrenceSystem': 'Usar padrão do sistema (dias)',
 	'page.settings.defaultRecurrenceUpdated': '✓ Recorrência padrão atualizada.',
+	'page.settings.notificationsCard': 'Notificações',
+	'page.settings.notificationsDescription':
+		'Receba e-mails do EinVault. Cuidadores só são notificados sobre lembretes dos companheiros atribuídos a eles.',
+	'page.settings.notifyReminderEmailLabel': 'Enviar e-mail quando um lembrete vencer',
+	'page.settings.notifyShiftEmailLabel':
+		'Enviar e-mail 24 horas antes de um turno começar ou terminar',
+	'page.settings.notificationsUpdated': 'Configurações de notificação atualizadas.',
+	'page.settings.notificationsNeedEmail':
+		'Adicione um e-mail à sua conta para receber notificações.',
 
 	// Page: Login
 	'page.login.title': 'Iniciar sessão',
@@ -739,6 +748,23 @@ const messages: Record<keyof Messages, string> = {
 		'Foi solicitada a redefinição de senha da sua conta EinVault ({username}). Use o link abaixo para escolher uma nova senha. O link expira em 30 minutos.',
 	'email.reset.cta': 'Redefinir senha',
 	'email.reset.ignore': 'Se você não solicitou isso, ignore este e-mail.',
+
+	// Email: reminder due
+	'email.reminder.subject': 'Lembrete: {title}',
+	'email.reminder.greeting': 'Olá, {name}!',
+	'email.reminder.body': '{companion} tem um lembrete pendente: {title}',
+	'email.reminder.dueLine': 'Vence: {due}',
+	'email.reminder.cta': 'Abrir EinVault',
+	'email.reminder.footer':
+		'Você está recebendo este e-mail porque as notificações de lembretes estão ativadas nas suas configurações do EinVault.',
+
+	// Email: caretaker shift alerts
+	'email.shift.startSubject': 'Turno começando em breve: {caretaker}',
+	'email.shift.endSubject': 'Turno terminando em breve: {caretaker}',
+	'email.shift.startBody': '{caretaker} começa um turno de cuidado em {start}.',
+	'email.shift.endBody': '{caretaker} termina um turno de cuidado em {end}.',
+	'email.shift.footer':
+		'Você está recebendo este e-mail porque as notificações de turnos estão ativadas nas suas configurações do EinVault.',
 
 	// Immich picker
 	'immich.picker.title': 'Escolher do Immich',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -248,7 +248,15 @@ const messages: Record<keyof Messages, string> = {
 		'Adicione um e-mail à sua conta para receber notificações por e-mail.',
 	'page.settings.ntfyTopicLabel': 'Tópico ntfy',
 	'page.settings.ntfyTopicHint':
-		'As notificações push vão para este tópico no servidor ntfy configurado pelo seu administrador. Escolha um nome longo e aleatório; qualquer pessoa que o conheça pode se inscrever. Deixe vazio para desativar os push.',
+		'As notificações push cobrem lembretes vencidos e alertas de turno do que você pode ver no EinVault. Vão para este tópico no servidor ntfy configurado pelo seu administrador. Escolha um nome longo e aleatório; qualquer pessoa que o conheça pode se inscrever. Deixe vazio para desativar os push.',
+	'page.settings.testEmail': 'Enviar e-mail de teste',
+	'page.settings.testNtfy': 'Enviar push de teste',
+	'page.settings.testSent': 'Notificação de teste enviada.',
+	'page.settings.testFailed': 'O teste falhou: {error}',
+	'error.testCooldown': 'Aguarde alguns segundos antes de enviar outro teste.',
+	'email.test.subject': 'Notificação de teste do EinVault',
+	'email.test.body':
+		'Esta é uma notificação de teste do EinVault. Se você está lendo isto, suas configurações de notificação funcionam.',
 
 	// Page: Login
 	'page.login.title': 'Iniciar sessão',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -245,7 +245,7 @@ const messages: Record<keyof Messages, string> = {
 		'Enviar e-mail 24 horas antes de um turno começar ou terminar',
 	'page.settings.notificationsUpdated': 'Configurações de notificação atualizadas.',
 	'page.settings.notificationsNeedEmail':
-		'Adicione um e-mail à sua conta para receber notificações.',
+		'Adicione um e-mail à sua conta para receber notificações por e-mail.',
 	'page.settings.ntfyTopicLabel': 'Tópico ntfy',
 	'page.settings.ntfyTopicHint':
 		'As notificações push vão para este tópico no servidor ntfy configurado pelo seu administrador. Escolha um nome longo e aleatório; qualquer pessoa que o conheça pode se inscrever. Deixe vazio para desativar os push.',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -101,6 +101,8 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidRecurrence': 'Configuração de recorrência inválida.',
 	'error.invalidDefaultRecurrence': 'Unidade de recorrência padrão inválida.',
 	'error.invalidRole': 'Função inválida.',
+	'error.invalidNtfyTopic':
+		'O tópico só pode conter letras, números, hífens e sublinhados (máx. 64).',
 	'error.invalidDate': 'Data inválida',
 	'error.invalidArchiveDate': 'Data de arquivo inválida.',
 	'error.invalidCompanionIds': 'Um ou mais IDs de companheiro são inválidos.',
@@ -244,6 +246,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsUpdated': 'Configurações de notificação atualizadas.',
 	'page.settings.notificationsNeedEmail':
 		'Adicione um e-mail à sua conta para receber notificações.',
+	'page.settings.ntfyTopicLabel': 'Tópico ntfy',
+	'page.settings.ntfyTopicHint':
+		'As notificações push vão para este tópico no servidor ntfy configurado pelo seu administrador. Escolha um nome longo e aleatório; qualquer pessoa que o conheça pode se inscrever. Deixe vazio para desativar os push.',
 
 	// Page: Login
 	'page.login.title': 'Iniciar sessão',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -92,6 +92,9 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordsMismatch': 'As palavras-passe não coincidem.',
 	'error.usernameAlreadyTaken': 'Nome de utilizador já em uso.',
 	'error.emailAlreadyTaken': 'Esse e-mail já está em uso.',
+	'error.emailRequired': 'O e-mail é obrigatório.',
+	'error.emailInvalid': 'Digite um e-mail válido.',
+	'error.tooManyResetRequests': 'Muitas solicitações. Tente novamente mais tarde.',
 	'error.invalidTheme': 'Tema inválido.',
 	'error.invalidLocale': 'Idioma inválido.',
 	'error.invalidReminderUndo': 'Valor de janela para desfazer inválido.',
@@ -242,6 +245,27 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.passwordLabel': 'Palavra-passe',
 	'page.login.signIn': 'Iniciar sessão',
 	'page.login.signingIn': 'A iniciar sessão…',
+	'page.login.forgotPassword': 'Esqueceu a senha?',
+
+	// Page: Forgot password
+	'page.forgot.title': 'Redefinir sua senha',
+	'page.forgot.instruction':
+		'Digite o e-mail da sua conta e enviaremos um link para redefinir sua senha.',
+	'page.forgot.emailLabel': 'E-mail',
+	'page.forgot.submit': 'Enviar link',
+	'page.forgot.sending': 'Enviando…',
+	'page.forgot.success': 'Se existir uma conta com esse e-mail, um link foi enviado.',
+	'page.forgot.backToLogin': 'Voltar ao login',
+
+	// Page: Reset password
+	'page.reset.title': 'Escolha uma nova senha',
+	'page.reset.newPasswordLabel': 'Nova senha',
+	'page.reset.confirmPasswordLabel': 'Confirmar nova senha',
+	'page.reset.submit': 'Salvar nova senha',
+	'page.reset.saving': 'Salvando…',
+	'page.reset.success': 'Sua senha foi atualizada. Agora você pode entrar.',
+	'page.reset.invalid': 'Este link é inválido ou expirou.',
+	'page.reset.requestNew': 'Solicitar um novo link',
 
 	// Page: Setup
 	'page.setup.title': 'Configuração',
@@ -707,6 +731,14 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousMedia': 'Mídia anterior',
 	'aria.nextMedia': 'Próxima mídia',
 	'aria.viewPhoto': 'Ver foto de {name}',
+
+	// Email: password reset
+	'email.reset.subject': 'Redefina sua senha do EinVault',
+	'email.reset.greeting': 'Olá, {name}!',
+	'email.reset.body':
+		'Foi solicitada a redefinição de senha da sua conta EinVault ({username}). Use o link abaixo para escolher uma nova senha. O link expira em 30 minutos.',
+	'email.reset.cta': 'Redefinir senha',
+	'email.reset.ignore': 'Se você não solicitou isso, ignore este e-mail.',
 
 	// Immich picker
 	'immich.picker.title': 'Escolher do Immich',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -91,6 +91,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.passwordTooLong': 'A palavra-passe deve ter no máximo 128 caracteres.',
 	'error.passwordsMismatch': 'As palavras-passe não coincidem.',
 	'error.usernameAlreadyTaken': 'Nome de utilizador já em uso.',
+	'error.emailAlreadyTaken': 'Esse e-mail já está em uso.',
 	'error.invalidTheme': 'Tema inválido.',
 	'error.invalidLocale': 'Idioma inválido.',
 	'error.invalidReminderUndo': 'Valor de janela para desfazer inválido.',

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -18,7 +18,7 @@ import {
 	REMINDER_UNDO_DEFAULT_SENTINEL,
 	REMINDER_UNDO_SECONDS_DEFAULT
 } from '$lib/server/env';
-import { parseRecurrenceUnit } from '$lib/server/validation';
+import { parseRecurrenceUnit, EMAIL_RE } from '$lib/server/validation';
 import { NTFY_TOPIC_RE, isNtfyEnabled, sendNtfy } from '$lib/server/notify/ntfy';
 import { isMailEnabled, sendMail } from '$lib/server/mail';
 import { buildTestEmail } from '$lib/server/mail/templates';
@@ -60,6 +60,9 @@ export async function handleAccountUpdate(
 	}
 
 	if (email) {
+		if (!EMAIL_RE.test(email)) {
+			return fail(400, { accountError: t(locale, 'error.emailInvalid') });
+		}
 		const emailConflict = await db.query.users.findFirst({
 			where: eq(schema.users.email, email)
 		});
@@ -234,9 +237,13 @@ export async function handleTestEmail(
 			buildTestEmail(user.locale, { displayName: user.displayName, email: user.email })
 		);
 	} catch (err) {
-		const msg = err instanceof Error ? err.message : String(err);
+		// Full detail to the server log only. nodemailer messages can embed the
+		// SMTP host:port; surface just the error-code class (EAUTH, ECONNECTION,
+		// ...) to the client, which is host-free and still useful for debugging.
+		console.error(`[mail] test email for user ${user.id} failed:`, err);
+		const code = (err as { code?: string } | null)?.code ?? 'send failed';
 		return fail(502, {
-			notificationsTestError: t(locale, 'page.settings.testFailed', { error: msg })
+			notificationsTestError: t(locale, 'page.settings.testFailed', { error: code })
 		});
 	}
 	stampTestCooldown(`${user.id}:email`);
@@ -264,6 +271,9 @@ export async function handleTestNtfy(
 			message: t(user.locale, 'email.test.body')
 		});
 	} catch (err) {
+		// sendNtfy errors are host-free (HTTP status, or undici's opaque "fetch
+		// failed"); safe to surface, but log full detail server-side too.
+		console.error(`[ntfy] test push for user ${user.id} failed:`, err);
 		const msg = err instanceof Error ? err.message : String(err);
 		return fail(502, {
 			notificationsTestError: t(locale, 'page.settings.testFailed', { error: msg })

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -19,6 +19,7 @@ import {
 	REMINDER_UNDO_SECONDS_DEFAULT
 } from '$lib/server/env';
 import { parseRecurrenceUnit } from '$lib/server/validation';
+import { NTFY_TOPIC_RE } from '$lib/server/notify/ntfy';
 
 export async function handleAccountUpdate(
 	userId: string,
@@ -177,14 +178,20 @@ export async function handleDefaultRecurrenceUpdate(
 	return { defaultRecurrenceSuccess: true };
 }
 
-export async function handleNotificationsUpdate(userId: string, request: Request) {
+export async function handleNotificationsUpdate(userId: string, request: Request, locale: Locale) {
 	const data = await request.formData();
 	const notifyReminderEmail = data.get('notifyReminderEmail') === 'on';
 	const notifyShiftEmail = data.get('notifyShiftEmail') === 'on';
+	const rawTopic = String(data.get('ntfyTopic') ?? '').trim();
+	const ntfyTopic = rawTopic || null;
+
+	if (ntfyTopic && !NTFY_TOPIC_RE.test(ntfyTopic)) {
+		return fail(400, { notificationsError: t(locale, 'error.invalidNtfyTopic') });
+	}
 
 	await db
 		.update(schema.users)
-		.set({ notifyReminderEmail, notifyShiftEmail })
+		.set({ notifyReminderEmail, notifyShiftEmail, ntfyTopic })
 		.where(eq(schema.users.id, userId));
 
 	return { notificationsSuccess: true };

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -31,7 +31,10 @@ export async function handleAccountUpdate(
 	const username = String(data.get('username') ?? '')
 		.trim()
 		.toLowerCase();
-	const email = String(data.get('email') ?? '').trim() || null;
+	const email =
+		String(data.get('email') ?? '')
+			.trim()
+			.toLowerCase() || null;
 	const phone = String(data.get('phone') ?? '').trim() || null;
 	const currentPassword = String(data.get('currentPassword') ?? '');
 	const newPassword = String(data.get('newPassword') ?? '');
@@ -51,6 +54,15 @@ export async function handleAccountUpdate(
 	});
 	if (existing && existing.id !== userId) {
 		return fail(400, { accountError: t(locale, 'error.usernameAlreadyTakenAccount') });
+	}
+
+	if (email) {
+		const emailConflict = await db.query.users.findFirst({
+			where: eq(schema.users.email, email)
+		});
+		if (emailConflict && emailConflict.id !== userId) {
+			return fail(400, { accountError: t(locale, 'error.emailAlreadyTaken') });
+		}
 	}
 
 	const updates: Partial<typeof schema.users.$inferInsert> = {

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -96,7 +96,18 @@ export async function handleAccountUpdate(
 		updates.passwordHash = await bcrypt.hash(newPassword, 12);
 	}
 
-	await db.update(schema.users).set(updates).where(eq(schema.users.id, userId));
+	try {
+		await db.update(schema.users).set(updates).where(eq(schema.users.id, userId));
+	} catch (err) {
+		if (
+			err instanceof Error &&
+			(err as Error & { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE' &&
+			err.message.includes('users_email_idx')
+		) {
+			return fail(400, { accountError: t(locale, 'error.emailAlreadyTaken') });
+		}
+		throw err;
+	}
 
 	if (updates.passwordHash) {
 		await invalidateAllUserSessions(userId);

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -176,3 +176,16 @@ export async function handleDefaultRecurrenceUpdate(
 
 	return { defaultRecurrenceSuccess: true };
 }
+
+export async function handleNotificationsUpdate(userId: string, request: Request) {
+	const data = await request.formData();
+	const notifyReminderEmail = data.get('notifyReminderEmail') === 'on';
+	const notifyShiftEmail = data.get('notifyShiftEmail') === 'on';
+
+	await db
+		.update(schema.users)
+		.set({ notifyReminderEmail, notifyShiftEmail })
+		.where(eq(schema.users.id, userId));
+
+	return { notificationsSuccess: true };
+}

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -19,7 +19,9 @@ import {
 	REMINDER_UNDO_SECONDS_DEFAULT
 } from '$lib/server/env';
 import { parseRecurrenceUnit } from '$lib/server/validation';
-import { NTFY_TOPIC_RE } from '$lib/server/notify/ntfy';
+import { NTFY_TOPIC_RE, isNtfyEnabled, sendNtfy } from '$lib/server/notify/ntfy';
+import { isMailEnabled, sendMail } from '$lib/server/mail';
+import { buildTestEmail } from '$lib/server/mail/templates';
 
 export async function handleAccountUpdate(
 	userId: string,
@@ -195,4 +197,77 @@ export async function handleNotificationsUpdate(userId: string, request: Request
 		.where(eq(schema.users.id, userId));
 
 	return { notificationsSuccess: true };
+}
+
+// Test sends are immediate (not via the outbox) so the user gets instant
+// feedback. Light per-user cooldown to keep a stuck double-click from
+// hammering SMTP or ntfy. In-process state, single-instance assumption.
+const TEST_COOLDOWN_MS = 10 * 1000;
+const lastTestAt = new Map<string, number>();
+
+function testOnCooldown(key: string): boolean {
+	const now = Date.now();
+	const last = lastTestAt.get(key) ?? 0;
+	if (now - last < TEST_COOLDOWN_MS) return true;
+	lastTestAt.set(key, now);
+	return false;
+}
+
+export async function handleTestEmail(
+	user: { id: string; displayName: string; email: string | null; locale: Locale },
+	locale: Locale
+) {
+	if (!isMailEnabled() || !user.email) {
+		return fail(400, {
+			notificationsTestError: t(locale, 'page.settings.testFailed', {
+				error: 'email unavailable'
+			})
+		});
+	}
+	if (testOnCooldown(`${user.id}:email`)) {
+		return fail(429, { notificationsTestError: t(locale, 'error.testCooldown') });
+	}
+	try {
+		await sendMail(
+			buildTestEmail(user.locale, { displayName: user.displayName, email: user.email })
+		);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return fail(502, {
+			notificationsTestError: t(locale, 'page.settings.testFailed', { error: msg })
+		});
+	}
+	return { notificationsTestSuccess: true };
+}
+
+export async function handleTestNtfy(
+	user: { id: string; displayName: string; locale: Locale },
+	locale: Locale
+) {
+	const row = await db.query.users.findFirst({
+		where: eq(schema.users.id, user.id),
+		columns: { ntfyTopic: true }
+	});
+	if (!isNtfyEnabled() || !row?.ntfyTopic) {
+		return fail(400, {
+			notificationsTestError: t(locale, 'page.settings.testFailed', {
+				error: 'ntfy unavailable'
+			})
+		});
+	}
+	if (testOnCooldown(`${user.id}:ntfy`)) {
+		return fail(429, { notificationsTestError: t(locale, 'error.testCooldown') });
+	}
+	try {
+		await sendNtfy(row.ntfyTopic, {
+			title: t(user.locale, 'email.test.subject'),
+			message: t(user.locale, 'email.test.body')
+		});
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return fail(502, {
+			notificationsTestError: t(locale, 'page.settings.testFailed', { error: msg })
+		});
+	}
+	return { notificationsTestSuccess: true };
 }

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -201,16 +201,18 @@ export async function handleNotificationsUpdate(userId: string, request: Request
 
 // Test sends are immediate (not via the outbox) so the user gets instant
 // feedback. Light per-user cooldown to keep a stuck double-click from
-// hammering SMTP or ntfy. In-process state, single-instance assumption.
+// hammering SMTP or ntfy. Only successful sends stamp the cooldown: a user
+// debugging a broken config gets to retry immediately. In-process state,
+// single-instance assumption.
 const TEST_COOLDOWN_MS = 10 * 1000;
 const lastTestAt = new Map<string, number>();
 
 function testOnCooldown(key: string): boolean {
-	const now = Date.now();
-	const last = lastTestAt.get(key) ?? 0;
-	if (now - last < TEST_COOLDOWN_MS) return true;
-	lastTestAt.set(key, now);
-	return false;
+	return Date.now() - (lastTestAt.get(key) ?? 0) < TEST_COOLDOWN_MS;
+}
+
+function stampTestCooldown(key: string): void {
+	lastTestAt.set(key, Date.now());
 }
 
 export async function handleTestEmail(
@@ -237,18 +239,16 @@ export async function handleTestEmail(
 			notificationsTestError: t(locale, 'page.settings.testFailed', { error: msg })
 		});
 	}
+	stampTestCooldown(`${user.id}:email`);
 	return { notificationsTestSuccess: true };
 }
 
 export async function handleTestNtfy(
-	user: { id: string; displayName: string; locale: Locale },
+	user: { id: string; displayName: string; ntfyTopic: string | null; locale: Locale },
 	locale: Locale
 ) {
-	const row = await db.query.users.findFirst({
-		where: eq(schema.users.id, user.id),
-		columns: { ntfyTopic: true }
-	});
-	if (!isNtfyEnabled() || !row?.ntfyTopic) {
+	// locals.user is selected fresh per request, same trust as email above.
+	if (!isNtfyEnabled() || !user.ntfyTopic) {
 		return fail(400, {
 			notificationsTestError: t(locale, 'page.settings.testFailed', {
 				error: 'ntfy unavailable'
@@ -259,7 +259,7 @@ export async function handleTestNtfy(
 		return fail(429, { notificationsTestError: t(locale, 'error.testCooldown') });
 	}
 	try {
-		await sendNtfy(row.ntfyTopic, {
+		await sendNtfy(user.ntfyTopic, {
 			title: t(user.locale, 'email.test.subject'),
 			message: t(user.locale, 'email.test.body')
 		});
@@ -269,5 +269,6 @@ export async function handleTestNtfy(
 			notificationsTestError: t(locale, 'page.settings.testFailed', { error: msg })
 		});
 	}
+	stampTestCooldown(`${user.id}:ntfy`);
 	return { notificationsTestSuccess: true };
 }

--- a/src/lib/server/account.ts
+++ b/src/lib/server/account.ts
@@ -102,7 +102,7 @@ export async function handleAccountUpdate(
 		if (
 			err instanceof Error &&
 			(err as Error & { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE' &&
-			err.message.includes('users_email_idx')
+			err.message.includes('users.email')
 		) {
 			return fail(400, { accountError: t(locale, 'error.emailAlreadyTaken') });
 		}

--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -50,7 +50,9 @@ export async function validateAuth(event: RequestEvent, { refreshCookie = true }
 			email: user.email ?? null,
 			phone: user.phone ?? null,
 			reminderUndoSeconds: user.reminderUndoSeconds ?? null,
-			defaultRecurrenceUnit: user.defaultRecurrenceUnit ?? null
+			defaultRecurrenceUnit: user.defaultRecurrenceUnit ?? null,
+			notifyReminderEmail: user.notifyReminderEmail ?? false,
+			notifyShiftEmail: user.notifyShiftEmail ?? false
 		}
 	};
 }

--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -52,7 +52,8 @@ export async function validateAuth(event: RequestEvent, { refreshCookie = true }
 			reminderUndoSeconds: user.reminderUndoSeconds ?? null,
 			defaultRecurrenceUnit: user.defaultRecurrenceUnit ?? null,
 			notifyReminderEmail: user.notifyReminderEmail ?? false,
-			notifyShiftEmail: user.notifyShiftEmail ?? false
+			notifyShiftEmail: user.notifyShiftEmail ?? false,
+			ntfyTopic: user.ntfyTopic ?? null
 		}
 	};
 }

--- a/src/lib/server/auth/password-reset.ts
+++ b/src/lib/server/auth/password-reset.ts
@@ -1,0 +1,86 @@
+import { db, schema } from '$lib/server/db';
+import { and, eq, gt, lt } from 'drizzle-orm';
+import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from '@oslojs/encoding';
+import { sha256 } from '@oslojs/crypto/sha2';
+
+// Mirrors the session token scheme (src/lib/server/auth/session.ts): a random
+// 20-byte base32 token travels in the email link; only its sha256 hex lands in
+// the DB. sha256 (not bcrypt) is correct for high-entropy random tokens.
+
+const RESET_TOKEN_DURATION_MS = 30 * 60 * 1000;
+// DB-backed cooldown between token issues per user. Survives restarts, unlike
+// the in-memory per-IP limiter in the forgot route.
+const MIN_REISSUE_INTERVAL_MS = 60 * 1000;
+
+function generateResetToken(): string {
+	const bytes = new Uint8Array(20);
+	crypto.getRandomValues(bytes);
+	return encodeBase32LowerCaseNoPadding(bytes);
+}
+
+function tokenToId(token: string): string {
+	return encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+}
+
+/**
+ * Issue a reset token for a user. Returns the raw token for the email link,
+ * or null when a token was already issued within the cooldown window.
+ * Last-request-wins: any previous tokens for the user are deleted.
+ */
+export async function createResetToken(userId: string): Promise<string | null> {
+	const recent = await db.query.passwordResetTokens.findFirst({
+		where: and(
+			eq(schema.passwordResetTokens.userId, userId),
+			gt(schema.passwordResetTokens.createdAt, new Date(Date.now() - MIN_REISSUE_INTERVAL_MS))
+		),
+		columns: { id: true }
+	});
+	if (recent) return null;
+
+	const token = generateResetToken();
+	await db.delete(schema.passwordResetTokens).where(eq(schema.passwordResetTokens.userId, userId));
+	await db.insert(schema.passwordResetTokens).values({
+		id: tokenToId(token),
+		userId,
+		expiresAt: new Date(Date.now() + RESET_TOKEN_DURATION_MS)
+	});
+	return token;
+}
+
+/**
+ * Validate a raw token. Returns the owning user or null. Expired rows and
+ * tokens whose user became ineligible (deactivated, OIDC-only) are deleted on
+ * sight, so a token can never bootstrap a password onto an SSO account.
+ */
+export async function validateResetToken(token: string) {
+	const id = tokenToId(token);
+	const row = await db.query.passwordResetTokens.findFirst({
+		where: eq(schema.passwordResetTokens.id, id)
+	});
+	if (!row) return null;
+
+	if (row.expiresAt.getTime() < Date.now()) {
+		await db.delete(schema.passwordResetTokens).where(eq(schema.passwordResetTokens.id, id));
+		return null;
+	}
+
+	const user = await db.query.users.findFirst({ where: eq(schema.users.id, row.userId) });
+	if (!user || !user.isActive || !user.passwordHash) {
+		await db.delete(schema.passwordResetTokens).where(eq(schema.passwordResetTokens.id, id));
+		return null;
+	}
+
+	return { user };
+}
+
+/** Single-use enforcement: drop every reset token a user holds. */
+export async function consumeUserResetTokens(userId: string): Promise<void> {
+	await db.delete(schema.passwordResetTokens).where(eq(schema.passwordResetTokens.userId, userId));
+}
+
+/** Opportunistic cleanup, piggybacked on forgot-page requests. */
+export async function cleanupExpiredResetTokens(): Promise<void> {
+	await db
+		.delete(schema.passwordResetTokens)
+		.where(lt(schema.passwordResetTokens.expiresAt, new Date()));
+}

--- a/src/lib/server/auth/password-reset.ts
+++ b/src/lib/server/auth/password-reset.ts
@@ -1,5 +1,5 @@
 import { db, schema } from '$lib/server/db';
-import { and, eq, gt, lt } from 'drizzle-orm';
+import { and, eq, gte, lt } from 'drizzle-orm';
 import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from '@oslojs/encoding';
 import { sha256 } from '@oslojs/crypto/sha2';
 
@@ -28,23 +28,35 @@ function tokenToId(token: string): string {
  * Last-request-wins: any previous tokens for the user are deleted.
  */
 export async function createResetToken(userId: string): Promise<string | null> {
-	const recent = await db.query.passwordResetTokens.findFirst({
-		where: and(
-			eq(schema.passwordResetTokens.userId, userId),
-			gt(schema.passwordResetTokens.createdAt, new Date(Date.now() - MIN_REISSUE_INTERVAL_MS))
-		),
-		columns: { id: true }
-	});
-	if (recent) return null;
-
 	const token = generateResetToken();
-	await db.delete(schema.passwordResetTokens).where(eq(schema.passwordResetTokens.userId, userId));
-	await db.insert(schema.passwordResetTokens).values({
-		id: tokenToId(token),
-		userId,
-		expiresAt: new Date(Date.now() + RESET_TOKEN_DURATION_MS)
+	// One synchronous transaction so two near-simultaneous requests cannot both
+	// pass the cooldown check (better-sqlite3 transactions must not await).
+	const issued = db.transaction((tx) => {
+		const recent = tx
+			.select({ id: schema.passwordResetTokens.id })
+			.from(schema.passwordResetTokens)
+			.where(
+				and(
+					eq(schema.passwordResetTokens.userId, userId),
+					gte(schema.passwordResetTokens.createdAt, new Date(Date.now() - MIN_REISSUE_INTERVAL_MS))
+				)
+			)
+			.get();
+		if (recent) return false;
+
+		tx.delete(schema.passwordResetTokens)
+			.where(eq(schema.passwordResetTokens.userId, userId))
+			.run();
+		tx.insert(schema.passwordResetTokens)
+			.values({
+				id: tokenToId(token),
+				userId,
+				expiresAt: new Date(Date.now() + RESET_TOKEN_DURATION_MS)
+			})
+			.run();
+		return true;
 	});
-	return token;
+	return issued ? token : null;
 }
 
 /**
@@ -64,12 +76,14 @@ export async function validateResetToken(token: string) {
 		return null;
 	}
 
-	const user = await db.query.users.findFirst({ where: eq(schema.users.id, row.userId) });
-	if (!user || !user.isActive || !user.passwordHash) {
+	const fullUser = await db.query.users.findFirst({ where: eq(schema.users.id, row.userId) });
+	if (!fullUser || !fullUser.isActive || !fullUser.passwordHash) {
 		await db.delete(schema.passwordResetTokens).where(eq(schema.passwordResetTokens.id, id));
 		return null;
 	}
 
+	// Never hand the hash to callers — same hygiene as validateSessionToken.
+	const { passwordHash: _passwordHash, ...user } = fullUser;
 	return { user };
 }
 

--- a/src/lib/server/auth/password-reset.ts
+++ b/src/lib/server/auth/password-reset.ts
@@ -83,6 +83,7 @@ export async function validateResetToken(token: string) {
 	}
 
 	// Never hand the hash to callers — same hygiene as validateSessionToken.
+	// eslint-disable-next-line no-unused-vars
 	const { passwordHash: _passwordHash, ...user } = fullUser;
 	return { user };
 }

--- a/src/lib/server/auth/password-reset.ts
+++ b/src/lib/server/auth/password-reset.ts
@@ -88,10 +88,9 @@ export async function validateResetToken(token: string) {
 	return { user };
 }
 
-/** Single-use enforcement: drop every reset token a user holds. */
-export async function consumeUserResetTokens(userId: string): Promise<void> {
-	await db.delete(schema.passwordResetTokens).where(eq(schema.passwordResetTokens.userId, userId));
-}
+// Single-use enforcement lives inline in the reset action's transaction
+// (src/routes/auth/reset/+page.server.ts) so the token burn, password update,
+// and session sweep stay atomic.
 
 /** Opportunistic cleanup, piggybacked on forgot-page requests. */
 export async function cleanupExpiredResetTokens(): Promise<void> {

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -90,15 +90,15 @@ export const passwordResetTokens = sqliteTable(
 // makes producers idempotent across overlapping scans and restarts.
 export type OutboxPayload =
 	| { kind: 'reminderDue'; reminderId: string }
-	| { kind: 'shiftStart'; shiftId: string }
-	| { kind: 'shiftEnd'; shiftId: string };
+	| { kind: 'shiftStart'; shiftId: string; boundaryEpoch: number }
+	| { kind: 'shiftEnd'; shiftId: string; boundaryEpoch: number };
 
 export const notificationOutbox = sqliteTable(
 	'notification_outbox',
 	{
 		id: text('id').primaryKey(),
 		// reminder: 'reminder:{reminderId}:{dueAtEpochSeconds}:{userId}:{channel}'
-		// shift:    'shift:{shiftId}:{start|end}:{userId}:{channel}'
+		// shift:    'shift:{shiftId}:{start|end}:{boundaryEpochSeconds}:{userId}:{channel}'
 		// One row per occurrence per recipient per channel.
 		dedupeKey: text('dedupe_key').notNull(),
 		userId: text('user_id')

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -39,7 +39,11 @@ export const users = sqliteTable(
 		reminderUndoSeconds: integer('reminder_undo_seconds'),
 		defaultRecurrenceUnit: text('default_recurrence_unit', {
 			enum: ['day', 'week', 'month', 'year']
-		})
+		}),
+		notifyReminderEmail: integer('notify_reminder_email', { mode: 'boolean' })
+			.notNull()
+			.default(false),
+		notifyShiftEmail: integer('notify_shift_email', { mode: 'boolean' }).notNull().default(false)
 	},
 	(t) => [
 		uniqueIndex('users_oidc_idx').on(t.oidcIssuer, t.oidcSubject),
@@ -78,6 +82,45 @@ export const passwordResetTokens = sqliteTable(
 			.default(sql`(unixepoch())`)
 	},
 	(t) => [index('password_reset_user_idx').on(t.userId)]
+);
+
+// Notification outbox (issue #12). Detection (the scheduler's producers) and
+// delivery (the drain) are decoupled through this table so a crash, restart,
+// or SMTP outage never silently drops a notification. The unique dedupe key
+// makes producers idempotent across overlapping scans and restarts.
+export type OutboxPayload =
+	| { kind: 'reminderDue'; reminderId: string }
+	| { kind: 'shiftStart'; shiftId: string }
+	| { kind: 'shiftEnd'; shiftId: string };
+
+export const notificationOutbox = sqliteTable(
+	'notification_outbox',
+	{
+		id: text('id').primaryKey(),
+		// reminder: 'reminder:{reminderId}:{dueAtEpochSeconds}:{userId}:{channel}'
+		// shift:    'shift:{shiftId}:{start|end}:{userId}:{channel}'
+		// One row per occurrence per recipient per channel.
+		dedupeKey: text('dedupe_key').notNull(),
+		userId: text('user_id')
+			.notNull()
+			.references(() => users.id, { onDelete: 'cascade' }),
+		channel: text('channel', { enum: ['email', 'ntfy', 'apprise'] }).notNull(),
+		// Rendering happens at send time in the recipient's locale; the payload
+		// carries ids only.
+		payload: text('payload', { mode: 'json' }).$type<OutboxPayload>().notNull(),
+		// queued -> claimed -> sent | skipped | failed; claimed rows orphaned by a
+		// crash are reset to queued at boot. skipped = conditions no longer hold
+		// (reminder completed, user opted out, shift already started) — not an error.
+		status: text('status', { enum: ['queued', 'claimed', 'sent', 'skipped', 'failed'] })
+			.notNull()
+			.default('queued'),
+		attempts: integer('attempts').notNull().default(0),
+		createdAt: integer('created_at', { mode: 'timestamp' })
+			.notNull()
+			.default(sql`(unixepoch())`),
+		sentAt: integer('sent_at', { mode: 'timestamp' })
+	},
+	(t) => [uniqueIndex('outbox_dedupe_idx').on(t.dedupeKey), index('outbox_status_idx').on(t.status)]
 );
 
 // companions
@@ -351,6 +394,7 @@ export const caretakerShifts = sqliteTable(
 export type User = typeof users.$inferSelect;
 export type Session = typeof sessions.$inferSelect;
 export type PasswordResetToken = typeof passwordResetTokens.$inferSelect;
+export type NotificationOutboxRow = typeof notificationOutbox.$inferSelect;
 export type Companion = typeof companions.$inferSelect;
 export type JournalEntry = typeof journalEntries.$inferSelect;
 export type JournalPhoto = typeof journalPhotos.$inferSelect;
@@ -371,9 +415,14 @@ export const passwordResetTokensRelations = relations(passwordResetTokens, ({ on
 	user: one(users, { fields: [passwordResetTokens.userId], references: [users.id] })
 }));
 
+export const notificationOutboxRelations = relations(notificationOutbox, ({ one }) => ({
+	user: one(users, { fields: [notificationOutbox.userId], references: [users.id] })
+}));
+
 export const usersRelations = relations(users, ({ many }) => ({
 	sessions: many(sessions),
 	passwordResetTokens: many(passwordResetTokens),
+	notificationOutbox: many(notificationOutbox),
 	companionCaretakers: many(companionCaretakers),
 	shifts: many(caretakerShifts),
 	loggedJournalEntries: many(journalEntries),

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -89,7 +89,7 @@ export const passwordResetTokens = sqliteTable(
 // or SMTP outage never silently drops a notification. The unique dedupe key
 // makes producers idempotent across overlapping scans and restarts.
 export type OutboxPayload =
-	| { kind: 'reminderDue'; reminderId: string }
+	| { kind: 'reminderDue'; reminderId: string; dueAtEpoch: number }
 	| { kind: 'shiftStart'; shiftId: string; boundaryEpoch: number }
 	| { kind: 'shiftEnd'; shiftId: string; boundaryEpoch: number };
 

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -43,7 +43,12 @@ export const users = sqliteTable(
 		notifyReminderEmail: integer('notify_reminder_email', { mode: 'boolean' })
 			.notNull()
 			.default(false),
-		notifyShiftEmail: integer('notify_shift_email', { mode: 'boolean' }).notNull().default(false)
+		notifyShiftEmail: integer('notify_shift_email', { mode: 'boolean' }).notNull().default(false),
+		// ntfy topic name on the site-configured server (env NTFY_URL). A
+		// non-empty topic is the opt-in for push notifications; the user
+		// receives both categories (reminders, shift alerts) within their
+		// role's visibility scope. Null = no pushes.
+		ntfyTopic: text('ntfy_topic')
 	},
 	(t) => [
 		uniqueIndex('users_oidc_idx').on(t.oidcIssuer, t.oidcSubject),

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -63,6 +63,23 @@ export const sessions = sqliteTable(
 	(t) => [index('session_user_idx').on(t.userId)]
 );
 
+export const passwordResetTokens = sqliteTable(
+	'password_reset_tokens',
+	{
+		// sha256 hex of the raw token — same storage pattern as sessions.id, so a
+		// DB leak never exposes a usable token.
+		id: text('id').primaryKey(),
+		userId: text('user_id')
+			.notNull()
+			.references(() => users.id, { onDelete: 'cascade' }),
+		expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+		createdAt: integer('created_at', { mode: 'timestamp' })
+			.notNull()
+			.default(sql`(unixepoch())`)
+	},
+	(t) => [index('password_reset_user_idx').on(t.userId)]
+);
+
 // companions
 
 export const companions = sqliteTable(
@@ -333,6 +350,7 @@ export const caretakerShifts = sqliteTable(
 
 export type User = typeof users.$inferSelect;
 export type Session = typeof sessions.$inferSelect;
+export type PasswordResetToken = typeof passwordResetTokens.$inferSelect;
 export type Companion = typeof companions.$inferSelect;
 export type JournalEntry = typeof journalEntries.$inferSelect;
 export type JournalPhoto = typeof journalPhotos.$inferSelect;
@@ -349,8 +367,13 @@ export const sessionsRelations = relations(sessions, ({ one }) => ({
 	user: one(users, { fields: [sessions.userId], references: [users.id] })
 }));
 
+export const passwordResetTokensRelations = relations(passwordResetTokens, ({ one }) => ({
+	user: one(users, { fields: [passwordResetTokens.userId], references: [users.id] })
+}));
+
 export const usersRelations = relations(users, ({ many }) => ({
 	sessions: many(sessions),
+	passwordResetTokens: many(passwordResetTokens),
 	companionCaretakers: many(companionCaretakers),
 	shifts: many(caretakerShifts),
 	loggedJournalEntries: many(journalEntries),

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -41,7 +41,10 @@ export const users = sqliteTable(
 			enum: ['day', 'week', 'month', 'year']
 		})
 	},
-	(t) => [uniqueIndex('users_oidc_idx').on(t.oidcIssuer, t.oidcSubject)]
+	(t) => [
+		uniqueIndex('users_oidc_idx').on(t.oidcIssuer, t.oidcSubject),
+		uniqueIndex('users_email_idx').on(t.email)
+	]
 );
 
 export const sessions = sqliteTable(

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -250,6 +250,62 @@ export function logImmichBootStatus(): void {
 	}
 }
 
+// Optional SMTP email (issue #12). Off unless SMTP_HOST and SMTP_FROM are both
+// set (same gating convention as OIDC and Immich). Used for the forgot-password
+// flow; future PRs add reminder notifications on top of the same transport.
+export interface SmtpConfig {
+	host: string;
+	port: number;
+	// true = implicit TLS (typically port 465); false = STARTTLS upgrade (587).
+	secure: boolean;
+	// Auth is optional: unauthenticated LAN relays are common in homelab setups.
+	user: string | null;
+	pass: string | null;
+	// RFC 5322 From, e.g. 'EinVault <einvault@example.com>'.
+	from: string;
+}
+
+const SMTP_REQUIRED_VARS = ['SMTP_HOST', 'SMTP_FROM'] as const;
+
+function readSmtpConfig(): { config: SmtpConfig | null; missing: string[] } {
+	const missing = SMTP_REQUIRED_VARS.filter((name) => !env[name]?.trim());
+	if (missing.length === SMTP_REQUIRED_VARS.length) return { config: null, missing };
+	if (missing.length > 0) return { config: null, missing };
+	return {
+		config: {
+			host: env.SMTP_HOST!.trim(),
+			port: envInt(env.SMTP_PORT, 587),
+			secure: envBool(env.SMTP_SECURE, false),
+			user: env.SMTP_USER?.trim() || null,
+			pass: env.SMTP_PASS || null,
+			from: env.SMTP_FROM!.trim()
+		},
+		missing: []
+	};
+}
+
+const smtpResult = readSmtpConfig();
+export const SMTP_CONFIG = smtpResult.config;
+
+export function logSmtpBootStatus(): void {
+	if (smtpResult.missing.length > 0 && smtpResult.missing.length < SMTP_REQUIRED_VARS.length) {
+		console.warn(
+			`[mail] Partial SMTP config detected (missing: ${smtpResult.missing.join(', ')}). Email disabled. Set both SMTP_HOST and SMTP_FROM to enable.`
+		);
+		return;
+	}
+	if (SMTP_CONFIG) {
+		console.info(
+			`[mail] SMTP enabled host=${SMTP_CONFIG.host} port=${SMTP_CONFIG.port} secure=${SMTP_CONFIG.secure} auth=${SMTP_CONFIG.user ? 'yes' : 'no'}`
+		);
+		if (!env.ORIGIN) {
+			console.warn(
+				'[mail] ORIGIN is not set; password reset links may carry the wrong origin behind a reverse proxy.'
+			);
+		}
+	}
+}
+
 // 0 = no undo window (instant commit). >0 = seconds before dismissal commits.
 export const REMINDER_UNDO_SECONDS_DEFAULT = Math.min(
 	envNonNegativeInt(env.REMINDER_UNDO_SECONDS, 7),

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -313,6 +313,54 @@ export function logSmtpBootStatus(): void {
 	}
 }
 
+// Optional ntfy push channel (issue #12). Off unless NTFY_URL is set. The
+// env configures the SERVER only (base URL + optional access token); each
+// user sets their own topic name in Settings -> Notifications. A non-empty
+// topic is that user's opt-in. Per-user topics (instead of one site topic)
+// preserve the caretaker visibility model: a shared topic would broadcast
+// every companion's reminders and every caretaker's schedule to anyone
+// subscribed.
+export interface NtfyConfig {
+	// Server base, e.g. 'https://ntfy.sh' or a self-hosted instance.
+	baseUrl: string;
+	// Optional bearer token (self-hosted ntfy with auth).
+	token: string | null;
+}
+
+function readNtfyConfig(): { config: NtfyConfig | null; invalid: boolean } {
+	const raw = env.NTFY_URL?.trim();
+	if (!raw) return { config: null, invalid: false };
+	try {
+		const url = new URL(raw);
+		return {
+			config: {
+				baseUrl: `${url.origin}${url.pathname.replace(/\/$/, '')}`,
+				token: env.NTFY_TOKEN?.trim() || null
+			},
+			invalid: false
+		};
+	} catch {
+		return { config: null, invalid: true };
+	}
+}
+
+const ntfyResult = readNtfyConfig();
+export const NTFY_CONFIG = ntfyResult.config;
+
+export function logNtfyBootStatus(): void {
+	if (ntfyResult.invalid) {
+		console.warn(
+			`[ntfy] NTFY_URL='${env.NTFY_URL}' is not a valid URL (expected e.g. https://ntfy.sh). ntfy disabled.`
+		);
+		return;
+	}
+	if (NTFY_CONFIG) {
+		console.info(
+			`[ntfy] enabled server=${NTFY_CONFIG.baseUrl} auth=${NTFY_CONFIG.token ? 'yes' : 'no'} (users opt in by setting a topic in Settings)`
+		);
+	}
+}
+
 // 0 = no undo window (instant commit). >0 = seconds before dismissal commits.
 export const REMINDER_UNDO_SECONDS_DEFAULT = Math.min(
 	envNonNegativeInt(env.REMINDER_UNDO_SECONDS, 7),

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -305,6 +305,11 @@ export function logSmtpBootStatus(): void {
 				'[mail] ORIGIN is not set; password reset links may carry the wrong origin behind a reverse proxy.'
 			);
 		}
+		if (SMTP_CONFIG.user && !SMTP_CONFIG.pass) {
+			console.warn(
+				'[mail] SMTP_USER is set but SMTP_PASS is empty; auth will use a blank password.'
+			);
+		}
 	}
 }
 

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -277,6 +277,8 @@ function readSmtpConfig(): { config: SmtpConfig | null; missing: string[] } {
 			port: envInt(env.SMTP_PORT, 587),
 			secure: envBool(env.SMTP_SECURE, false),
 			user: env.SMTP_USER?.trim() || null,
+			// Deliberately not trimmed: passwords may legitimately contain
+			// leading/trailing whitespace.
 			pass: env.SMTP_PASS || null,
 			from: env.SMTP_FROM!.trim()
 		},

--- a/src/lib/server/mail/index.ts
+++ b/src/lib/server/mail/index.ts
@@ -33,5 +33,6 @@ export interface MailMessage {
 
 export async function sendMail(message: MailMessage): Promise<void> {
 	if (!SMTP_CONFIG) throw new Error('SMTP is not configured');
-	await getTransporter().sendMail({ from: SMTP_CONFIG.from, ...message });
+	// from last: the configured sender is never caller-overridable.
+	await getTransporter().sendMail({ ...message, from: SMTP_CONFIG.from });
 }

--- a/src/lib/server/mail/index.ts
+++ b/src/lib/server/mail/index.ts
@@ -1,0 +1,37 @@
+import nodemailer from 'nodemailer';
+import type { Transporter } from 'nodemailer';
+import { SMTP_CONFIG } from '$lib/server/env';
+
+// Lazy singleton: the transporter holds a connection pool config but opens
+// sockets only when a message is sent, so creating it at first use is cheap
+// and keeps boot independent of SMTP reachability.
+let transporter: Transporter | null = null;
+
+export function isMailEnabled(): boolean {
+	return SMTP_CONFIG !== null;
+}
+
+function getTransporter(): Transporter {
+	if (!SMTP_CONFIG) throw new Error('SMTP is not configured');
+	if (!transporter) {
+		transporter = nodemailer.createTransport({
+			host: SMTP_CONFIG.host,
+			port: SMTP_CONFIG.port,
+			secure: SMTP_CONFIG.secure,
+			auth: SMTP_CONFIG.user ? { user: SMTP_CONFIG.user, pass: SMTP_CONFIG.pass ?? '' } : undefined
+		});
+	}
+	return transporter;
+}
+
+export interface MailMessage {
+	to: string;
+	subject: string;
+	text: string;
+	html?: string;
+}
+
+export async function sendMail(message: MailMessage): Promise<void> {
+	if (!SMTP_CONFIG) throw new Error('SMTP is not configured');
+	await getTransporter().sendMail({ from: SMTP_CONFIG.from, ...message });
+}

--- a/src/lib/server/mail/templates.ts
+++ b/src/lib/server/mail/templates.ts
@@ -22,7 +22,7 @@ function tHtml(locale: Locale, key: Parameters<typeof t>[1], param?: [string, st
 	// Escape the catalog text with the placeholder still in it, then replace the
 	// placeholder with the escaped value. escapeHtml never produces '{' or '}',
 	// so the placeholder survives escaping intact.
-	return escapeHtml(t(locale, key)).replaceAll(`{${name}}`, escapeHtml(value));
+	return escapeHtml(t(locale, key)).replaceAll(`{${name}}`, () => escapeHtml(value));
 }
 
 export function buildResetEmail(

--- a/src/lib/server/mail/templates.ts
+++ b/src/lib/server/mail/templates.ts
@@ -67,7 +67,7 @@ export function buildResetEmail(
 
 // Server TZ (the container's TZ env var) — consistent with how the app
 // renders times elsewhere.
-function formatWhen(locale: Locale, when: Date): string {
+export function formatWhen(locale: Locale, when: Date): string {
 	return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' }).format(when);
 }
 

--- a/src/lib/server/mail/templates.ts
+++ b/src/lib/server/mail/templates.ts
@@ -1,0 +1,59 @@
+import { t, type Locale } from '$lib/i18n';
+import type { MailMessage } from '$lib/server/mail';
+
+// displayName/username are user-controlled; escape anything interpolated into
+// the HTML body so a crafted name cannot inject markup into the email.
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;');
+}
+
+/**
+ * Interpolate one {param} into a message AFTER escaping both the message and
+ * the value, so localized text and user-controlled values are both HTML-safe.
+ */
+function tHtml(locale: Locale, key: Parameters<typeof t>[1], param?: [string, string]): string {
+	if (!param) return escapeHtml(t(locale, key));
+	const [name, value] = param;
+	// Escape the catalog text with the placeholder still in it, then replace the
+	// placeholder with the escaped value. escapeHtml never produces '{' or '}',
+	// so the placeholder survives escaping intact.
+	return escapeHtml(t(locale, key)).replaceAll(`{${name}}`, escapeHtml(value));
+}
+
+export function buildResetEmail(
+	locale: Locale,
+	user: { displayName: string; username: string; email: string },
+	link: string
+): MailMessage {
+	const greeting = t(locale, 'email.reset.greeting', { name: user.displayName });
+	const body = t(locale, 'email.reset.body', { username: user.username });
+	const cta = t(locale, 'email.reset.cta');
+	const ignore = t(locale, 'email.reset.ignore');
+
+	const text = `${greeting}\n\n${body}\n\n${link}\n\n${ignore}`;
+
+	const html = `<!doctype html>
+<html>
+	<body style="font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px; color: #222;">
+		<p>${tHtml(locale, 'email.reset.greeting', ['name', user.displayName])}</p>
+		<p>${tHtml(locale, 'email.reset.body', ['username', user.username])}</p>
+		<p style="margin: 24px 0;">
+			<a href="${escapeHtml(link)}" style="display: inline-block; background: #4f46e5; color: #ffffff; padding: 10px 18px; border-radius: 6px; text-decoration: none;">${escapeHtml(cta)}</a>
+		</p>
+		<p style="font-size: 12px; color: #666; word-break: break-all;">${escapeHtml(link)}</p>
+		<p style="font-size: 12px; color: #666;">${escapeHtml(ignore)}</p>
+	</body>
+</html>`;
+
+	return {
+		to: user.email,
+		subject: t(locale, 'email.reset.subject'),
+		text,
+		html
+	};
+}

--- a/src/lib/server/mail/templates.ts
+++ b/src/lib/server/mail/templates.ts
@@ -118,6 +118,29 @@ export function buildReminderEmail(
 	};
 }
 
+export function buildTestEmail(
+	locale: Locale,
+	user: { displayName: string; email: string }
+): MailMessage {
+	const greeting = t(locale, 'email.reminder.greeting', { name: user.displayName });
+	const body = t(locale, 'email.test.body');
+
+	const html = `<!doctype html>
+<html>
+	<body style="font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px; color: #222;">
+		<p>${tHtml(locale, 'email.reminder.greeting', { name: user.displayName })}</p>
+		<p>${escapeHtml(body)}</p>
+	</body>
+</html>`;
+
+	return {
+		to: user.email,
+		subject: t(locale, 'email.test.subject'),
+		text: `${greeting}\n\n${body}`,
+		html
+	};
+}
+
 export function buildShiftEmail(
 	locale: Locale,
 	user: { displayName: string; email: string },

--- a/src/lib/server/mail/templates.ts
+++ b/src/lib/server/mail/templates.ts
@@ -13,16 +13,23 @@ function escapeHtml(value: string): string {
 }
 
 /**
- * Interpolate one {param} into a message AFTER escaping both the message and
- * the value, so localized text and user-controlled values are both HTML-safe.
+ * Escape the catalog text with placeholders still in it, then replace each
+ * placeholder with its escaped value. escapeHtml never produces '{' or '}',
+ * so placeholders survive escaping intact; the replacement callback keeps
+ * '$'-patterns in values literal.
  */
-function tHtml(locale: Locale, key: Parameters<typeof t>[1], param?: [string, string]): string {
-	if (!param) return escapeHtml(t(locale, key));
-	const [name, value] = param;
-	// Escape the catalog text with the placeholder still in it, then replace the
-	// placeholder with the escaped value. escapeHtml never produces '{' or '}',
-	// so the placeholder survives escaping intact.
-	return escapeHtml(t(locale, key)).replaceAll(`{${name}}`, () => escapeHtml(value));
+function tHtml(
+	locale: Locale,
+	key: Parameters<typeof t>[1],
+	params?: Record<string, string>
+): string {
+	let out = escapeHtml(t(locale, key));
+	if (params) {
+		for (const [name, value] of Object.entries(params)) {
+			out = out.replaceAll(`{${name}}`, () => escapeHtml(value));
+		}
+	}
+	return out;
 }
 
 export function buildResetEmail(
@@ -40,8 +47,8 @@ export function buildResetEmail(
 	const html = `<!doctype html>
 <html>
 	<body style="font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px; color: #222;">
-		<p>${tHtml(locale, 'email.reset.greeting', ['name', user.displayName])}</p>
-		<p>${tHtml(locale, 'email.reset.body', ['username', user.username])}</p>
+		<p>${tHtml(locale, 'email.reset.greeting', { name: user.displayName })}</p>
+		<p>${tHtml(locale, 'email.reset.body', { username: user.username })}</p>
 		<p style="margin: 24px 0;">
 			<a href="${escapeHtml(link)}" style="display: inline-block; background: #4f46e5; color: #ffffff; padding: 10px 18px; border-radius: 6px; text-decoration: none;">${escapeHtml(cta)}</a>
 		</p>
@@ -54,6 +61,104 @@ export function buildResetEmail(
 		to: user.email,
 		subject: t(locale, 'email.reset.subject'),
 		text,
+		html
+	};
+}
+
+// Server TZ (the container's TZ env var) — consistent with how the app
+// renders times elsewhere.
+function formatWhen(locale: Locale, when: Date): string {
+	return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' }).format(when);
+}
+
+export function buildReminderEmail(
+	locale: Locale,
+	user: { displayName: string; email: string },
+	reminder: { title: string; description: string | null; dueAt: Date },
+	companionName: string,
+	link: string | null
+): MailMessage {
+	const greeting = t(locale, 'email.reminder.greeting', { name: user.displayName });
+	const body = t(locale, 'email.reminder.body', {
+		companion: companionName,
+		title: reminder.title
+	});
+	const dueLine = t(locale, 'email.reminder.dueLine', { due: formatWhen(locale, reminder.dueAt) });
+	const cta = t(locale, 'email.reminder.cta');
+	const footer = t(locale, 'email.reminder.footer');
+
+	const textParts = [greeting, body];
+	if (reminder.description) textParts.push(reminder.description);
+	textParts.push(dueLine);
+	if (link) textParts.push(link);
+	textParts.push(footer);
+
+	const descriptionHtml = reminder.description
+		? `\n\t\t<p>${escapeHtml(reminder.description)}</p>`
+		: '';
+	const ctaHtml = link
+		? `\n\t\t<p style="margin: 24px 0;">\n\t\t\t<a href="${escapeHtml(link)}" style="display: inline-block; background: #4f46e5; color: #ffffff; padding: 10px 18px; border-radius: 6px; text-decoration: none;">${escapeHtml(cta)}</a>\n\t\t</p>`
+		: '';
+
+	const html = `<!doctype html>
+<html>
+	<body style="font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px; color: #222;">
+		<p>${tHtml(locale, 'email.reminder.greeting', { name: user.displayName })}</p>
+		<p>${tHtml(locale, 'email.reminder.body', { companion: companionName, title: reminder.title })}</p>${descriptionHtml}
+		<p><strong>${escapeHtml(dueLine)}</strong></p>${ctaHtml}
+		<p style="font-size: 12px; color: #666;">${escapeHtml(footer)}</p>
+	</body>
+</html>`;
+
+	return {
+		to: user.email,
+		subject: t(locale, 'email.reminder.subject', { title: reminder.title }),
+		text: textParts.join('\n\n'),
+		html
+	};
+}
+
+export function buildShiftEmail(
+	locale: Locale,
+	user: { displayName: string; email: string },
+	kind: 'shiftStart' | 'shiftEnd',
+	caretakerName: string,
+	shift: { startAt: Date; endAt: Date },
+	link: string | null
+): MailMessage {
+	const subjectKey = kind === 'shiftStart' ? 'email.shift.startSubject' : 'email.shift.endSubject';
+	const bodyKey = kind === 'shiftStart' ? 'email.shift.startBody' : 'email.shift.endBody';
+	const bodyParams: Record<string, string> =
+		kind === 'shiftStart'
+			? { caretaker: caretakerName, start: formatWhen(locale, shift.startAt) }
+			: { caretaker: caretakerName, end: formatWhen(locale, shift.endAt) };
+
+	const greeting = t(locale, 'email.reminder.greeting', { name: user.displayName });
+	const body = t(locale, bodyKey, bodyParams);
+	const cta = t(locale, 'email.reminder.cta');
+	const footer = t(locale, 'email.shift.footer');
+
+	const textParts = [greeting, body];
+	if (link) textParts.push(link);
+	textParts.push(footer);
+
+	const ctaHtml = link
+		? `\n\t\t<p style="margin: 24px 0;">\n\t\t\t<a href="${escapeHtml(link)}" style="display: inline-block; background: #4f46e5; color: #ffffff; padding: 10px 18px; border-radius: 6px; text-decoration: none;">${escapeHtml(cta)}</a>\n\t\t</p>`
+		: '';
+
+	const html = `<!doctype html>
+<html>
+	<body style="font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px; color: #222;">
+		<p>${tHtml(locale, 'email.reminder.greeting', { name: user.displayName })}</p>
+		<p>${tHtml(locale, bodyKey, bodyParams)}</p>${ctaHtml}
+		<p style="font-size: 12px; color: #666;">${escapeHtml(footer)}</p>
+	</body>
+</html>`;
+
+	return {
+		to: user.email,
+		subject: t(locale, subjectKey, { caretaker: caretakerName }),
+		text: textParts.join('\n\n'),
 		html
 	};
 }

--- a/src/lib/server/notify/ntfy.ts
+++ b/src/lib/server/notify/ntfy.ts
@@ -34,9 +34,16 @@ export async function sendNtfy(topic: string, msg: NtfyMessage): Promise<void> {
 			title: msg.title,
 			message: msg.message,
 			...(msg.click ? { click: msg.click } : {})
-		})
+		}),
+		// A hung publish must fail (and retry on the next scan) rather than
+		// wedge the single-flight drain loop forever.
+		signal: AbortSignal.timeout(15_000)
 	});
 	if (!res.ok) {
-		throw new Error(`ntfy publish failed: ${res.status} ${res.statusText}`);
+		const detail = await res.text().catch(() => '');
+		throw new Error(
+			`ntfy publish failed: ${res.status} ${res.statusText}${detail ? ` - ${detail.slice(0, 200)}` : ''}`
+		);
 	}
+	await res.body?.cancel();
 }

--- a/src/lib/server/notify/ntfy.ts
+++ b/src/lib/server/notify/ntfy.ts
@@ -1,0 +1,42 @@
+import { NTFY_CONFIG } from '$lib/server/env';
+
+// ntfy publisher (issue #12). Uses the JSON publish endpoint (POST to the
+// server base with the topic in the body) instead of topic-URL PUT with
+// Title headers: JSON bodies carry UTF-8 titles (umlauts, accents) safely,
+// raw HTTP headers do not.
+
+export function isNtfyEnabled(): boolean {
+	return NTFY_CONFIG !== null;
+}
+
+// ntfy topic rules: letters, digits, underscore, dash. Enforced both at
+// settings-save time and (defensively) before publish.
+export const NTFY_TOPIC_RE = /^[a-zA-Z0-9_-]{1,64}$/;
+
+export interface NtfyMessage {
+	title: string;
+	message: string;
+	// Optional click-through URL (ntfy 'click' action).
+	click?: string | null;
+}
+
+export async function sendNtfy(topic: string, msg: NtfyMessage): Promise<void> {
+	if (!NTFY_CONFIG) throw new Error('ntfy is not configured');
+	if (!NTFY_TOPIC_RE.test(topic)) throw new Error(`invalid ntfy topic '${topic}'`);
+	const res = await fetch(NTFY_CONFIG.baseUrl, {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			...(NTFY_CONFIG.token ? { authorization: `Bearer ${NTFY_CONFIG.token}` } : {})
+		},
+		body: JSON.stringify({
+			topic,
+			title: msg.title,
+			message: msg.message,
+			...(msg.click ? { click: msg.click } : {})
+		})
+	});
+	if (!res.ok) {
+		throw new Error(`ntfy publish failed: ${res.status} ${res.statusText}`);
+	}
+}

--- a/src/lib/server/notify/outbox.ts
+++ b/src/lib/server/notify/outbox.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, inArray, lt, notInArray, sql } from 'drizzle-orm';
 import { db, schema } from '$lib/server/db';
 import { generateId } from '$lib/server/utils';
-import type { OutboxPayload } from '$lib/server/db/schema';
+import type { OutboxPayload, NotificationOutboxRow } from '$lib/server/db/schema';
 
 // Give up on a row after this many claims. The counter increments on each
 // atomic claim, so a row that keeps failing (SMTP rejects, render crash)
@@ -54,7 +54,7 @@ export async function enqueue(rows: EnqueueRow[]): Promise<number> {
 	return inserted.length;
 }
 
-export type ClaimedNotification = typeof schema.notificationOutbox.$inferSelect;
+export type ClaimedNotification = NotificationOutboxRow;
 
 /**
  * Atomically claim the oldest queued row: select a candidate, then transition

--- a/src/lib/server/notify/outbox.ts
+++ b/src/lib/server/notify/outbox.ts
@@ -1,0 +1,141 @@
+import { and, asc, eq, inArray, lt, sql } from 'drizzle-orm';
+import { db, schema } from '$lib/server/db';
+import { generateId } from '$lib/server/utils';
+import type { OutboxPayload } from '$lib/server/db/schema';
+
+// Give up on a row after this many claims. The counter increments on each
+// atomic claim, so a row that keeps failing (SMTP rejects, render crash)
+// becomes terminal 'failed' instead of retrying forever. Same shape as the
+// video worker's cap.
+export const MAX_ATTEMPTS = 3;
+
+// Sent/skipped/failed rows are kept this long for operator inspection.
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type OutboxChannel = 'email' | 'ntfy' | 'apprise';
+
+export function reminderDedupeKey(
+	reminderId: string,
+	dueAt: Date,
+	userId: string,
+	channel: OutboxChannel
+): string {
+	return `reminder:${reminderId}:${Math.floor(dueAt.getTime() / 1000)}:${userId}:${channel}`;
+}
+
+export function shiftDedupeKey(
+	shiftId: string,
+	kind: 'shiftStart' | 'shiftEnd',
+	userId: string,
+	channel: OutboxChannel
+): string {
+	return `shift:${shiftId}:${kind === 'shiftStart' ? 'start' : 'end'}:${userId}:${channel}`;
+}
+
+export interface EnqueueRow {
+	dedupeKey: string;
+	userId: string;
+	channel: OutboxChannel;
+	payload: OutboxPayload;
+}
+
+/**
+ * Idempotent enqueue: the unique dedupe index swallows rows already produced
+ * by an earlier scan or a pre-restart process. Returns how many were new.
+ */
+export async function enqueue(rows: EnqueueRow[]): Promise<number> {
+	if (rows.length === 0) return 0;
+	const inserted = await db
+		.insert(schema.notificationOutbox)
+		.values(rows.map((r) => ({ id: generateId(15), ...r })))
+		.onConflictDoNothing({ target: schema.notificationOutbox.dedupeKey })
+		.returning({ id: schema.notificationOutbox.id });
+	return inserted.length;
+}
+
+export type ClaimedNotification = typeof schema.notificationOutbox.$inferSelect;
+
+/**
+ * Atomically claim the oldest queued row: select a candidate, then transition
+ * it queued -> claimed guarded on its still being queued (incrementing the
+ * attempt counter). Loops past candidates lost to a race; returns null only
+ * when the queue is empty. Mirrors the video worker's claimNext.
+ */
+export async function claimNext(): Promise<ClaimedNotification | null> {
+	for (;;) {
+		const [candidate] = await db
+			.select({ id: schema.notificationOutbox.id })
+			.from(schema.notificationOutbox)
+			.where(eq(schema.notificationOutbox.status, 'queued'))
+			.orderBy(asc(schema.notificationOutbox.createdAt))
+			.limit(1);
+		if (!candidate) return null;
+
+		const [claimed] = await db
+			.update(schema.notificationOutbox)
+			.set({ status: 'claimed', attempts: sql`${schema.notificationOutbox.attempts} + 1` })
+			.where(
+				and(
+					eq(schema.notificationOutbox.id, candidate.id),
+					eq(schema.notificationOutbox.status, 'queued')
+				)
+			)
+			.returning();
+		if (claimed) return claimed;
+	}
+}
+
+export async function markSent(id: string): Promise<void> {
+	await db
+		.update(schema.notificationOutbox)
+		.set({ status: 'sent', sentAt: new Date() })
+		.where(eq(schema.notificationOutbox.id, id));
+}
+
+/** Conditions no longer hold (reminder completed, user opted out) — not an error. */
+export async function markSkipped(id: string): Promise<void> {
+	await db
+		.update(schema.notificationOutbox)
+		.set({ status: 'skipped' })
+		.where(eq(schema.notificationOutbox.id, id));
+}
+
+/**
+ * Remove the row entirely so the dedupe key frees up and a producer can
+ * re-create it later. Used when a shift is rescheduled beyond the lead window
+ * before its alert went out — the alert should fire again when the new time
+ * approaches, which a terminal 'skipped' row would block.
+ */
+export async function deleteRow(id: string): Promise<void> {
+	await db.delete(schema.notificationOutbox).where(eq(schema.notificationOutbox.id, id));
+}
+
+/** Retry if attempts remain, else terminal failure. */
+export async function markFailedOrRequeue(row: ClaimedNotification): Promise<void> {
+	await db
+		.update(schema.notificationOutbox)
+		.set({ status: row.attempts >= MAX_ATTEMPTS ? 'failed' : 'queued' })
+		.where(eq(schema.notificationOutbox.id, row.id));
+}
+
+/** Boot recovery: rows orphaned mid-send by a crash go back in the queue. */
+export async function recoverOrphanedClaims(): Promise<number> {
+	const reset = await db
+		.update(schema.notificationOutbox)
+		.set({ status: 'queued' })
+		.where(eq(schema.notificationOutbox.status, 'claimed'))
+		.returning({ id: schema.notificationOutbox.id });
+	return reset.length;
+}
+
+/** Drop terminal rows older than the retention window. */
+export async function cleanupOldRows(): Promise<void> {
+	await db
+		.delete(schema.notificationOutbox)
+		.where(
+			and(
+				inArray(schema.notificationOutbox.status, ['sent', 'skipped', 'failed']),
+				lt(schema.notificationOutbox.createdAt, new Date(Date.now() - RETENTION_MS))
+			)
+		);
+}

--- a/src/lib/server/notify/outbox.ts
+++ b/src/lib/server/notify/outbox.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, lt, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, lt, notInArray, sql } from 'drizzle-orm';
 import { db, schema } from '$lib/server/db';
 import { generateId } from '$lib/server/utils';
 import type { OutboxPayload } from '$lib/server/db/schema';
@@ -26,10 +26,11 @@ export function reminderDedupeKey(
 export function shiftDedupeKey(
 	shiftId: string,
 	kind: 'shiftStart' | 'shiftEnd',
+	boundary: Date,
 	userId: string,
 	channel: OutboxChannel
 ): string {
-	return `shift:${shiftId}:${kind === 'shiftStart' ? 'start' : 'end'}:${userId}:${channel}`;
+	return `shift:${shiftId}:${kind === 'shiftStart' ? 'start' : 'end'}:${Math.floor(boundary.getTime() / 1000)}:${userId}:${channel}`;
 }
 
 export interface EnqueueRow {
@@ -60,13 +61,24 @@ export type ClaimedNotification = typeof schema.notificationOutbox.$inferSelect;
  * it queued -> claimed guarded on its still being queued (incrementing the
  * attempt counter). Loops past candidates lost to a race; returns null only
  * when the queue is empty. Mirrors the video worker's claimNext.
+ *
+ * Pass excludeIds to skip rows that already failed this pass — retries get one
+ * attempt per scan, so the 60s tick acts as retry backoff.
  */
-export async function claimNext(): Promise<ClaimedNotification | null> {
+export async function claimNext(
+	excludeIds?: ReadonlySet<string>
+): Promise<ClaimedNotification | null> {
 	for (;;) {
+		const where = excludeIds?.size
+			? and(
+					eq(schema.notificationOutbox.status, 'queued'),
+					notInArray(schema.notificationOutbox.id, [...excludeIds])
+				)
+			: eq(schema.notificationOutbox.status, 'queued');
 		const [candidate] = await db
 			.select({ id: schema.notificationOutbox.id })
 			.from(schema.notificationOutbox)
-			.where(eq(schema.notificationOutbox.status, 'queued'))
+			.where(where)
 			.orderBy(asc(schema.notificationOutbox.createdAt))
 			.limit(1);
 		if (!candidate) return null;
@@ -98,16 +110,6 @@ export async function markSkipped(id: string): Promise<void> {
 		.update(schema.notificationOutbox)
 		.set({ status: 'skipped' })
 		.where(eq(schema.notificationOutbox.id, id));
-}
-
-/**
- * Remove the row entirely so the dedupe key frees up and a producer can
- * re-create it later. Used when a shift is rescheduled beyond the lead window
- * before its alert went out — the alert should fire again when the new time
- * approaches, which a terminal 'skipped' row would block.
- */
-export async function deleteRow(id: string): Promise<void> {
-	await db.delete(schema.notificationOutbox).where(eq(schema.notificationOutbox.id, id));
 }
 
 /** Retry if attempts remain, else terminal failure. */

--- a/src/lib/server/notify/scheduler.ts
+++ b/src/lib/server/notify/scheduler.ts
@@ -5,6 +5,7 @@
 // assumption: the in-memory flag and the select-then-claim pattern both
 // presume one app process per database — the same accepted constraint as the
 // video worker.
+// Delivery is at-least-once: a crash between sendMail and markSent re-sends that one notification after boot recovery — accepted trade-off.
 import { and, eq, gt, isNotNull, isNull, lte } from 'drizzle-orm';
 import { env } from '$env/dynamic/private';
 import { db, schema } from '$lib/server/db';
@@ -13,7 +14,6 @@ import { buildReminderEmail, buildShiftEmail } from '$lib/server/mail/templates'
 import {
 	claimNext,
 	cleanupOldRows,
-	deleteRow,
 	enqueue,
 	markFailedOrRequeue,
 	markSent,
@@ -32,11 +32,6 @@ const SCAN_INTERVAL_MS = 60 * 1000;
 const CATCH_UP_MS = 24 * 60 * 60 * 1000;
 // Shift alerts fire when a boundary (start or end) enters this window.
 const SHIFT_LEAD_MS = 24 * 60 * 60 * 1000;
-// Reschedule slack: at delivery time a boundary may sit slightly past the
-// lead window because the producer ran up to one scan earlier. Beyond this,
-// the shift was genuinely rescheduled and the row is deleted for later
-// re-production.
-const SHIFT_RESCHEDULE_SLACK_MS = 5 * 60 * 1000;
 
 let timer: ReturnType<typeof setInterval> | null = null;
 let scanning = false;
@@ -138,10 +133,14 @@ async function produceShifts(now: Date): Promise<EnqueueRow[]> {
 				// Admins/members always; among caretakers only the shift owner.
 				if (user.role === 'caretaker' && user.id !== shift.userId) continue;
 				rows.push({
-					dedupeKey: shiftDedupeKey(shift.id, b.kind, user.id, 'email'),
+					dedupeKey: shiftDedupeKey(shift.id, b.kind, b.at, user.id, 'email'),
 					userId: user.id,
 					channel: 'email',
-					payload: { kind: b.kind, shiftId: shift.id }
+					payload: {
+						kind: b.kind,
+						shiftId: shift.id,
+						boundaryEpoch: Math.floor(b.at.getTime() / 1000)
+					}
 				});
 			}
 		}
@@ -190,6 +189,18 @@ async function deliverReminder(
 		await markSkipped(row.id);
 		return;
 	}
+	if (user.role === 'caretaker') {
+		const stillAssigned = await db.query.companionCaretakers.findFirst({
+			where: and(
+				eq(schema.companionCaretakers.companionId, reminder.companionId),
+				eq(schema.companionCaretakers.userId, user.id)
+			)
+		});
+		if (!stillAssigned) {
+			await markSkipped(row.id);
+			return;
+		}
+	}
 	const companion = await db.query.companions.findFirst({
 		where: eq(schema.companions.id, reminder.companionId)
 	});
@@ -212,7 +223,7 @@ async function deliverReminder(
 
 async function deliverShift(
 	row: ClaimedNotification,
-	payload: { kind: 'shiftStart' | 'shiftEnd'; shiftId: string }
+	payload: { kind: 'shiftStart' | 'shiftEnd'; shiftId: string; boundaryEpoch: number }
 ): Promise<void> {
 	const shift = await db.query.caretakerShifts.findFirst({
 		where: eq(schema.caretakerShifts.id, payload.shiftId)
@@ -222,16 +233,16 @@ async function deliverShift(
 		return;
 	}
 	const boundary = payload.kind === 'shiftStart' ? shift.startAt : shift.endAt;
-	const now = Date.now();
-	// Boundary already passed: alert is stale, drop it silently.
-	if (boundary.getTime() <= now) {
+	// The row was created for a specific boundary time. If the shift has been
+	// rescheduled since, this row is moot — the producer creates a fresh row
+	// (new dedupe key) when the new time enters the window.
+	if (Math.floor(boundary.getTime() / 1000) !== payload.boundaryEpoch) {
 		await markSkipped(row.id);
 		return;
 	}
-	// Rescheduled far beyond the lead window: free the dedupe key so the
-	// producer re-creates the alert when the new time approaches.
-	if (boundary.getTime() - now > SHIFT_LEAD_MS + SHIFT_RESCHEDULE_SLACK_MS) {
-		await deleteRow(row.id);
+	// Boundary already passed: alert is stale, drop it silently.
+	if (boundary.getTime() <= Date.now()) {
+		await markSkipped(row.id);
 		return;
 	}
 	const user = await eligibleRecipient(row.userId);
@@ -265,8 +276,12 @@ async function deliverShift(
 
 /** Drain the queue until empty. Per-row errors requeue/fail that row only. */
 async function drain(): Promise<void> {
+	// One attempt per row per pass: rows requeued after a failure are excluded
+	// until the next scan, so the 60s tick acts as retry backoff instead of
+	// burning every attempt back-to-back against a struggling SMTP server.
+	const failedThisPass = new Set<string>();
 	for (;;) {
-		const row = await claimNext();
+		const row = await claimNext(failedThisPass);
 		if (!row) return;
 		try {
 			if (row.payload.kind === 'reminderDue') {
@@ -276,6 +291,7 @@ async function drain(): Promise<void> {
 			}
 		} catch (err) {
 			console.error(`[notify] delivery failed (attempt ${row.attempts}):`, err);
+			failedThisPass.add(row.id);
 			await markFailedOrRequeue(row);
 		}
 	}

--- a/src/lib/server/notify/scheduler.ts
+++ b/src/lib/server/notify/scheduler.ts
@@ -206,7 +206,7 @@ async function eligibleRecipient(userId: string) {
 		where: eq(schema.users.id, userId),
 		columns: { passwordHash: false }
 	});
-	if (!user || !user.isActive || !user.email) return null;
+	if (!user || !user.isActive) return null;
 	return user;
 }
 
@@ -237,7 +237,7 @@ async function deliverReminder(
 		return;
 	}
 	const user = await eligibleRecipient(row.userId);
-	if (!user || !user.notifyReminderEmail) {
+	if (!user || !user.email || !user.notifyReminderEmail) {
 		await markSkipped(row.id);
 		return;
 	}
@@ -264,7 +264,7 @@ async function deliverReminder(
 	const link = publicLink(`/${companion.id}/reminders`);
 	const message = buildReminderEmail(
 		user.locale,
-		{ displayName: user.displayName, email: user.email! },
+		{ displayName: user.displayName, email: user.email },
 		{ title: reminder.title, description: reminder.description, dueAt: reminder.dueAt },
 		companion.name,
 		link
@@ -298,7 +298,7 @@ async function deliverShift(
 		return;
 	}
 	const user = await eligibleRecipient(row.userId);
-	if (!user || !user.notifyShiftEmail) {
+	if (!user || !user.email || !user.notifyShiftEmail) {
 		await markSkipped(row.id);
 		return;
 	}
@@ -322,7 +322,7 @@ async function deliverShift(
 	const link = publicLink(user.role === 'caretaker' ? '/care' : '/');
 	const message = buildShiftEmail(
 		user.locale,
-		{ displayName: user.displayName, email: user.email! },
+		{ displayName: user.displayName, email: user.email },
 		payload.kind,
 		caretaker.displayName,
 		{ startAt: shift.startAt, endAt: shift.endAt },

--- a/src/lib/server/notify/scheduler.ts
+++ b/src/lib/server/notify/scheduler.ts
@@ -89,7 +89,11 @@ async function produceReminders(now: Date): Promise<EnqueueRow[]> {
 				dedupeKey: reminderDedupeKey(reminder.id, reminder.dueAt, user.id, 'email'),
 				userId: user.id,
 				channel: 'email',
-				payload: { kind: 'reminderDue', reminderId: reminder.id }
+				payload: {
+					kind: 'reminderDue',
+					reminderId: reminder.id,
+					dueAtEpoch: Math.floor(reminder.dueAt.getTime() / 1000)
+				}
 			});
 		}
 	}
@@ -174,13 +178,20 @@ function publicLink(path: string): string | null {
 
 async function deliverReminder(
 	row: ClaimedNotification,
-	payload: { reminderId: string }
+	payload: { reminderId: string; dueAtEpoch: number }
 ): Promise<void> {
 	const reminder = await db.query.reminders.findFirst({
 		where: eq(schema.reminders.id, payload.reminderId)
 	});
 	// Reminder deleted or completed since enqueue: nothing to say anymore.
 	if (!reminder || reminder.completedAt) {
+		await markSkipped(row.id);
+		return;
+	}
+	// The row was created for a specific occurrence time. If the reminder was
+	// rescheduled since, this row is moot — the producer creates a fresh row
+	// (new dedupe key) when the new time comes due.
+	if (Math.floor(reminder.dueAt.getTime() / 1000) !== payload.dueAtEpoch) {
 		await markSkipped(row.id);
 		return;
 	}
@@ -250,6 +261,12 @@ async function deliverShift(
 		await markSkipped(row.id);
 		return;
 	}
+	// Symmetry with deliverReminder's assignment re-check: a user demoted to
+	// caretaker after enqueue must not receive another caretaker's shift alert.
+	if (user.role === 'caretaker' && user.id !== shift.userId) {
+		await markSkipped(row.id);
+		return;
+	}
 	const caretaker = await db.query.users.findFirst({
 		where: eq(schema.users.id, shift.userId),
 		columns: { displayName: true }
@@ -284,6 +301,12 @@ async function drain(): Promise<void> {
 		const row = await claimNext(failedThisPass);
 		if (!row) return;
 		try {
+			// Drain handles the email channel only; ntfy/apprise land in later PRs.
+			if (row.channel !== 'email') {
+				console.error(`[notify] no deliverer for channel '${row.channel}'; skipping row ${row.id}`);
+				await markSkipped(row.id);
+				continue;
+			}
 			if (row.payload.kind === 'reminderDue') {
 				await deliverReminder(row, row.payload);
 			} else {

--- a/src/lib/server/notify/scheduler.ts
+++ b/src/lib/server/notify/scheduler.ts
@@ -1,0 +1,315 @@
+// Notification scheduler (issue #12). A 60-second in-process interval that
+// (a) produces outbox rows for newly-due reminders and for shifts entering
+// the 24h lead window, then (b) drains the queue through SMTP. Single-flight
+// like the video worker: overlapping ticks are no-ops. Single-process
+// assumption: the in-memory flag and the select-then-claim pattern both
+// presume one app process per database — the same accepted constraint as the
+// video worker.
+import { and, eq, gt, isNotNull, isNull, lte } from 'drizzle-orm';
+import { env } from '$env/dynamic/private';
+import { db, schema } from '$lib/server/db';
+import { isMailEnabled, sendMail } from '$lib/server/mail';
+import { buildReminderEmail, buildShiftEmail } from '$lib/server/mail/templates';
+import {
+	claimNext,
+	cleanupOldRows,
+	deleteRow,
+	enqueue,
+	markFailedOrRequeue,
+	markSent,
+	markSkipped,
+	recoverOrphanedClaims,
+	reminderDedupeKey,
+	shiftDedupeKey,
+	type ClaimedNotification,
+	type EnqueueRow
+} from './outbox';
+
+const SCAN_INTERVAL_MS = 60 * 1000;
+// First-deploy guard: reminders overdue longer than this never produce a
+// notification. Without it, enabling the feature on an existing install would
+// email every historically overdue reminder at once.
+const CATCH_UP_MS = 24 * 60 * 60 * 1000;
+// Shift alerts fire when a boundary (start or end) enters this window.
+const SHIFT_LEAD_MS = 24 * 60 * 60 * 1000;
+// Reschedule slack: at delivery time a boundary may sit slightly past the
+// lead window because the producer ran up to one scan earlier. Beyond this,
+// the shift was genuinely rescheduled and the row is deleted for later
+// re-production.
+const SHIFT_RESCHEDULE_SLACK_MS = 5 * 60 * 1000;
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let scanning = false;
+
+interface Recipient {
+	id: string;
+	role: 'admin' | 'member' | 'caretaker';
+}
+
+async function optedInUsers(
+	flag: typeof schema.users.notifyReminderEmail | typeof schema.users.notifyShiftEmail
+): Promise<Recipient[]> {
+	return db
+		.select({ id: schema.users.id, role: schema.users.role })
+		.from(schema.users)
+		.where(and(eq(flag, true), eq(schema.users.isActive, true), isNotNull(schema.users.email)));
+}
+
+/** Due reminders → one outbox row per eligible recipient. */
+async function produceReminders(now: Date): Promise<EnqueueRow[]> {
+	const due = await db
+		.select({
+			id: schema.reminders.id,
+			dueAt: schema.reminders.dueAt,
+			companionId: schema.reminders.companionId
+		})
+		.from(schema.reminders)
+		.innerJoin(schema.companions, eq(schema.reminders.companionId, schema.companions.id))
+		.where(
+			and(
+				isNull(schema.reminders.completedAt),
+				lte(schema.reminders.dueAt, now),
+				gt(schema.reminders.dueAt, new Date(now.getTime() - CATCH_UP_MS)),
+				eq(schema.companions.isActive, true)
+			)
+		);
+	if (due.length === 0) return [];
+
+	const recipients = await optedInUsers(schema.users.notifyReminderEmail);
+	if (recipients.length === 0) return [];
+
+	// Caretakers are eligible only for companions they are assigned to. Shift
+	// status is deliberately ignored: assigned means notified (product call —
+	// a reminder due off-shift is still that caretaker's companion).
+	const assignments = await db.query.companionCaretakers.findMany();
+	const assigned = new Set(assignments.map((a) => `${a.companionId}:${a.userId}`));
+
+	const rows: EnqueueRow[] = [];
+	for (const reminder of due) {
+		for (const user of recipients) {
+			if (user.role === 'caretaker' && !assigned.has(`${reminder.companionId}:${user.id}`)) {
+				continue;
+			}
+			rows.push({
+				dedupeKey: reminderDedupeKey(reminder.id, reminder.dueAt, user.id, 'email'),
+				userId: user.id,
+				channel: 'email',
+				payload: { kind: 'reminderDue', reminderId: reminder.id }
+			});
+		}
+	}
+	return rows;
+}
+
+/**
+ * Shifts whose start or end falls within the next 24h → one outbox row per
+ * recipient per boundary. Recipients: opted-in admins/members plus the
+ * shift's own caretaker (their shift, their alert). Other caretakers never.
+ * Windows are future-only (boundary > now), so a boundary that slipped past
+ * while the app was down simply never alerts — no stale notifications.
+ */
+async function produceShifts(now: Date): Promise<EnqueueRow[]> {
+	const horizon = new Date(now.getTime() + SHIFT_LEAD_MS);
+	const upcoming = await db
+		.select({
+			id: schema.caretakerShifts.id,
+			userId: schema.caretakerShifts.userId,
+			startAt: schema.caretakerShifts.startAt,
+			endAt: schema.caretakerShifts.endAt
+		})
+		.from(schema.caretakerShifts)
+		.where(
+			and(gt(schema.caretakerShifts.endAt, now), lte(schema.caretakerShifts.startAt, horizon))
+		);
+	if (upcoming.length === 0) return [];
+
+	const recipients = await optedInUsers(schema.users.notifyShiftEmail);
+	if (recipients.length === 0) return [];
+
+	const rows: EnqueueRow[] = [];
+	for (const shift of upcoming) {
+		const boundaries: Array<{ kind: 'shiftStart' | 'shiftEnd'; at: Date }> = [
+			{ kind: 'shiftStart', at: shift.startAt },
+			{ kind: 'shiftEnd', at: shift.endAt }
+		];
+		for (const b of boundaries) {
+			if (b.at <= now || b.at > horizon) continue;
+			for (const user of recipients) {
+				// Admins/members always; among caretakers only the shift owner.
+				if (user.role === 'caretaker' && user.id !== shift.userId) continue;
+				rows.push({
+					dedupeKey: shiftDedupeKey(shift.id, b.kind, user.id, 'email'),
+					userId: user.id,
+					channel: 'email',
+					payload: { kind: b.kind, shiftId: shift.id }
+				});
+			}
+		}
+	}
+	return rows;
+}
+
+async function produce(): Promise<void> {
+	const now = new Date();
+	const rows = [...(await produceReminders(now)), ...(await produceShifts(now))];
+	const fresh = await enqueue(rows);
+	if (fresh > 0) console.info(`[notify] enqueued ${fresh} notification(s)`);
+}
+
+/** Resolve the recipient, or null if no longer eligible at delivery time. */
+async function eligibleRecipient(userId: string) {
+	const user = await db.query.users.findFirst({
+		where: eq(schema.users.id, userId),
+		columns: { passwordHash: false }
+	});
+	if (!user || !user.isActive || !user.email) return null;
+	return user;
+}
+
+// Deep links need a configured public origin; without one the email simply
+// has no button (boot already warns about ORIGIN when SMTP is on).
+function publicLink(path: string): string | null {
+	const origin = env.ORIGIN?.trim().replace(/\/$/, '') || null;
+	return origin ? `${origin}${path}` : null;
+}
+
+async function deliverReminder(
+	row: ClaimedNotification,
+	payload: { reminderId: string }
+): Promise<void> {
+	const reminder = await db.query.reminders.findFirst({
+		where: eq(schema.reminders.id, payload.reminderId)
+	});
+	// Reminder deleted or completed since enqueue: nothing to say anymore.
+	if (!reminder || reminder.completedAt) {
+		await markSkipped(row.id);
+		return;
+	}
+	const user = await eligibleRecipient(row.userId);
+	if (!user || !user.notifyReminderEmail) {
+		await markSkipped(row.id);
+		return;
+	}
+	const companion = await db.query.companions.findFirst({
+		where: eq(schema.companions.id, reminder.companionId)
+	});
+	if (!companion || !companion.isActive) {
+		await markSkipped(row.id);
+		return;
+	}
+
+	const link = publicLink(`/${companion.id}/reminders`);
+	const message = buildReminderEmail(
+		user.locale,
+		{ displayName: user.displayName, email: user.email! },
+		{ title: reminder.title, description: reminder.description, dueAt: reminder.dueAt },
+		companion.name,
+		link
+	);
+	await sendMail(message);
+	await markSent(row.id);
+}
+
+async function deliverShift(
+	row: ClaimedNotification,
+	payload: { kind: 'shiftStart' | 'shiftEnd'; shiftId: string }
+): Promise<void> {
+	const shift = await db.query.caretakerShifts.findFirst({
+		where: eq(schema.caretakerShifts.id, payload.shiftId)
+	});
+	if (!shift) {
+		await markSkipped(row.id);
+		return;
+	}
+	const boundary = payload.kind === 'shiftStart' ? shift.startAt : shift.endAt;
+	const now = Date.now();
+	// Boundary already passed: alert is stale, drop it silently.
+	if (boundary.getTime() <= now) {
+		await markSkipped(row.id);
+		return;
+	}
+	// Rescheduled far beyond the lead window: free the dedupe key so the
+	// producer re-creates the alert when the new time approaches.
+	if (boundary.getTime() - now > SHIFT_LEAD_MS + SHIFT_RESCHEDULE_SLACK_MS) {
+		await deleteRow(row.id);
+		return;
+	}
+	const user = await eligibleRecipient(row.userId);
+	if (!user || !user.notifyShiftEmail) {
+		await markSkipped(row.id);
+		return;
+	}
+	const caretaker = await db.query.users.findFirst({
+		where: eq(schema.users.id, shift.userId),
+		columns: { displayName: true }
+	});
+	if (!caretaker) {
+		await markSkipped(row.id);
+		return;
+	}
+
+	// Caretaker lands on their dashboard; admins/members on home (they cannot
+	// open /care).
+	const link = publicLink(user.role === 'caretaker' ? '/care' : '/');
+	const message = buildShiftEmail(
+		user.locale,
+		{ displayName: user.displayName, email: user.email! },
+		payload.kind,
+		caretaker.displayName,
+		{ startAt: shift.startAt, endAt: shift.endAt },
+		link
+	);
+	await sendMail(message);
+	await markSent(row.id);
+}
+
+/** Drain the queue until empty. Per-row errors requeue/fail that row only. */
+async function drain(): Promise<void> {
+	for (;;) {
+		const row = await claimNext();
+		if (!row) return;
+		try {
+			if (row.payload.kind === 'reminderDue') {
+				await deliverReminder(row, row.payload);
+			} else {
+				await deliverShift(row, row.payload);
+			}
+		} catch (err) {
+			console.error(`[notify] delivery failed (attempt ${row.attempts}):`, err);
+			await markFailedOrRequeue(row);
+		}
+	}
+}
+
+async function scan(): Promise<void> {
+	if (scanning) return;
+	scanning = true;
+	try {
+		await produce();
+		await drain();
+		await cleanupOldRows();
+	} catch (err) {
+		console.error('[notify] scan failed:', err);
+	} finally {
+		scanning = false;
+	}
+}
+
+/**
+ * Boot entry point. No-op unless SMTP is configured. Recovers rows orphaned
+ * by a crash, runs one immediate scan, then ticks every minute. The timer is
+ * unref'd so it never keeps the process alive.
+ */
+export function startNotifyScheduler(): void {
+	if (!isMailEnabled()) return;
+	if (timer) return;
+	recoverOrphanedClaims()
+		.then((n) => {
+			if (n > 0) console.info(`[notify] recovered ${n} interrupted notification(s)`);
+			return scan();
+		})
+		.catch((err) => console.error('[notify] scheduler start failed:', err));
+	timer = setInterval(() => void scan(), SCAN_INTERVAL_MS);
+	timer.unref();
+	console.info('[notify] notification scheduler started (60s interval)');
+}

--- a/src/lib/server/notify/scheduler.ts
+++ b/src/lib/server/notify/scheduler.ts
@@ -6,11 +6,13 @@
 // presume one app process per database — the same accepted constraint as the
 // video worker.
 // Delivery is at-least-once: a crash between sendMail and markSent re-sends that one notification after boot recovery — accepted trade-off.
-import { and, eq, gt, isNotNull, isNull, lte } from 'drizzle-orm';
+import { and, eq, gt, isNull, lte } from 'drizzle-orm';
 import { env } from '$env/dynamic/private';
+import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { isMailEnabled, sendMail } from '$lib/server/mail';
-import { buildReminderEmail, buildShiftEmail } from '$lib/server/mail/templates';
+import { buildReminderEmail, buildShiftEmail, formatWhen } from '$lib/server/mail/templates';
+import { isNtfyEnabled, sendNtfy } from './ntfy';
 import {
 	claimNext,
 	cleanupOldRows,
@@ -39,15 +41,29 @@ let scanning = false;
 interface Recipient {
 	id: string;
 	role: 'admin' | 'member' | 'caretaker';
+	email: string | null;
+	ntfyTopic: string | null;
+	flag: boolean;
 }
 
-async function optedInUsers(
-	flag: typeof schema.users.notifyReminderEmail | typeof schema.users.notifyShiftEmail
+/**
+ * Users relevant to a notification category: active, with the category's
+ * email flag and their ntfy topic. Channel filtering happens at the call
+ * site: email rows need flag && email, ntfy rows need a topic.
+ */
+async function categoryRecipients(
+	flagColumn: typeof schema.users.notifyReminderEmail | typeof schema.users.notifyShiftEmail
 ): Promise<Recipient[]> {
 	return db
-		.select({ id: schema.users.id, role: schema.users.role })
+		.select({
+			id: schema.users.id,
+			role: schema.users.role,
+			email: schema.users.email,
+			ntfyTopic: schema.users.ntfyTopic,
+			flag: flagColumn
+		})
 		.from(schema.users)
-		.where(and(eq(flag, true), eq(schema.users.isActive, true), isNotNull(schema.users.email)));
+		.where(eq(schema.users.isActive, true));
 }
 
 /** Due reminders → one outbox row per eligible recipient. */
@@ -70,31 +86,44 @@ async function produceReminders(now: Date): Promise<EnqueueRow[]> {
 		);
 	if (due.length === 0) return [];
 
-	const recipients = await optedInUsers(schema.users.notifyReminderEmail);
-	if (recipients.length === 0) return [];
-
+	const recipients = await categoryRecipients(schema.users.notifyReminderEmail);
 	// Caretakers are eligible only for companions they are assigned to. Shift
 	// status is deliberately ignored: assigned means notified (product call —
 	// a reminder due off-shift is still that caretaker's companion).
 	const assignments = await db.query.companionCaretakers.findMany();
 	const assigned = new Set(assignments.map((a) => `${a.companionId}:${a.userId}`));
 
+	const mailOn = isMailEnabled();
+	const ntfyOn = isNtfyEnabled();
 	const rows: EnqueueRow[] = [];
 	for (const reminder of due) {
 		for (const user of recipients) {
+			// Same visibility scope for every channel: caretakers only for
+			// companions assigned to them. Shift status is deliberately ignored.
 			if (user.role === 'caretaker' && !assigned.has(`${reminder.companionId}:${user.id}`)) {
 				continue;
 			}
-			rows.push({
-				dedupeKey: reminderDedupeKey(reminder.id, reminder.dueAt, user.id, 'email'),
-				userId: user.id,
-				channel: 'email',
-				payload: {
-					kind: 'reminderDue',
-					reminderId: reminder.id,
-					dueAtEpoch: Math.floor(reminder.dueAt.getTime() / 1000)
-				}
-			});
+			const payload = {
+				kind: 'reminderDue' as const,
+				reminderId: reminder.id,
+				dueAtEpoch: Math.floor(reminder.dueAt.getTime() / 1000)
+			};
+			if (mailOn && user.flag && user.email) {
+				rows.push({
+					dedupeKey: reminderDedupeKey(reminder.id, reminder.dueAt, user.id, 'email'),
+					userId: user.id,
+					channel: 'email',
+					payload
+				});
+			}
+			if (ntfyOn && user.ntfyTopic) {
+				rows.push({
+					dedupeKey: reminderDedupeKey(reminder.id, reminder.dueAt, user.id, 'ntfy'),
+					userId: user.id,
+					channel: 'ntfy',
+					payload
+				});
+			}
 		}
 	}
 	return rows;
@@ -122,9 +151,10 @@ async function produceShifts(now: Date): Promise<EnqueueRow[]> {
 		);
 	if (upcoming.length === 0) return [];
 
-	const recipients = await optedInUsers(schema.users.notifyShiftEmail);
-	if (recipients.length === 0) return [];
+	const recipients = await categoryRecipients(schema.users.notifyShiftEmail);
 
+	const mailOn = isMailEnabled();
+	const ntfyOn = isNtfyEnabled();
 	const rows: EnqueueRow[] = [];
 	for (const shift of upcoming) {
 		const boundaries: Array<{ kind: 'shiftStart' | 'shiftEnd'; at: Date }> = [
@@ -136,16 +166,27 @@ async function produceShifts(now: Date): Promise<EnqueueRow[]> {
 			for (const user of recipients) {
 				// Admins/members always; among caretakers only the shift owner.
 				if (user.role === 'caretaker' && user.id !== shift.userId) continue;
-				rows.push({
-					dedupeKey: shiftDedupeKey(shift.id, b.kind, b.at, user.id, 'email'),
-					userId: user.id,
-					channel: 'email',
-					payload: {
-						kind: b.kind,
-						shiftId: shift.id,
-						boundaryEpoch: Math.floor(b.at.getTime() / 1000)
-					}
-				});
+				const payload = {
+					kind: b.kind,
+					shiftId: shift.id,
+					boundaryEpoch: Math.floor(b.at.getTime() / 1000)
+				};
+				if (mailOn && user.flag && user.email) {
+					rows.push({
+						dedupeKey: shiftDedupeKey(shift.id, b.kind, b.at, user.id, 'email'),
+						userId: user.id,
+						channel: 'email',
+						payload
+					});
+				}
+				if (ntfyOn && user.ntfyTopic) {
+					rows.push({
+						dedupeKey: shiftDedupeKey(shift.id, b.kind, b.at, user.id, 'ntfy'),
+						userId: user.id,
+						channel: 'ntfy',
+						payload
+					});
+				}
 			}
 		}
 	}
@@ -291,6 +332,107 @@ async function deliverShift(
 	await markSent(row.id);
 }
 
+async function deliverReminderNtfy(
+	row: ClaimedNotification,
+	payload: { reminderId: string; dueAtEpoch: number }
+): Promise<void> {
+	const reminder = await db.query.reminders.findFirst({
+		where: eq(schema.reminders.id, payload.reminderId)
+	});
+	if (!reminder || reminder.completedAt) {
+		await markSkipped(row.id);
+		return;
+	}
+	if (Math.floor(reminder.dueAt.getTime() / 1000) !== payload.dueAtEpoch) {
+		await markSkipped(row.id);
+		return;
+	}
+	const user = await eligibleRecipient(row.userId);
+	if (!user || !user.ntfyTopic) {
+		await markSkipped(row.id);
+		return;
+	}
+	if (user.role === 'caretaker') {
+		const stillAssigned = await db.query.companionCaretakers.findFirst({
+			where: and(
+				eq(schema.companionCaretakers.companionId, reminder.companionId),
+				eq(schema.companionCaretakers.userId, user.id)
+			)
+		});
+		if (!stillAssigned) {
+			await markSkipped(row.id);
+			return;
+		}
+	}
+	const companion = await db.query.companions.findFirst({
+		where: eq(schema.companions.id, reminder.companionId)
+	});
+	if (!companion || !companion.isActive) {
+		await markSkipped(row.id);
+		return;
+	}
+
+	await sendNtfy(user.ntfyTopic, {
+		title: t(user.locale, 'email.reminder.subject', { title: reminder.title }),
+		message: `${t(user.locale, 'email.reminder.body', { companion: companion.name, title: reminder.title })}\n${t(user.locale, 'email.reminder.dueLine', { due: formatWhen(user.locale, reminder.dueAt) })}`,
+		click: publicLink(`/${companion.id}/reminders`)
+	});
+	await markSent(row.id);
+}
+
+async function deliverShiftNtfy(
+	row: ClaimedNotification,
+	payload: { kind: 'shiftStart' | 'shiftEnd'; shiftId: string; boundaryEpoch: number }
+): Promise<void> {
+	const shift = await db.query.caretakerShifts.findFirst({
+		where: eq(schema.caretakerShifts.id, payload.shiftId)
+	});
+	if (!shift) {
+		await markSkipped(row.id);
+		return;
+	}
+	const boundary = payload.kind === 'shiftStart' ? shift.startAt : shift.endAt;
+	if (Math.floor(boundary.getTime() / 1000) !== payload.boundaryEpoch) {
+		await markSkipped(row.id);
+		return;
+	}
+	if (boundary.getTime() <= Date.now()) {
+		await markSkipped(row.id);
+		return;
+	}
+	const user = await eligibleRecipient(row.userId);
+	if (!user || !user.ntfyTopic) {
+		await markSkipped(row.id);
+		return;
+	}
+	if (user.role === 'caretaker' && user.id !== shift.userId) {
+		await markSkipped(row.id);
+		return;
+	}
+	const caretaker = await db.query.users.findFirst({
+		where: eq(schema.users.id, shift.userId),
+		columns: { displayName: true }
+	});
+	if (!caretaker) {
+		await markSkipped(row.id);
+		return;
+	}
+
+	const subjectKey =
+		payload.kind === 'shiftStart' ? 'email.shift.startSubject' : 'email.shift.endSubject';
+	const bodyKey = payload.kind === 'shiftStart' ? 'email.shift.startBody' : 'email.shift.endBody';
+	const bodyParams: Record<string, string> =
+		payload.kind === 'shiftStart'
+			? { caretaker: caretaker.displayName, start: formatWhen(user.locale, shift.startAt) }
+			: { caretaker: caretaker.displayName, end: formatWhen(user.locale, shift.endAt) };
+	await sendNtfy(user.ntfyTopic, {
+		title: t(user.locale, subjectKey, { caretaker: caretaker.displayName }),
+		message: t(user.locale, bodyKey, bodyParams),
+		click: publicLink(user.role === 'caretaker' ? '/care' : '/')
+	});
+	await markSent(row.id);
+}
+
 /** Drain the queue until empty. Per-row errors requeue/fail that row only. */
 async function drain(): Promise<void> {
 	// One attempt per row per pass: rows requeued after a failure are excluded
@@ -301,16 +443,22 @@ async function drain(): Promise<void> {
 		const row = await claimNext(failedThisPass);
 		if (!row) return;
 		try {
-			// Drain handles the email channel only; ntfy/apprise land in later PRs.
-			if (row.channel !== 'email') {
+			if (row.channel === 'email') {
+				if (row.payload.kind === 'reminderDue') {
+					await deliverReminder(row, row.payload);
+				} else {
+					await deliverShift(row, row.payload);
+				}
+			} else if (row.channel === 'ntfy') {
+				if (row.payload.kind === 'reminderDue') {
+					await deliverReminderNtfy(row, row.payload);
+				} else {
+					await deliverShiftNtfy(row, row.payload);
+				}
+			} else {
+				// apprise lands in a later PR.
 				console.error(`[notify] no deliverer for channel '${row.channel}'; skipping row ${row.id}`);
 				await markSkipped(row.id);
-				continue;
-			}
-			if (row.payload.kind === 'reminderDue') {
-				await deliverReminder(row, row.payload);
-			} else {
-				await deliverShift(row, row.payload);
 			}
 		} catch (err) {
 			console.error(`[notify] delivery failed (attempt ${row.attempts}):`, err);
@@ -335,12 +483,12 @@ async function scan(): Promise<void> {
 }
 
 /**
- * Boot entry point. No-op unless SMTP is configured. Recovers rows orphaned
- * by a crash, runs one immediate scan, then ticks every minute. The timer is
- * unref'd so it never keeps the process alive.
+ * Boot entry point. No-op unless SMTP or ntfy is configured. Recovers rows
+ * orphaned by a crash, runs one immediate scan, then ticks every minute. The
+ * timer is unref'd so it never keeps the process alive.
  */
 export function startNotifyScheduler(): void {
-	if (!isMailEnabled()) return;
+	if (!isMailEnabled() && !isNtfyEnabled()) return;
 	if (timer) return;
 	recoverOrphanedClaims()
 		.then((n) => {
@@ -350,5 +498,10 @@ export function startNotifyScheduler(): void {
 		.catch((err) => console.error('[notify] scheduler start failed:', err));
 	timer = setInterval(() => void scan(), SCAN_INTERVAL_MS);
 	timer.unref();
-	console.info('[notify] notification scheduler started (60s interval)');
+	console.info(
+		`[notify] notification scheduler started (60s interval, channels: ${[
+			...(isMailEnabled() ? ['email'] : []),
+			...(isNtfyEnabled() ? ['ntfy'] : [])
+		].join('+')})`
+	);
 }

--- a/src/lib/server/validation.ts
+++ b/src/lib/server/validation.ts
@@ -2,6 +2,12 @@ function parseEnum<T extends string>(value: string, valid: readonly T[]): T | nu
 	return valid.includes(value as T) ? (value as T) : null;
 }
 
+// Loose email shape check, shared by every write path that stores users.email.
+// Deliberately permissive (one @, a dot in the domain, no whitespace): catches
+// fat-finger garbage before it becomes an undeliverable notification address,
+// without trying to fully validate RFC 5322.
+export const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 // Mood
 
 export type Mood = 'great' | 'good' | 'meh' | 'off' | 'sick';

--- a/src/routes/(app)/(admin)/admin/users/+page.server.ts
+++ b/src/routes/(app)/(admin)/admin/users/+page.server.ts
@@ -236,7 +236,10 @@ export const actions: Actions = {
 		const username = String(data.get('username') ?? '')
 			.trim()
 			.toLowerCase();
-		const email = String(data.get('email') ?? '').trim() || null;
+		const email =
+			String(data.get('email') ?? '')
+				.trim()
+				.toLowerCase() || null;
 		const phone = String(data.get('phone') ?? '').trim() || null;
 		const role = parseRole(String(data.get('role') ?? ''));
 
@@ -252,6 +255,15 @@ export const actions: Actions = {
 			where: and(eq(schema.users.username, username), ne(schema.users.id, userId))
 		});
 		if (conflict) return fail(400, { editError: t(locals.locale, 'error.usernameAlreadyTaken') });
+
+		if (email) {
+			const emailConflict = await db.query.users.findFirst({
+				where: and(eq(schema.users.email, email), ne(schema.users.id, userId))
+			});
+			if (emailConflict) {
+				return fail(400, { editError: t(locals.locale, 'error.emailAlreadyTaken') });
+			}
+		}
 
 		await db
 			.update(schema.users)

--- a/src/routes/(app)/(admin)/admin/users/+page.server.ts
+++ b/src/routes/(app)/(admin)/admin/users/+page.server.ts
@@ -265,10 +265,21 @@ export const actions: Actions = {
 			}
 		}
 
-		await db
-			.update(schema.users)
-			.set({ displayName, username, email, phone, role })
-			.where(eq(schema.users.id, userId));
+		try {
+			await db
+				.update(schema.users)
+				.set({ displayName, username, email, phone, role })
+				.where(eq(schema.users.id, userId));
+		} catch (err) {
+			if (
+				err instanceof Error &&
+				(err as Error & { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE' &&
+				err.message.includes('users_email_idx')
+			) {
+				return fail(400, { editError: t(locals.locale, 'error.emailAlreadyTaken') });
+			}
+			throw err;
+		}
 
 		return { editSuccess: true };
 	},

--- a/src/routes/(app)/(admin)/admin/users/+page.server.ts
+++ b/src/routes/(app)/(admin)/admin/users/+page.server.ts
@@ -274,7 +274,7 @@ export const actions: Actions = {
 			if (
 				err instanceof Error &&
 				(err as Error & { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE' &&
-				err.message.includes('users_email_idx')
+				err.message.includes('users.email')
 			) {
 				return fail(400, { editError: t(locals.locale, 'error.emailAlreadyTaken') });
 			}

--- a/src/routes/(app)/(admin)/admin/users/+page.server.ts
+++ b/src/routes/(app)/(admin)/admin/users/+page.server.ts
@@ -6,7 +6,7 @@ import { eq, and, ne, lt, gt } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 import bcrypt from 'bcryptjs';
 import { invalidateAllUserSessions } from '$lib/server/auth/session';
-import { parseRole } from '$lib/server/validation';
+import { parseRole, EMAIL_RE } from '$lib/server/validation';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -257,6 +257,9 @@ export const actions: Actions = {
 		if (conflict) return fail(400, { editError: t(locals.locale, 'error.usernameAlreadyTaken') });
 
 		if (email) {
+			if (!EMAIL_RE.test(email)) {
+				return fail(400, { editError: t(locals.locale, 'error.emailInvalid') });
+			}
 			const emailConflict = await db.query.users.findFirst({
 				where: and(eq(schema.users.email, email), ne(schema.users.id, userId))
 			});

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -6,7 +6,9 @@ import {
 	handleAccountUpdate,
 	handleReminderUndoUpdate,
 	handleDefaultRecurrenceUpdate,
-	handleNotificationsUpdate
+	handleNotificationsUpdate,
+	handleTestEmail,
+	handleTestNtfy
 } from '$lib/server/account';
 import { isMailEnabled } from '$lib/server/mail';
 import { isNtfyEnabled } from '$lib/server/notify/ntfy';
@@ -113,6 +115,16 @@ export const actions: Actions = {
 	notifications: async ({ request, locals }) => {
 		if (!locals.user) redirect(302, '/auth/login');
 		return handleNotificationsUpdate(locals.user.id, request, locals.locale);
+	},
+
+	testEmail: async ({ locals }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+		return handleTestEmail(locals.user, locals.locale);
+	},
+
+	testNtfy: async ({ locals }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+		return handleTestNtfy(locals.user, locals.locale);
 	},
 
 	restore: async ({ request, locals }) => {

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -9,6 +9,7 @@ import {
 	handleNotificationsUpdate
 } from '$lib/server/account';
 import { isMailEnabled } from '$lib/server/mail';
+import { isNtfyEnabled } from '$lib/server/notify/ntfy';
 import { isSecureRequest } from '$lib/server/auth';
 import { t, SUPPORTED_LOCALES } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
@@ -38,7 +39,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		companions,
 		archivedCompanions,
 		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT,
-		mailEnabled: isMailEnabled()
+		mailEnabled: isMailEnabled(),
+		ntfyEnabled: isNtfyEnabled()
 	};
 };
 
@@ -110,7 +112,7 @@ export const actions: Actions = {
 
 	notifications: async ({ request, locals }) => {
 		if (!locals.user) redirect(302, '/auth/login');
-		return handleNotificationsUpdate(locals.user.id, request);
+		return handleNotificationsUpdate(locals.user.id, request, locals.locale);
 	},
 
 	restore: async ({ request, locals }) => {

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -5,8 +5,10 @@ import { eq } from 'drizzle-orm';
 import {
 	handleAccountUpdate,
 	handleReminderUndoUpdate,
-	handleDefaultRecurrenceUpdate
+	handleDefaultRecurrenceUpdate,
+	handleNotificationsUpdate
 } from '$lib/server/account';
+import { isMailEnabled } from '$lib/server/mail';
 import { isSecureRequest } from '$lib/server/auth';
 import { t, SUPPORTED_LOCALES } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
@@ -35,7 +37,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		user: locals.user,
 		companions,
 		archivedCompanions,
-		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT
+		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT,
+		mailEnabled: isMailEnabled()
 	};
 };
 
@@ -103,6 +106,11 @@ export const actions: Actions = {
 	defaultRecurrence: async ({ request, locals }) => {
 		if (!locals.user) redirect(302, '/auth/login');
 		return handleDefaultRecurrenceUpdate(locals.user.id, request, locals.locale);
+	},
+
+	notifications: async ({ request, locals }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+		return handleNotificationsUpdate(locals.user.id, request);
 	},
 
 	restore: async ({ request, locals }) => {

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -12,6 +12,7 @@
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import ReminderUndoCard from '$lib/components/settings/ReminderUndoCard.svelte';
 	import DefaultRecurrenceCard from '$lib/components/settings/DefaultRecurrenceCard.svelte';
+	import NotificationsCard from '$lib/components/settings/NotificationsCard.svelte';
 	import { Pencil, Plus, RotateCcw } from '@lucide/svelte';
 	import { getContext } from 'svelte';
 	import { t, getLocale, SUPPORTED_LOCALES, LOCALE_LABELS } from '$lib/i18n';
@@ -233,6 +234,17 @@
 			: undefined}
 		errorMessage={form?.reminderUndoError}
 	/>
+
+	{#if data.mailEnabled}
+		<NotificationsCard
+			reminderEnabled={data.user?.notifyReminderEmail ?? false}
+			shiftEnabled={data.user?.notifyShiftEmail ?? false}
+			hasEmail={Boolean(data.user?.email)}
+			successMessage={form?.notificationsSuccess
+				? t(locale, 'page.settings.notificationsUpdated')
+				: undefined}
+		/>
+	{/if}
 
 	{#if data.user?.role !== 'caretaker'}
 		<DefaultRecurrenceCard

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -235,14 +235,17 @@
 		errorMessage={form?.reminderUndoError}
 	/>
 
-	{#if data.mailEnabled}
+	{#if data.mailEnabled || data.ntfyEnabled}
 		<NotificationsCard
 			reminderEnabled={data.user?.notifyReminderEmail ?? false}
 			shiftEnabled={data.user?.notifyShiftEmail ?? false}
 			hasEmail={Boolean(data.user?.email)}
+			ntfyEnabled={data.ntfyEnabled}
+			ntfyTopic={data.user?.ntfyTopic ?? null}
 			successMessage={form?.notificationsSuccess
 				? t(locale, 'page.settings.notificationsUpdated')
 				: undefined}
+			errorMessage={form?.notificationsError}
 		/>
 	{/if}
 

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -247,6 +247,10 @@
 				? t(locale, 'page.settings.notificationsUpdated')
 				: undefined}
 			errorMessage={form?.notificationsError}
+			testSuccessMessage={form?.notificationsTestSuccess
+				? t(locale, 'page.settings.testSent')
+				: undefined}
+			testErrorMessage={form?.notificationsTestError}
 		/>
 	{/if}
 

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -240,6 +240,7 @@
 			reminderEnabled={data.user?.notifyReminderEmail ?? false}
 			shiftEnabled={data.user?.notifyShiftEmail ?? false}
 			hasEmail={Boolean(data.user?.email)}
+			mailEnabled={data.mailEnabled}
 			ntfyEnabled={data.ntfyEnabled}
 			ntfyTopic={data.user?.ntfyTopic ?? null}
 			successMessage={form?.notificationsSuccess

--- a/src/routes/(caretaker)/care/settings/+page.server.ts
+++ b/src/routes/(caretaker)/care/settings/+page.server.ts
@@ -4,7 +4,9 @@ import { getUpcomingShifts } from '$lib/server/shifts';
 import {
 	handleAccountUpdate,
 	handleReminderUndoUpdate,
-	handleNotificationsUpdate
+	handleNotificationsUpdate,
+	handleTestEmail,
+	handleTestNtfy
 } from '$lib/server/account';
 import { t, SUPPORTED_LOCALES } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
@@ -66,5 +68,15 @@ export const actions: Actions = {
 	notifications: async ({ request, locals }) => {
 		if (!locals.user) redirect(302, '/auth/login');
 		return handleNotificationsUpdate(locals.user.id, request, locals.locale);
+	},
+
+	testEmail: async ({ locals }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+		return handleTestEmail(locals.user, locals.locale);
+	},
+
+	testNtfy: async ({ locals }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+		return handleTestNtfy(locals.user, locals.locale);
 	}
 };

--- a/src/routes/(caretaker)/care/settings/+page.server.ts
+++ b/src/routes/(caretaker)/care/settings/+page.server.ts
@@ -13,6 +13,7 @@ import { eq } from 'drizzle-orm';
 import { isSecureRequest } from '$lib/server/auth';
 import { REMINDER_UNDO_SECONDS_DEFAULT } from '$lib/server/env';
 import { isMailEnabled } from '$lib/server/mail';
+import { isNtfyEnabled } from '$lib/server/notify/ntfy';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -21,7 +22,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		user: locals.user,
 		upcomingShifts,
 		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT,
-		mailEnabled: isMailEnabled()
+		mailEnabled: isMailEnabled(),
+		ntfyEnabled: isNtfyEnabled()
 	};
 };
 
@@ -63,6 +65,6 @@ export const actions: Actions = {
 
 	notifications: async ({ request, locals }) => {
 		if (!locals.user) redirect(302, '/auth/login');
-		return handleNotificationsUpdate(locals.user.id, request);
+		return handleNotificationsUpdate(locals.user.id, request, locals.locale);
 	}
 };

--- a/src/routes/(caretaker)/care/settings/+page.server.ts
+++ b/src/routes/(caretaker)/care/settings/+page.server.ts
@@ -1,13 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { getUpcomingShifts } from '$lib/server/shifts';
-import { handleAccountUpdate, handleReminderUndoUpdate } from '$lib/server/account';
+import {
+	handleAccountUpdate,
+	handleReminderUndoUpdate,
+	handleNotificationsUpdate
+} from '$lib/server/account';
 import { t, SUPPORTED_LOCALES } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
 import { isSecureRequest } from '$lib/server/auth';
 import { REMINDER_UNDO_SECONDS_DEFAULT } from '$lib/server/env';
+import { isMailEnabled } from '$lib/server/mail';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -15,7 +20,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 	return {
 		user: locals.user,
 		upcomingShifts,
-		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT
+		reminderUndoDefault: REMINDER_UNDO_SECONDS_DEFAULT,
+		mailEnabled: isMailEnabled()
 	};
 };
 
@@ -53,5 +59,10 @@ export const actions: Actions = {
 	reminderUndo: async ({ request, locals }) => {
 		if (!locals.user) redirect(302, '/auth/login');
 		return handleReminderUndoUpdate(locals.user.id, request, locals.locale);
+	},
+
+	notifications: async ({ request, locals }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+		return handleNotificationsUpdate(locals.user.id, request);
 	}
 };

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -269,14 +269,17 @@
 		errorMessage={form?.reminderUndoError}
 	/>
 
-	{#if data.mailEnabled}
+	{#if data.mailEnabled || data.ntfyEnabled}
 		<NotificationsCard
 			reminderEnabled={data.user?.notifyReminderEmail ?? false}
 			shiftEnabled={data.user?.notifyShiftEmail ?? false}
 			hasEmail={Boolean(data.user?.email)}
+			ntfyEnabled={data.ntfyEnabled}
+			ntfyTopic={data.user?.ntfyTopic ?? null}
 			successMessage={form?.notificationsSuccess
 				? t(locale, 'page.settings.notificationsUpdated')
 				: undefined}
+			errorMessage={form?.notificationsError}
 		/>
 	{/if}
 

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -281,6 +281,10 @@
 				? t(locale, 'page.settings.notificationsUpdated')
 				: undefined}
 			errorMessage={form?.notificationsError}
+			testSuccessMessage={form?.notificationsTestSuccess
+				? t(locale, 'page.settings.testSent')
+				: undefined}
+			testErrorMessage={form?.notificationsTestError}
 		/>
 	{/if}
 

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -274,6 +274,7 @@
 			reminderEnabled={data.user?.notifyReminderEmail ?? false}
 			shiftEnabled={data.user?.notifyShiftEmail ?? false}
 			hasEmail={Boolean(data.user?.email)}
+			mailEnabled={data.mailEnabled}
 			ntfyEnabled={data.ntfyEnabled}
 			ntfyTopic={data.user?.ntfyTopic ?? null}
 			successMessage={form?.notificationsSuccess

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -10,6 +10,7 @@
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ReminderUndoCard from '$lib/components/settings/ReminderUndoCard.svelte';
+	import NotificationsCard from '$lib/components/settings/NotificationsCard.svelte';
 	import { Calendar } from '@lucide/svelte';
 	import { SvelteDate } from 'svelte/reactivity';
 	import { t, getLocale, SUPPORTED_LOCALES, LOCALE_LABELS, type MessageKey } from '$lib/i18n';
@@ -267,6 +268,17 @@
 			: undefined}
 		errorMessage={form?.reminderUndoError}
 	/>
+
+	{#if data.mailEnabled}
+		<NotificationsCard
+			reminderEnabled={data.user?.notifyReminderEmail ?? false}
+			shiftEnabled={data.user?.notifyShiftEmail ?? false}
+			hasEmail={Boolean(data.user?.email)}
+			successMessage={form?.notificationsSuccess
+				? t(locale, 'page.settings.notificationsUpdated')
+				: undefined}
+		/>
+	{/if}
 
 	<!-- My Shifts -->
 	<Card id="shifts">

--- a/src/routes/auth/forgot/+page.server.ts
+++ b/src/routes/auth/forgot/+page.server.ts
@@ -1,0 +1,90 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { t } from '$lib/i18n';
+import { db, schema } from '$lib/server/db';
+import { eq } from 'drizzle-orm';
+import { isMailEnabled, sendMail } from '$lib/server/mail';
+import { buildResetEmail } from '$lib/server/mail/templates';
+import { createResetToken, cleanupExpiredResetTokens } from '$lib/server/auth/password-reset';
+
+// In-process per-IP limiter, same caveats as the login limiter: state resets on
+// restart, single-instance only. A DB-backed per-user cooldown lives in
+// createResetToken and survives restarts.
+const forgotAttempts = new Map<string, { count: number; resetAt: number }>();
+const MAX_ATTEMPTS = 5;
+const WINDOW_MS = 15 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+let lastCleanup = Date.now();
+
+function checkRateLimit(ip: string): boolean {
+	const now = Date.now();
+
+	if (now - lastCleanup > CLEANUP_INTERVAL_MS) {
+		for (const [key, val] of forgotAttempts) {
+			if (now > val.resetAt) forgotAttempts.delete(key);
+		}
+		lastCleanup = now;
+	}
+
+	const record = forgotAttempts.get(ip);
+	if (!record || now > record.resetAt) {
+		forgotAttempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+		return true;
+	}
+	if (record.count >= MAX_ATTEMPTS) return false;
+	record.count++;
+	return true;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const load: PageServerLoad = async ({ locals }) => {
+	if (!isMailEnabled()) redirect(302, '/auth/login');
+	if (locals.user) redirect(302, '/');
+};
+
+export const actions: Actions = {
+	default: async ({ request, getClientAddress, locals, url }) => {
+		const locale = locals.locale;
+		if (!isMailEnabled()) redirect(302, '/auth/login');
+
+		if (!checkRateLimit(getClientAddress())) {
+			return fail(429, { error: t(locale, 'error.tooManyResetRequests') });
+		}
+
+		const data = await request.formData();
+		const email = String(data.get('email') ?? '')
+			.trim()
+			.toLowerCase();
+
+		if (!email) return fail(400, { error: t(locale, 'error.emailRequired') });
+		if (!EMAIL_RE.test(email)) return fail(400, { error: t(locale, 'error.emailInvalid') });
+
+		cleanupExpiredResetTokens().catch((err) =>
+			console.error('[mail] reset token cleanup failed:', err)
+		);
+
+		// Enumeration safety: every outcome below this point returns the same
+		// generic success. The send is fire-and-forget so response timing does not
+		// reveal whether the address matched an account.
+		const user = await db.query.users.findFirst({ where: eq(schema.users.email, email) });
+		if (user && user.isActive && user.passwordHash && user.email) {
+			const userId = user.id;
+			const token = await createResetToken(userId);
+			if (token) {
+				const link = `${url.origin}/auth/reset?token=${encodeURIComponent(token)}`;
+				const message = buildResetEmail(
+					user.locale,
+					{ displayName: user.displayName, username: user.username, email: user.email },
+					link
+				);
+				sendMail(message).catch((err) =>
+					console.error(`[mail] reset email to user ${userId} failed:`, err)
+				);
+			}
+		}
+
+		return { success: true };
+	}
+};

--- a/src/routes/auth/forgot/+page.server.ts
+++ b/src/routes/auth/forgot/+page.server.ts
@@ -1,11 +1,13 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
+import { env } from '$env/dynamic/private';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
 import { isMailEnabled, sendMail } from '$lib/server/mail';
 import { buildResetEmail } from '$lib/server/mail/templates';
 import { createResetToken, cleanupExpiredResetTokens } from '$lib/server/auth/password-reset';
+import { EMAIL_RE } from '$lib/server/validation';
 
 // In-process per-IP limiter, same caveats as the login limiter: state resets on
 // restart, single-instance only. A DB-backed per-user cooldown lives in
@@ -36,8 +38,6 @@ function checkRateLimit(ip: string): boolean {
 	record.count++;
 	return true;
 }
-
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!isMailEnabled()) redirect(302, '/auth/login');
@@ -73,7 +73,14 @@ export const actions: Actions = {
 			const userId = user.id;
 			const token = await createResetToken(userId);
 			if (token) {
-				const link = `${url.origin}/auth/reset?token=${encodeURIComponent(token)}`;
+				// Build the link from the configured ORIGIN, never the request's
+				// own origin. With ORIGIN unset, adapter-node derives url.origin
+				// from the Host header, so a forged Host (with a matching Origin to
+				// pass CSRF) would mint a valid token inside a link pointing at the
+				// attacker's host. ORIGIN is the documented production requirement;
+				// url.origin is only the dev (localhost) fallback.
+				const origin = env.ORIGIN?.trim().replace(/\/$/, '') || url.origin;
+				const link = `${origin}/auth/reset?token=${encodeURIComponent(token)}`;
 				const message = buildResetEmail(
 					user.locale,
 					{ displayName: user.displayName, username: user.username, email: user.email },

--- a/src/routes/auth/forgot/+page.svelte
+++ b/src/routes/auth/forgot/+page.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import type { ActionData } from './$types';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Card, CardContent } from '$lib/components/ui/card/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import { t, getLocale } from '$lib/i18n';
+
+	let { form }: { form: ActionData } = $props();
+	let loading = $state(false);
+	const locale = getLocale();
+</script>
+
+<svelte:head>
+	<title>{t(locale, 'page.forgot.title')} | EinVault</title>
+</svelte:head>
+
+<div class="min-h-screen flex items-center justify-center p-4 bg-background">
+	<div class="w-full max-w-sm">
+		<div class="text-center mb-8">
+			<h1 class="font-display text-2xl font-bold text-primary">
+				{t(locale, 'page.forgot.title')}
+			</h1>
+		</div>
+
+		<Card class="animate-slide-up">
+			<CardContent class="pt-6">
+				{#if form?.success}
+					<Alert>
+						<AlertDescription>{t(locale, 'page.forgot.success')}</AlertDescription>
+					</Alert>
+				{:else}
+					<form method="POST" onsubmit={() => (loading = true)} class="space-y-4">
+						{#if form?.error}
+							<Alert variant="destructive">
+								<AlertDescription>{form.error}</AlertDescription>
+							</Alert>
+						{/if}
+
+						<p class="text-sm text-muted-foreground">
+							{t(locale, 'page.forgot.instruction')}
+						</p>
+
+						<div class="space-y-1.5">
+							<Label for="email">{t(locale, 'page.forgot.emailLabel')}</Label>
+							<Input id="email" name="email" type="email" required autocomplete="email" />
+						</div>
+
+						<Button type="submit" class="w-full" disabled={loading}>
+							{loading ? t(locale, 'page.forgot.sending') : t(locale, 'page.forgot.submit')}
+						</Button>
+					</form>
+				{/if}
+
+				<div class="mt-4 text-center">
+					<a href="/auth/login" class="text-xs text-muted-foreground hover:text-primary underline">
+						{t(locale, 'page.forgot.backToLogin')}
+					</a>
+				</div>
+			</CardContent>
+		</Card>
+	</div>
+</div>

--- a/src/routes/auth/login/+page.server.ts
+++ b/src/routes/auth/login/+page.server.ts
@@ -2,6 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { t } from '$lib/i18n';
 import { isOidcEnabled, getOidcProviderName } from '$lib/server/auth/oidc';
+import { isMailEnabled } from '$lib/server/mail';
 import { db, schema } from '$lib/server/db';
 import {
 	generateSessionToken,
@@ -69,7 +70,8 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	return {
 		oidcEnabled: isOidcEnabled(),
 		oidcProviderName: getOidcProviderName(),
-		oidcError
+		oidcError,
+		mailEnabled: isMailEnabled()
 	};
 };
 

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -97,6 +97,16 @@
 							required
 							autocomplete="current-password"
 						/>
+						{#if data.mailEnabled}
+							<div class="text-right">
+								<a
+									href="/auth/forgot"
+									class="text-xs text-muted-foreground hover:text-primary underline"
+								>
+									{t(locale, 'page.login.forgotPassword')}
+								</a>
+							</div>
+						{/if}
 					</div>
 
 					<Button type="submit" class="w-full" disabled={loading}>

--- a/src/routes/auth/oidc/callback/+server.ts
+++ b/src/routes/auth/oidc/callback/+server.ts
@@ -98,7 +98,7 @@ export const GET: RequestHandler = async ({ url, cookies, locals, request, getCl
 	const sub = idTokenClaims.sub;
 	const iss = idTokenClaims.iss;
 	const email: string | undefined =
-		typeof idTokenClaims.email === 'string' ? idTokenClaims.email.toLowerCase() : undefined;
+		typeof idTokenClaims.email === 'string' ? idTokenClaims.email.trim().toLowerCase() : undefined;
 	const emailVerified = idTokenClaims.email_verified === true;
 	const preferredUsername: string | undefined =
 		typeof (idTokenClaims as Record<string, unknown>)['preferred_username'] === 'string'
@@ -203,6 +203,18 @@ export const GET: RequestHandler = async ({ url, cookies, locals, request, getCl
 		const newUserId = generateId(15);
 		const role = evaluateRole(idTokenClaims, defaultRoleEnv);
 
+		// If the email is already owned by a different account, omit it from the
+		// new row rather than crashing on the unique constraint.
+		let insertEmail: string | null = email || null;
+		if (insertEmail) {
+			const emailTaken = tx
+				.select({ id: schema.users.id })
+				.from(schema.users)
+				.where(eq(schema.users.email, insertEmail))
+				.get();
+			if (emailTaken) insertEmail = null;
+		}
+
 		tx.insert(schema.users)
 			.values({
 				id: newUserId,
@@ -210,7 +222,7 @@ export const GET: RequestHandler = async ({ url, cookies, locals, request, getCl
 				displayName: displayName || username,
 				passwordHash: null,
 				role,
-				email: email || null,
+				email: insertEmail,
 				oidcSubject: sub,
 				oidcIssuer: iss,
 				lastLoginAt: new Date()

--- a/src/routes/auth/reset/+page.server.ts
+++ b/src/routes/auth/reset/+page.server.ts
@@ -1,0 +1,53 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { t } from '$lib/i18n';
+import { db, schema } from '$lib/server/db';
+import { eq } from 'drizzle-orm';
+import bcrypt from 'bcryptjs';
+import { invalidateAllUserSessions } from '$lib/server/auth/session';
+import { validateResetToken, consumeUserResetTokens } from '$lib/server/auth/password-reset';
+
+export const load: PageServerLoad = async ({ url, locals }) => {
+	if (locals.user) redirect(302, '/');
+
+	const token = url.searchParams.get('token') ?? '';
+	const valid = token ? (await validateResetToken(token)) !== null : false;
+	return { valid };
+};
+
+export const actions: Actions = {
+	default: async ({ request, locals }) => {
+		const locale = locals.locale;
+
+		const data = await request.formData();
+		const token = String(data.get('token') ?? '');
+		const newPassword = String(data.get('newPassword') ?? '');
+		const confirmPassword = String(data.get('confirmPassword') ?? '');
+
+		// Re-validate in the action: the load-time check is advisory only, and the
+		// token may have expired or been consumed between render and submit.
+		const result = token ? await validateResetToken(token) : null;
+		if (!result) {
+			return fail(400, { error: t(locale, 'page.reset.invalid') });
+		}
+
+		if (newPassword.length < 8) {
+			return fail(400, { error: t(locale, 'error.passwordTooShort') });
+		}
+		if (newPassword.length > 128) {
+			return fail(400, { error: t(locale, 'error.passwordTooLong') });
+		}
+		if (newPassword !== confirmPassword) {
+			return fail(400, { error: t(locale, 'error.passwordsMismatch') });
+		}
+
+		const passwordHash = await bcrypt.hash(newPassword, 12);
+		await db.update(schema.users).set({ passwordHash }).where(eq(schema.users.id, result.user.id));
+
+		// Single-use + lock out anyone holding a stolen session.
+		await consumeUserResetTokens(result.user.id);
+		await invalidateAllUserSessions(result.user.id);
+
+		return { success: true };
+	}
+};

--- a/src/routes/auth/reset/+page.server.ts
+++ b/src/routes/auth/reset/+page.server.ts
@@ -4,8 +4,7 @@ import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
 import { eq } from 'drizzle-orm';
 import bcrypt from 'bcryptjs';
-import { invalidateAllUserSessions } from '$lib/server/auth/session';
-import { validateResetToken, consumeUserResetTokens } from '$lib/server/auth/password-reset';
+import { validateResetToken } from '$lib/server/auth/password-reset';
 
 export const load: PageServerLoad = async ({ url, locals }) => {
 	if (locals.user) redirect(302, '/');
@@ -28,7 +27,7 @@ export const actions: Actions = {
 		// token may have expired or been consumed between render and submit.
 		const result = token ? await validateResetToken(token) : null;
 		if (!result) {
-			return fail(400, { error: t(locale, 'page.reset.invalid') });
+			return fail(400, { tokenInvalid: true });
 		}
 
 		if (newPassword.length < 8) {
@@ -42,11 +41,17 @@ export const actions: Actions = {
 		}
 
 		const passwordHash = await bcrypt.hash(newPassword, 12);
-		await db.update(schema.users).set({ passwordHash }).where(eq(schema.users.id, result.user.id));
+		const targetUserId = result.user.id;
 
-		// Single-use + lock out anyone holding a stolen session.
-		await consumeUserResetTokens(result.user.id);
-		await invalidateAllUserSessions(result.user.id);
+		// One transaction: the password change, token burn, and session sweep
+		// land together or not at all.
+		db.transaction((tx) => {
+			tx.update(schema.users).set({ passwordHash }).where(eq(schema.users.id, targetUserId)).run();
+			tx.delete(schema.passwordResetTokens)
+				.where(eq(schema.passwordResetTokens.userId, targetUserId))
+				.run();
+			tx.delete(schema.sessions).where(eq(schema.sessions.userId, targetUserId)).run();
+		});
 
 		return { success: true };
 	}

--- a/src/routes/auth/reset/+page.svelte
+++ b/src/routes/auth/reset/+page.svelte
@@ -38,7 +38,7 @@
 							{t(locale, 'page.forgot.backToLogin')}
 						</a>
 					</div>
-				{:else if !data.valid && !form?.error}
+				{:else if form?.tokenInvalid || (!data.valid && !form?.error)}
 					<Alert variant="destructive">
 						<AlertDescription>{t(locale, 'page.reset.invalid')}</AlertDescription>
 					</Alert>

--- a/src/routes/auth/reset/+page.svelte
+++ b/src/routes/auth/reset/+page.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import type { ActionData, PageData } from './$types';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Card, CardContent } from '$lib/components/ui/card/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import { t, getLocale } from '$lib/i18n';
+
+	let { form, data }: { form: ActionData; data: PageData } = $props();
+	let loading = $state(false);
+	const locale = getLocale();
+
+	const token = $derived(page.url.searchParams.get('token') ?? '');
+</script>
+
+<svelte:head>
+	<title>{t(locale, 'page.reset.title')} | EinVault</title>
+</svelte:head>
+
+<div class="min-h-screen flex items-center justify-center p-4 bg-background">
+	<div class="w-full max-w-sm">
+		<div class="text-center mb-8">
+			<h1 class="font-display text-2xl font-bold text-primary">
+				{t(locale, 'page.reset.title')}
+			</h1>
+		</div>
+
+		<Card class="animate-slide-up">
+			<CardContent class="pt-6">
+				{#if form?.success}
+					<Alert>
+						<AlertDescription>{t(locale, 'page.reset.success')}</AlertDescription>
+					</Alert>
+					<div class="mt-4 text-center">
+						<a href="/auth/login" class="text-sm text-primary underline">
+							{t(locale, 'page.forgot.backToLogin')}
+						</a>
+					</div>
+				{:else if !data.valid && !form?.error}
+					<Alert variant="destructive">
+						<AlertDescription>{t(locale, 'page.reset.invalid')}</AlertDescription>
+					</Alert>
+					<div class="mt-4 text-center">
+						<a href="/auth/forgot" class="text-sm text-primary underline">
+							{t(locale, 'page.reset.requestNew')}
+						</a>
+					</div>
+				{:else}
+					<form method="POST" onsubmit={() => (loading = true)} class="space-y-4">
+						{#if form?.error}
+							<Alert variant="destructive">
+								<AlertDescription>{form.error}</AlertDescription>
+							</Alert>
+						{/if}
+
+						<input type="hidden" name="token" value={token} />
+
+						<div class="space-y-1.5">
+							<Label for="newPassword">{t(locale, 'page.reset.newPasswordLabel')}</Label>
+							<Input
+								id="newPassword"
+								name="newPassword"
+								type="password"
+								required
+								minlength={8}
+								maxlength={128}
+								autocomplete="new-password"
+							/>
+						</div>
+
+						<div class="space-y-1.5">
+							<Label for="confirmPassword">{t(locale, 'page.reset.confirmPasswordLabel')}</Label>
+							<Input
+								id="confirmPassword"
+								name="confirmPassword"
+								type="password"
+								required
+								minlength={8}
+								maxlength={128}
+								autocomplete="new-password"
+							/>
+						</div>
+
+						<Button type="submit" class="w-full" disabled={loading}>
+							{loading ? t(locale, 'page.reset.saving') : t(locale, 'page.reset.submit')}
+						</Button>
+					</form>
+				{/if}
+			</CardContent>
+		</Card>
+	</div>
+</div>


### PR DESCRIPTION
Closes #12.

## What's here

**SMTP email (optional).** Set `SMTP_HOST` + `SMTP_FROM` to enable outbound email. Nodemailer in-process, no sidecar. Same gating convention as OIDC and Immich: unset means off, partial config warns at boot.

**Forgot password.** Self-service reset flow on the login page, shown only when SMTP is configured. Tokens are 20 random bytes, stored as sha256, 30 minute expiry, single use. All sessions are invalidated on reset. OIDC-only accounts are excluded end to end, so a reset link can never bootstrap a password onto an SSO account. Responses are enumeration-safe and rate limited. Password reset stays email-only by design: account recovery must work even if the notification stack is down.

**Unique emails.** `users.email` now has a unique index. The migration lowercases and trims existing emails, then resolves duplicates by keeping the oldest account's address and clearing the rest. If your install had duplicate emails, affected users need to re-add theirs under Account settings.

**Reminder and shift notifications.** Opt-in per user (Settings > Notifications, available to caretakers too): an email when a reminder comes due, and an email 24 hours before a caretaker shift starts or ends. Caretakers only receive reminders for companions assigned to them and shift alerts for their own shifts. Delivery runs through a `notification_outbox` table with a 60 second in-process scheduler (same single-flight claim/recover pattern as the video worker), so restarts and SMTP outages retry instead of dropping notifications. A 24 hour catch-up cutoff prevents a first deploy from emailing every historically overdue reminder.

**ntfy push (optional).** Set `NTFY_URL` (server base) and optionally `NTFY_TOKEN`; each user then sets their own topic under Settings > Notifications. A topic is per-user rather than site-wide so the caretaker visibility model holds: a shared topic would broadcast every companion's reminders and every caretaker's schedule to anyone subscribed. Works alongside or instead of SMTP. On public servers like ntfy.sh the topic name is the only access control, so the UI nudges users toward long random names.

## Env vars

`SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`, `NTFY_URL`, `NTFY_TOKEN`. All documented in README, .env.example and both compose files. `ORIGIN` matters more now: reset links and notification deep links are built from it (boot warning added when unset).

## Notes

- Migrations 0015-0018 run automatically on boot as usual.
- Delivery is at-least-once: a crash between send and acknowledge re-sends that one notification after recovery.
- Email timestamps render in the server's `TZ`.
- Apprise (from the issue discussion) is not included as the baseline transport: per-user locale rendering has to happen in-app anyway, which reduces Apprise to a relay, and account recovery should not depend on a sidecar. The outbox channel enum already reserves `apprise`, so a driver can land later as a thin addition for people who want Telegram/Discord/Matrix fan-out.

Six locales updated. `npm run check`, `npm run lint` and `npm run build` are clean; the full flows were verified manually against maildev and a mock ntfy server (reset round-trip, dedupe, retry/backoff, opt-out races, caretaker scoping).