### PR TITLE
Speed up release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,15 @@ on:
 permissions:
   contents: read
 
+# Queue pushes to the same ref instead of racing them: a version-bump push
+# right after a merge would otherwise start before the merge build has written
+# its layer cache and pay for a full rebuild. Note GitHub keeps only the newest
+# pending run per group, so rapid-fire pushes may skip building intermediate
+# commits; only tag commits that were the tip of a push.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -23,15 +32,25 @@ jobs:
       - run: npm ci --ignore-scripts
       - run: npm run lint
 
+  # Each architecture builds natively (arm64 on an arm runner, no QEMU) and
+  # pushes by digest; the merge job below stitches the digests into one
+  # multi-arch manifest.
   build:
-    runs-on: ubuntu-latest
-    needs: lint
-    if: always() && needs.lint.result != 'failure' && needs.lint.result != 'cancelled'
+    if: github.ref_type == 'branch'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-      id-token: write
-      attestations: write
 
     steps:
       - name: Checkout
@@ -47,35 +66,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - name: Extract sha tag metadata
-        id: meta-sha
+      - name: Extract image metadata
+        id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/einvault
           tags: |
             type=sha,prefix=sha-
 
-      - name: Extract release tag metadata
-        id: meta-release
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/einvault
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-
-      - name: Build and push
+      - name: Build and push by digest
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
-          push: true
-          tags: ${{ steps.meta-sha.outputs.tags }}
-          labels: ${{ steps.meta-sha.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/einvault,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
           provenance: mode=max
           sbom: true
 
@@ -84,44 +92,136 @@ jobs:
         with:
           cache: true
 
-      - name: Scan image with Trivy (linux/amd64)
+      - name: Scan image with Trivy
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
         run: |
           trivy image \
-            --platform linux/amd64 \
+            --platform ${{ matrix.platform }} \
             --severity CRITICAL,HIGH \
             --ignore-unfixed \
             --exit-code 1 \
             --pkg-types os,library \
             "$IMAGE"
 
-      - name: Scan image with Trivy (linux/arm64)
+      - name: Export digest
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          trivy image \
-            --platform linux/arm64 \
-            --severity CRITICAL,HIGH \
-            --ignore-unfixed \
-            --exit-code 1 \
-            --pkg-types os,library \
-            "$IMAGE"
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/einvault
+          tags: |
+            type=sha,prefix=sha-
+            type=ref,event=branch
+
+      - name: Create multi-arch manifest
+        id: manifest
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/einvault
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          tag_args=$(printf '%s\n' "$TAGS" | grep -v '^$' | sed 's/^/-t /' | tr '\n' ' ')
+          # shellcheck disable=SC2086,SC2046
+          docker buildx imagetools create $tag_args \
+            $(printf "$IMAGE@sha256:%s " *)
+          digest=$(docker buildx imagetools inspect "$IMAGE:sha-${GITHUB_SHA::7}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/einvault
-          subject-digest: ${{ steps.build.outputs.digest }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
           push-to-registry: true
 
+  # Tag pushes don't rebuild: the commit was already built, scanned, and
+  # attested when it landed on main, so the release tags are stamped onto that
+  # exact image. Polls briefly because `git push --follow-tags` starts the
+  # branch and tag runs at the same time.
+  promote:
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract release tag metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/einvault
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
       - name: Promote release tags
-        if: steps.meta-release.outputs.tags != ''
         env:
-          SOURCE: ghcr.io/${{ github.repository_owner }}/einvault@${{ steps.build.outputs.digest }}
-          TAGS: ${{ steps.meta-release.outputs.tags }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/einvault
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           set -euo pipefail
+          SOURCE="$IMAGE:sha-${GITHUB_SHA::7}"
+          echo "waiting for $SOURCE (built by the main-branch run for this commit)"
+          for i in $(seq 1 60); do
+            if docker buildx imagetools inspect "$SOURCE" >/dev/null 2>&1; then
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "::error::$SOURCE not found after 30 minutes. Tags must point at a commit that was built from main." >&2
+              exit 1
+            fi
+            sleep 30
+          done
+          digest=$(docker buildx imagetools inspect "$SOURCE" --format '{{json .Manifest.Digest}}' | tr -d '"')
           printf '%s\n' "$TAGS" \
             | grep -v '^$' \
-            | xargs -r -P4 -I{} sh -c 'echo "promoting $1"; docker buildx imagetools create -t "$1" "$2"' _ {} "$SOURCE"
+            | xargs -r -P4 -I{} sh -c 'echo "promoting $1"; docker buildx imagetools create -t "$1" "$2"' _ {} "$IMAGE@$digest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,22 @@
 
 ARG NODE_IMAGE=node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
+# pkgmeta: zero out the version field so version-bump commits don't invalidate
+# the npm ci layer in deps; nothing in the install depends on the real version.
+FROM ${NODE_IMAGE} AS pkgmeta
+
+WORKDIR /meta
+
+COPY package.json package-lock.json ./
+RUN node -e "const fs = require('fs'); \
+    for (const f of ['package.json', 'package-lock.json']) { \
+      const j = JSON.parse(fs.readFileSync(f, 'utf8')); \
+      j.version = '0.0.0'; \
+      if (j.packages) j.packages[''].version = '0.0.0'; \
+      fs.writeFileSync(f, JSON.stringify(j)); \
+    }"
+
+
 # deps
 FROM ${NODE_IMAGE} AS deps
 
@@ -10,7 +26,7 @@ WORKDIR /build
 # Install build deps for better-sqlite3 and sharp native modules
 RUN apk add --no-cache python3 make g++
 
-COPY package.json package-lock.json ./
+COPY --from=pkgmeta /meta/package.json /meta/package-lock.json ./
 # Default-deny install scripts; rebuild only the two native modules that need them.
 RUN npm ci --ignore-scripts \
     && npm rebuild better-sqlite3 sharp


### PR DESCRIPTION
Release builds were slow (today's hit 21 minutes before being cancelled) for three stacked reasons: arm64 built under QEMU emulation, version-bump commits invalidated the npm ci layer, and back-to-back pushes raced each other's layer cache.

## Changes

**Native arm64 builds.** The build job is now a matrix: amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm` (free for public repos). Each pushes by digest and a merge job stitches them into one multi-arch manifest, which gets the `sha-*` and `main` tags plus the provenance attestation. No more compiling better-sqlite3 under emulation, and the two arches build in parallel.

**Tag pushes promote instead of rebuilding.** A `v*` tag run no longer builds anything. It waits for the `sha-<sha>` image from the main-branch run of the same commit, then stamps the semver tags onto that digest. Releases are now bit-identical to the image already built, scanned, and attested from main, and the tag run takes under a minute.

**Same-ref runs queue.** A `concurrency` group serializes pushes to main, so a version-bump push right after a merge reuses the merge build's cache instead of racing it and rebuilding from scratch.

**Version bumps no longer bust the deps cache.** A new `pkgmeta` Dockerfile stage zeroes the `version` field in `package.json`/`package-lock.json` before the deps stage copies them, so bump-only commits cache-hit the entire `npm ci` + native rebuild layer.

## Verification

- `pkgmeta` stage built locally; both files normalized to `0.0.0`.
- Rebuilt the `deps` stage after bumping the version to `99.99.99`: the `npm ci` layer reports `CACHED`.
- `npm run lint` clean.
- The matrix/merge/promote paths can't run locally; the first push to main after merging exercises them. Note the arm64 cache scope starts empty, so the first arm64 build compiles fresh (natively, so a few minutes).

## Expected timings per release cycle

| Run | Before | After |
|---|---|---|
| PR merge to main | 5-9 min (up to 20+ on cache miss) | ~3-5 min, arches in parallel |
| Version bump push | 5-9 min | ~1-2 min (deps layer cached) |
| Tag push | ~2 min (cached rebuild) | <1 min (promote only) |