### PR TITLE
Documents with Paperless-ngx import (#95)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,31 +154,31 @@ ORIGIN=https://einvault.yourdomain.com
 # recent assets across the whole library.
 # IMMICH_ALBUM_ID=
 
-# Optional: paperless-ngx document import
+# Optional: Paperless-ngx document import
 #
-# When set, members and admins get an "Add from paperless" option on the
-# Documents tab that searches a paperless-ngx instance and attaches a document
-# by reference. The document stays in paperless; EinVault stores only a
+# When set, members and admins get an "Add from Paperless" option on the
+# Documents tab that searches a Paperless-ngx instance and attaches a document
+# by reference. The document stays in Paperless; EinVault stores only a
 # reference and proxies reads through the server using the token. EinVault
-# never uploads to or deletes from paperless. Caretakers cannot use the picker.
+# never uploads to or deletes from Paperless. Caretakers cannot use the picker.
 #
 # Both PAPERLESS_URL and PAPERLESS_API_TOKEN must be set together. If only one
 # is set, the integration is disabled and a warning is logged at startup.
 
-# Base URL of your paperless-ngx instance (no trailing slash).
+# Base URL of your Paperless-ngx instance (no trailing slash).
 # PAPERLESS_URL=http://paperless.your-lan:8000
 
-# API token. Generate in paperless under Settings → "My Profile". The token can
+# API token. Generate in Paperless under Settings → "My Profile". The token can
 # read every document its user can see, so use a dedicated user whose
 # permissions are limited to the documents you want EinVault to access.
 # PAPERLESS_API_TOKEN=
 
 # Optional but strongly recommended: restrict the picker and import to a single
-# paperless tag id. Without it, every EinVault member can search the whole
-# paperless library.
+# Paperless tag ID. Without it, every EinVault member can search the whole
+# Paperless library.
 # PAPERLESS_TAG_ID=
 
-# Maximum number of documents (uploads and paperless references combined) per
+# Maximum number of documents (uploads and Paperless references combined) per
 # companion. Defaults to 200.
 # MAX_DOCUMENTS_PER_COMPANION=200
 

--- a/.env.example
+++ b/.env.example
@@ -154,6 +154,34 @@ ORIGIN=https://einvault.yourdomain.com
 # recent assets across the whole library.
 # IMMICH_ALBUM_ID=
 
+# Optional: paperless-ngx document import
+#
+# When set, members and admins get an "Add from paperless" option on the
+# Documents tab that searches a paperless-ngx instance and attaches a document
+# by reference. The document stays in paperless; EinVault stores only a
+# reference and proxies reads through the server using the token. EinVault
+# never uploads to or deletes from paperless. Caretakers cannot use the picker.
+#
+# Both PAPERLESS_URL and PAPERLESS_API_TOKEN must be set together. If only one
+# is set, the integration is disabled and a warning is logged at startup.
+
+# Base URL of your paperless-ngx instance (no trailing slash).
+# PAPERLESS_URL=http://paperless.your-lan:8000
+
+# API token. Generate in paperless under Settings → "My Profile". The token can
+# read every document its user can see, so use a dedicated user whose
+# permissions are limited to the documents you want EinVault to access.
+# PAPERLESS_API_TOKEN=
+
+# Optional but strongly recommended: restrict the picker and import to a single
+# paperless tag id. Without it, every EinVault member can search the whole
+# paperless library.
+# PAPERLESS_TAG_ID=
+
+# Maximum number of documents (uploads and paperless references combined) per
+# companion. Defaults to 200.
+# MAX_DOCUMENTS_PER_COMPANION=200
+
 # Optional: OIDC authentication
 #
 # Enable single sign-on via any OpenID Connect provider (Authelia, Authentik,

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ EinVault is a private, self-hosted companion health and care tracker built for h
   - [Video transcoding (optional)](#video-transcoding-optional)
   - [External image storage (optional)](#external-image-storage-optional)
   - [Immich integration (optional)](#immich-integration-optional)
+  - [Documents](#documents)
+  - [Paperless-ngx integration (optional)](#paperless-ngx-integration-optional)
   - [SMTP email (optional)](#smtp-email-optional)
   - [ntfy push notifications (optional)](#ntfy-push-notifications-optional)
   - [Data and backup](#data-and-backup)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Everything else in the compose file can be edited directly:
 | `UPLOAD_MAX_MB`               | `10`                | Maximum size in MB for image (photo and avatar) uploads. `BODY_SIZE_LIMIT` is derived from the larger of this and `VIDEO_MAX_MB` at container start.       |
 | `VIDEO_MAX_MB`                | `100`               | Maximum size in MB for journal video uploads. Videos are stored as-is unless transcoding is enabled (see below).                                           |
 | `MAX_DAILY_MEDIA`             | `5`                 | Maximum number of journal photos and videos (combined) per companion per day. (Renamed from `MAX_DAILY_PHOTOS`, still honored with a deprecation warning.) |
-| `MAX_DOCUMENTS_PER_COMPANION` | `200`               | Maximum number of documents (uploads and paperless references combined) stored per companion.                                                              |
+| `MAX_DOCUMENTS_PER_COMPANION` | `200`               | Maximum number of documents (uploads and Paperless references combined) stored per companion.                                                              |
 | `REMINDER_UNDO_SECONDS`       | `7`                 | Default undo window (seconds) when dismissing a Reminder. `0` disables the undo window. Each user can override in their settings.                          |
 | `user`                        | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                                                  |
 | `./data` volume               | `./data`            | Where the database and uploads are stored on the host.                                                                                                     |
@@ -157,17 +157,17 @@ When `IMMICH_URL` and `IMMICH_API_KEY` are set, members and admins get a "Pick f
 
 Each companion has a Documents tab for receipts, invoices, vaccination records, and other paperwork. Members and admins can upload PDFs and images (JPEG, PNG, WebP, HEIC) up to `UPLOAD_MAX_MB`, sort them into categories, set a document date, and link a document to a health event. Uploaded images are re-encoded server-side to strip metadata; PDFs are stored as received. Documents are private to members and admins; caretakers have no access. PDFs preview in the browser without leaving the page.
 
-### paperless-ngx integration (optional)
+### Paperless-ngx integration (optional)
 
-When `PAPERLESS_URL` and `PAPERLESS_API_TOKEN` are set, members and admins get an "Add from paperless" option on the Documents tab that searches a [paperless-ngx](https://docs.paperless-ngx.com/) instance and attaches a document by reference. The document stays in paperless; EinVault stores only a reference and proxies reads through the server using the token. EinVault never uploads to or deletes from paperless. Caretakers cannot use the picker. EinVault serves the archived (OCR'd PDF) version of each referenced document.
+When `PAPERLESS_URL` and `PAPERLESS_API_TOKEN` are set, members and admins get an "Add from Paperless" option on the Documents tab that searches a [Paperless-ngx](https://docs.paperless-ngx.com/) instance and attaches a document by reference. The document stays in Paperless; EinVault stores only a reference and proxies reads through the server using the token. EinVault never uploads to or deletes from Paperless. Caretakers cannot use the picker. EinVault serves the archived (OCR'd PDF) version of each referenced document.
 
-The token can read every document its paperless user can see, and any member can then search and attach them. Set `PAPERLESS_TAG_ID` to limit the picker and import to one tag, and use a dedicated paperless user whose object permissions are restricted to that tag.
+The token can read every document its Paperless user can see, and any member can then search and attach them. Set `PAPERLESS_TAG_ID` to limit the picker and import to one tag, and use a dedicated Paperless user whose object permissions are restricted to that tag.
 
 |                       | Default | Description                                                                                                                                                         |
 | --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PAPERLESS_URL`       | —       | Base URL of your paperless-ngx instance, e.g. `http://paperless.local:8000`. No trailing slash. Required if `PAPERLESS_API_TOKEN` is set.                           |
-| `PAPERLESS_API_TOKEN` | —       | API token. Generate in paperless under Settings → "My Profile". Use a dedicated user limited to the documents you want visible. Required if `PAPERLESS_URL` is set. |
-| `PAPERLESS_TAG_ID`    | —       | If set, only documents carrying this paperless tag id can be searched and imported. Strongly recommended; without it every member can search the whole library.     |
+| `PAPERLESS_URL`       | —       | Base URL of your Paperless-ngx instance, e.g. `http://paperless.local:8000`. No trailing slash. Required if `PAPERLESS_API_TOKEN` is set.                           |
+| `PAPERLESS_API_TOKEN` | —       | API token. Generate in Paperless under Settings → "My Profile". Use a dedicated user limited to the documents you want visible. Required if `PAPERLESS_URL` is set. |
+| `PAPERLESS_TAG_ID`    | —       | If set, only documents carrying this Paperless tag ID can be searched and imported. Strongly recommended; without it every member can search the whole library.     |
 
 ### SMTP email (optional)
 

--- a/README.md
+++ b/README.md
@@ -90,16 +90,17 @@ Open your domain and follow the `/setup` prompt to create your admin account.
 
 Everything else in the compose file can be edited directly:
 
-|                         | Default             | Description                                                                                                                                                |
-| ----------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TZ`                    | `UTC`               | Container timezone. Set to your local timezone (e.g. `America/New_York`, `Europe/London`) so dates and times display correctly.                            |
-| `UPLOAD_MAX_MB`         | `10`                | Maximum size in MB for image (photo and avatar) uploads. `BODY_SIZE_LIMIT` is derived from the larger of this and `VIDEO_MAX_MB` at container start.       |
-| `VIDEO_MAX_MB`          | `100`               | Maximum size in MB for journal video uploads. Videos are stored as-is unless transcoding is enabled (see below).                                           |
-| `MAX_DAILY_MEDIA`       | `5`                 | Maximum number of journal photos and videos (combined) per companion per day. (Renamed from `MAX_DAILY_PHOTOS`, still honored with a deprecation warning.) |
-| `REMINDER_UNDO_SECONDS` | `7`                 | Default undo window (seconds) when dismissing a Reminder. `0` disables the undo window. Each user can override in their settings.                          |
-| `user`                  | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                                                  |
-| `./data` volume         | `./data`            | Where the database and uploads are stored on the host.                                                                                                     |
-| `DATABASE_URL`          | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                                             |
+|                               | Default             | Description                                                                                                                                                |
+| ----------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TZ`                          | `UTC`               | Container timezone. Set to your local timezone (e.g. `America/New_York`, `Europe/London`) so dates and times display correctly.                            |
+| `UPLOAD_MAX_MB`               | `10`                | Maximum size in MB for image (photo and avatar) uploads. `BODY_SIZE_LIMIT` is derived from the larger of this and `VIDEO_MAX_MB` at container start.       |
+| `VIDEO_MAX_MB`                | `100`               | Maximum size in MB for journal video uploads. Videos are stored as-is unless transcoding is enabled (see below).                                           |
+| `MAX_DAILY_MEDIA`             | `5`                 | Maximum number of journal photos and videos (combined) per companion per day. (Renamed from `MAX_DAILY_PHOTOS`, still honored with a deprecation warning.) |
+| `MAX_DOCUMENTS_PER_COMPANION` | `200`               | Maximum number of documents (uploads and paperless references combined) stored per companion.                                                              |
+| `REMINDER_UNDO_SECONDS`       | `7`                 | Default undo window (seconds) when dismissing a Reminder. `0` disables the undo window. Each user can override in their settings.                          |
+| `user`                        | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                                                  |
+| `./data` volume               | `./data`            | Where the database and uploads are stored on the host.                                                                                                     |
+| `DATABASE_URL`                | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                                             |
 
 ### Video transcoding (optional)
 
@@ -151,6 +152,22 @@ When `IMMICH_URL` and `IMMICH_API_KEY` are set, members and admins get a "Pick f
 | `IMMICH_URL`      | —       | Base URL of your Immich server, e.g. `http://immich.local:2283`. No trailing slash. Required if `IMMICH_API_KEY` is set.                                                                     |
 | `IMMICH_API_KEY`  | —       | API key. Required permissions: `asset.read`, `asset.view`, plus `album.read` if `IMMICH_ALBUM_ID` is set. Generate in Immich → Account Settings → API Keys. Required if `IMMICH_URL` is set. |
 | `IMMICH_ALBUM_ID` | —       | If set, the picker only shows assets in this album. If unset, the picker shows the user's most recent assets across the whole library.                                                       |
+
+### Documents
+
+Each companion has a Documents tab for receipts, invoices, vaccination records, and other paperwork. Members and admins can upload PDFs and images (JPEG, PNG, WebP, HEIC) up to `UPLOAD_MAX_MB`, sort them into categories, set a document date, and link a document to a health event. Uploaded images are re-encoded server-side to strip metadata; PDFs are stored as received. Documents are private to members and admins; caretakers have no access. PDFs preview in the browser without leaving the page.
+
+### paperless-ngx integration (optional)
+
+When `PAPERLESS_URL` and `PAPERLESS_API_TOKEN` are set, members and admins get an "Add from paperless" option on the Documents tab that searches a [paperless-ngx](https://docs.paperless-ngx.com/) instance and attaches a document by reference. The document stays in paperless; EinVault stores only a reference and proxies reads through the server using the token. EinVault never uploads to or deletes from paperless. Caretakers cannot use the picker. EinVault serves the archived (OCR'd PDF) version of each referenced document.
+
+The token can read every document its paperless user can see, and any member can then search and attach them. Set `PAPERLESS_TAG_ID` to limit the picker and import to one tag, and use a dedicated paperless user whose object permissions are restricted to that tag.
+
+|                       | Default | Description                                                                                                                                                         |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PAPERLESS_URL`       | —       | Base URL of your paperless-ngx instance, e.g. `http://paperless.local:8000`. No trailing slash. Required if `PAPERLESS_API_TOKEN` is set.                           |
+| `PAPERLESS_API_TOKEN` | —       | API token. Generate in paperless under Settings → "My Profile". Use a dedicated user limited to the documents you want visible. Required if `PAPERLESS_URL` is set. |
+| `PAPERLESS_TAG_ID`    | —       | If set, only documents carrying this paperless tag id can be searched and imported. Strongly recommended; without it every member can search the whole library.     |
 
 ### SMTP email (optional)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,7 +35,7 @@ services:
       VIDEO_MAX_MB: ${VIDEO_MAX_MB:-100}
       # Maximum journal photos and videos (combined) per companion per day.
       MAX_DAILY_MEDIA: ${MAX_DAILY_MEDIA:-5}
-      # Maximum documents (uploads and paperless references) per companion.
+      # Maximum documents (uploads and Paperless references) per companion.
       MAX_DOCUMENTS_PER_COMPANION: ${MAX_DOCUMENTS_PER_COMPANION:-200}
       # Default undo window (seconds) for dismissing a Reminder. 0 disables it.
       REMINDER_UNDO_SECONDS: ${REMINDER_UNDO_SECONDS:-7}
@@ -72,7 +72,7 @@ services:
       IMMICH_API_KEY: ${IMMICH_API_KEY:-}
       IMMICH_ALBUM_ID: ${IMMICH_ALBUM_ID:-}
 
-      # Optional: paperless-ngx document import (reference mode). Both URL and
+      # Optional: Paperless-ngx document import (reference mode). Both URL and
       # token must be set together for the picker to activate.
       PAPERLESS_URL: ${PAPERLESS_URL:-}
       PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,6 +35,8 @@ services:
       VIDEO_MAX_MB: ${VIDEO_MAX_MB:-100}
       # Maximum journal photos and videos (combined) per companion per day.
       MAX_DAILY_MEDIA: ${MAX_DAILY_MEDIA:-5}
+      # Maximum documents (uploads and paperless references) per companion.
+      MAX_DOCUMENTS_PER_COMPANION: ${MAX_DOCUMENTS_PER_COMPANION:-200}
       # Default undo window (seconds) for dismissing a Reminder. 0 disables it.
       REMINDER_UNDO_SECONDS: ${REMINDER_UNDO_SECONDS:-7}
 
@@ -69,6 +71,12 @@ services:
       IMMICH_URL: ${IMMICH_URL:-}
       IMMICH_API_KEY: ${IMMICH_API_KEY:-}
       IMMICH_ALBUM_ID: ${IMMICH_ALBUM_ID:-}
+
+      # Optional: paperless-ngx document import (reference mode). Both URL and
+      # token must be set together for the picker to activate.
+      PAPERLESS_URL: ${PAPERLESS_URL:-}
+      PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN:-}
+      PAPERLESS_TAG_ID: ${PAPERLESS_TAG_ID:-}
 
       # Optional: SMTP email. Enables outbound mail and the "Forgot password?"
       # flow. Disabled unless SMTP_HOST and SMTP_FROM are both set.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,6 +32,8 @@ services:
       VIDEO_MAX_MB: 100
       # Maximum journal photos and videos (combined) per companion per day.
       MAX_DAILY_MEDIA: 5
+      # Maximum documents (uploads and paperless references) per companion.
+      MAX_DOCUMENTS_PER_COMPANION: 200
       # Default undo window (seconds) for dismissing a Reminder. 0 disables it.
       # Each user can override in their settings.
       REMINDER_UNDO_SECONDS: 7
@@ -82,6 +84,16 @@ services:
       # IMMICH_API_KEY:
       # Optional: restrict picker to a single Immich album.
       # IMMICH_ALBUM_ID:
+
+      # Optional: paperless-ngx document import (reference mode)
+      # When set, members and admins can attach paperless documents to a
+      # companion. EinVault stores a reference and proxies reads through the
+      # token; it never uploads or deletes from paperless. Both URL and token
+      # must be set together.
+      # PAPERLESS_URL: http://paperless.local:8000
+      # PAPERLESS_API_TOKEN:
+      # Optional but recommended: restrict picker/import to a single tag id.
+      # PAPERLESS_TAG_ID:
 
       # Optional: SMTP email
       # Enables outbound mail and the self-service "Forgot password?" flow on

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
       VIDEO_MAX_MB: 100
       # Maximum journal photos and videos (combined) per companion per day.
       MAX_DAILY_MEDIA: 5
-      # Maximum documents (uploads and paperless references) per companion.
+      # Maximum documents (uploads and Paperless references) per companion.
       MAX_DOCUMENTS_PER_COMPANION: 200
       # Default undo window (seconds) for dismissing a Reminder. 0 disables it.
       # Each user can override in their settings.
@@ -85,14 +85,14 @@ services:
       # Optional: restrict picker to a single Immich album.
       # IMMICH_ALBUM_ID:
 
-      # Optional: paperless-ngx document import (reference mode)
-      # When set, members and admins can attach paperless documents to a
+      # Optional: Paperless-ngx document import (reference mode)
+      # When set, members and admins can attach Paperless documents to a
       # companion. EinVault stores a reference and proxies reads through the
-      # token; it never uploads or deletes from paperless. Both URL and token
+      # token; it never uploads or deletes from Paperless. Both URL and token
       # must be set together.
       # PAPERLESS_URL: http://paperless.local:8000
       # PAPERLESS_API_TOKEN:
-      # Optional but recommended: restrict picker/import to a single tag id.
+      # Optional but recommended: restrict picker/import to a single tag ID.
       # PAPERLESS_TAG_ID:
 
       # Optional: SMTP email

--- a/drizzle/0019_smart_dreaming_celestial.sql
+++ b/drizzle/0019_smart_dreaming_celestial.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `documents` (
+	`id` text PRIMARY KEY NOT NULL,
+	`companion_id` text NOT NULL,
+	`health_event_id` text,
+	`filename` text NOT NULL,
+	`provider` text DEFAULT 'local' NOT NULL,
+	`storage_key` text NOT NULL,
+	`title` text NOT NULL,
+	`category` text DEFAULT 'other' NOT NULL,
+	`document_date` text,
+	`original_name` text,
+	`mime_type` text NOT NULL,
+	`size_bytes` integer,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`uploaded_by` text,
+	FOREIGN KEY (`companion_id`) REFERENCES `companions`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`health_event_id`) REFERENCES `health_events`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`uploaded_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `document_companion_idx` ON `documents` (`companion_id`);--> statement-breakpoint
+CREATE INDEX `document_health_event_idx` ON `documents` (`health_event_id`);

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1725 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "81ee0618-94ad-4c9d-a7cc-1223ab93e557",
+  "prevId": "f7fad1fb-9066-49a4-aec3-e494e1a134df",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "health_event_id": {
+          "name": "health_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "document_date": {
+          "name": "document_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "document_companion_idx": {
+          "name": "document_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "document_health_event_idx": {
+          "name": "document_health_event_idx",
+          "columns": [
+            "health_event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "documents_companion_id_companions_id_fk": {
+          "name": "documents_companion_id_companions_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_health_event_id_health_events_id_fk": {
+          "name": "documents_health_event_id_health_events_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "health_events",
+          "columnsFrom": [
+            "health_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "documents_uploaded_by_users_id_fk": {
+          "name": "documents_uploaded_by_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'photo'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_key": {
+          "name": "poster_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_attempts": {
+          "name": "transcode_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        },
+        "photo_status_idx": {
+          "name": "photo_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_outbox": {
+      "name": "notification_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "outbox_dedupe_idx": {
+          "name": "outbox_dedupe_idx",
+          "columns": [
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_outbox_user_id_users_id_fk": {
+          "name": "notification_outbox_user_id_users_id_fk",
+          "tableFrom": "notification_outbox",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "password_reset_user_idx": {
+          "name": "password_reset_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_reminder_email": {
+          "name": "notify_reminder_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_shift_email": {
+          "name": "notify_shift_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "ntfy_topic": {
+          "name": "ntfy_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1780832729465,
       "tag": "0018_lucky_carlie_cooper",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1780881094924,
+      "tag": "0019_smart_dreaming_celestial",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"marked": "^18.0.3",
 				"nodemailer": "^8.0.10",
 				"openid-client": "^6.8.4",
+				"pdfjs-dist": "^6.0.227",
 				"sharp": "^0.34.5",
 				"tailwind-merge": "^3.5.0"
 			},
@@ -1492,6 +1493,271 @@
 			"license": "ISC",
 			"peerDependencies": {
 				"svelte": "^5"
+			}
+		},
+		"node_modules/@napi-rs/canvas": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.0.tgz",
+			"integrity": "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==",
+			"license": "MIT",
+			"optional": true,
+			"workspaces": [
+				"e2e/*"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas-android-arm64": "1.0.0",
+				"@napi-rs/canvas-darwin-arm64": "1.0.0",
+				"@napi-rs/canvas-darwin-x64": "1.0.0",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0",
+				"@napi-rs/canvas-linux-arm64-gnu": "1.0.0",
+				"@napi-rs/canvas-linux-arm64-musl": "1.0.0",
+				"@napi-rs/canvas-linux-riscv64-gnu": "1.0.0",
+				"@napi-rs/canvas-linux-x64-gnu": "1.0.0",
+				"@napi-rs/canvas-linux-x64-musl": "1.0.0",
+				"@napi-rs/canvas-win32-arm64-msvc": "1.0.0",
+				"@napi-rs/canvas-win32-x64-msvc": "1.0.0"
+			}
+		},
+		"node_modules/@napi-rs/canvas-android-arm64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.0.tgz",
+			"integrity": "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-arm64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.0.tgz",
+			"integrity": "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-x64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.0.tgz",
+			"integrity": "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.0.tgz",
+			"integrity": "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.0.tgz",
+			"integrity": "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.0.tgz",
+			"integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.0.tgz",
+			"integrity": "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.0.tgz",
+			"integrity": "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-musl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.0.tgz",
+			"integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.0.tgz",
+			"integrity": "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.0.tgz",
+			"integrity": "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -4930,6 +5196,18 @@
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/pdfjs-dist": {
+			"version": "6.0.227",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
+			"integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=22.13.0 || >=24"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas": "^1.0.0"
+			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"marked": "^18.0.3",
 		"nodemailer": "^8.0.10",
 		"openid-client": "^6.8.4",
+		"pdfjs-dist": "^6.0.227",
 		"sharp": "^0.34.5",
 		"tailwind-merge": "^3.5.0"
 	},

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -104,7 +104,7 @@ const securityHeaders: Handle = async ({ event, resolve }) => {
 };
 
 // asset routes skip cookie refresh so responses stay cacheable
-const ASSET_PATHS = ['/api/avatars/', '/api/photos/'];
+const ASSET_PATHS = ['/api/avatars/', '/api/photos/', '/api/documents/'];
 
 const authContext: Handle = async ({ event, resolve }) => {
 	const isAsset = ASSET_PATHS.some((p) => event.url.pathname.startsWith(p));

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -7,6 +7,7 @@ import { logOidcBootStatus } from '$lib/server/auth/oidc';
 import {
 	S3_CONFIG,
 	logImmichBootStatus,
+	logPaperlessBootStatus,
 	logStorageBootStatus,
 	logDeprecatedEnvWarnings,
 	logVideoTranscodeBootStatus,
@@ -19,6 +20,7 @@ import { startNotifyScheduler } from '$lib/server/notify/scheduler';
 logOidcBootStatus();
 logStorageBootStatus();
 logImmichBootStatus();
+logPaperlessBootStatus();
 logDeprecatedEnvWarnings();
 logVideoTranscodeBootStatus();
 logSmtpBootStatus();

--- a/src/lib/components/DocumentPreview.svelte
+++ b/src/lib/components/DocumentPreview.svelte
@@ -170,7 +170,7 @@
 						size="sm"
 						disabled={pageNum <= 1}
 						onclick={() => renderPage(pageNum - 1)}
-						aria-label="previous page"
+						aria-label={t(locale, 'aria.previousPage')}
 					>
 						<ChevronLeft class="h-4 w-4" />
 					</Button>
@@ -182,7 +182,7 @@
 						size="sm"
 						disabled={pageNum >= pageCount}
 						onclick={() => renderPage(pageNum + 1)}
-						aria-label="next page"
+						aria-label={t(locale, 'aria.nextPage')}
 					>
 						<ChevronRight class="h-4 w-4" />
 					</Button>

--- a/src/lib/components/DocumentPreview.svelte
+++ b/src/lib/components/DocumentPreview.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { tick } from 'svelte';
+	import { t, getLocale } from '$lib/i18n';
+	import { X, ChevronLeft, ChevronRight, Download, Loader2 } from '@lucide/svelte';
+
+	interface Props {
+		open: boolean;
+		url: string;
+		mimeType: string;
+		title: string;
+		onclose: () => void;
+	}
+
+	let { open, url, mimeType, title, onclose }: Props = $props();
+	const locale = getLocale();
+
+	let dialogEl = $state<HTMLElement | null>(null);
+	let triggerEl = $state<HTMLElement | null>(null);
+	let canvasEl = $state<HTMLCanvasElement | null>(null);
+	let loading = $state(false);
+	let failed = $state(false);
+	let pageNum = $state(1);
+	let pageCount = $state(0);
+	// pdfjs PDFDocumentProxy; typed loosely to keep the lazy import simple.
+	let pdfDoc = $state<any>(null);
+	let renderTask: { cancel: () => void } | null = null;
+
+	const isPdf = $derived(mimeType === 'application/pdf');
+
+	async function loadPdf() {
+		loading = true;
+		failed = false;
+		pdfDoc = null;
+		pageNum = 1;
+		pageCount = 0;
+		try {
+			const pdfjs = await import('pdfjs-dist');
+			const workerUrl = (await import('pdfjs-dist/build/pdf.worker.min.mjs?url')).default;
+			pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
+			// isEvalSupported: false — pdf.js parses attacker-supplied bytes in
+			// our origin; eval paths were the vector for CVE-2024-4367. The flag
+			// is honored at runtime but dropped from v6's published types, so the
+			// param object is asserted to the getDocument signature.
+			const task = pdfjs.getDocument({
+				url,
+				isEvalSupported: false
+			} as Parameters<typeof pdfjs.getDocument>[0]);
+			pdfDoc = await task.promise;
+			pageCount = pdfDoc.numPages;
+			// Flip loading BEFORE rendering: the canvas only mounts in the
+			// !loading branch, and renderPage awaits tick() to find it.
+			loading = false;
+			await renderPage(1);
+		} catch (err) {
+			console.error('[document-preview]', err);
+			failed = true;
+			loading = false;
+		}
+	}
+
+	async function renderPage(n: number) {
+		if (!pdfDoc) return;
+		await tick(); // canvas mounts after loading flips
+		if (!canvasEl) return;
+		renderTask?.cancel();
+		const page = await pdfDoc.getPage(n);
+		const containerWidth = Math.min(900, dialogEl?.clientWidth ?? 900) - 48;
+		const baseViewport = page.getViewport({ scale: 1 });
+		const scale = (containerWidth / baseViewport.width) * (window.devicePixelRatio || 1);
+		const viewport = page.getViewport({ scale });
+		canvasEl.width = viewport.width;
+		canvasEl.height = viewport.height;
+		canvasEl.style.width = `${viewport.width / (window.devicePixelRatio || 1)}px`;
+		const ctx = canvasEl.getContext('2d')!;
+		const task = page.render({ canvasContext: ctx, viewport });
+		renderTask = task;
+		await task.promise.catch(() => {});
+		pageNum = n;
+	}
+
+	// Track only `open`/`isPdf` in the effect body. Cleanup runs on close/unmount.
+	$effect(() => {
+		if (!open) {
+			tick().then(() => triggerEl?.focus());
+			return;
+		}
+		triggerEl = document.activeElement as HTMLElement | null;
+		if (isPdf) loadPdf();
+		tick().then(() => dialogEl?.focus());
+		return () => {
+			renderTask?.cancel();
+			pdfDoc?.destroy?.();
+			pdfDoc = null;
+		};
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onclose();
+		if (isPdf && e.key === 'ArrowRight' && pageNum < pageCount) renderPage(pageNum + 1);
+		if (isPdf && e.key === 'ArrowLeft' && pageNum > 1) renderPage(pageNum - 1);
+	}
+</script>
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center p-4"
+		role="presentation"
+		onkeydown={handleKeydown}
+	>
+		<div
+			role="presentation"
+			class="absolute inset-0 bg-black/60"
+			onclick={onclose}
+			onkeydown={() => {}}
+		></div>
+
+		<div
+			bind:this={dialogEl}
+			role="dialog"
+			aria-modal="true"
+			aria-label={title}
+			tabindex="-1"
+			class="relative z-10 w-full max-w-[920px] max-h-[90vh] rounded-lg border border-border bg-card shadow-lg flex flex-col"
+		>
+			<div class="flex items-center justify-between gap-2 px-5 py-3 border-b border-border">
+				<h2 class="font-semibold text-foreground truncate">{title}</h2>
+				<div class="flex items-center gap-1 shrink-0">
+					<a
+						href={`${url}?download`}
+						class="rounded-md p-1.5 hover:bg-accent text-muted-foreground"
+						aria-label={t(locale, 'page.documents.download')}
+					>
+						<Download class="h-4 w-4" />
+					</a>
+					<button
+						type="button"
+						class="rounded-md p-1.5 hover:bg-accent text-muted-foreground"
+						aria-label={t(locale, 'paperless.picker.close')}
+						onclick={onclose}
+					>
+						<X class="h-4 w-4" />
+					</button>
+				</div>
+			</div>
+
+			<div class="flex-1 overflow-auto p-4 flex items-start justify-center">
+				{#if isPdf}
+					{#if loading}
+						<div class="flex items-center gap-2 py-16 text-muted-foreground">
+							<Loader2 class="h-5 w-5 animate-spin" />
+							<span class="text-sm">{t(locale, 'page.documents.previewLoading')}</span>
+						</div>
+					{:else if failed}
+						<p class="py-16 text-sm text-muted-foreground">
+							{t(locale, 'page.documents.previewFailed')}
+						</p>
+					{:else}
+						<canvas bind:this={canvasEl} class="rounded shadow max-w-full"></canvas>
+					{/if}
+				{:else}
+					<img src={url} alt={title} class="max-w-full max-h-[75vh] rounded shadow" />
+				{/if}
+			</div>
+
+			{#if isPdf && pageCount > 1}
+				<div class="flex items-center justify-center gap-3 px-5 py-2.5 border-t border-border">
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={pageNum <= 1}
+						onclick={() => renderPage(pageNum - 1)}
+						aria-label="previous page"
+					>
+						<ChevronLeft class="h-4 w-4" />
+					</Button>
+					<span class="text-sm text-muted-foreground">
+						{t(locale, 'page.documents.pageOf', { page: pageNum, total: pageCount })}
+					</span>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={pageNum >= pageCount}
+						onclick={() => renderPage(pageNum + 1)}
+						aria-label="next page"
+					>
+						<ChevronRight class="h-4 w-4" />
+					</Button>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/PaperlessPicker.svelte
+++ b/src/lib/components/PaperlessPicker.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { tick } from 'svelte';
+	import { t, getLocale } from '$lib/i18n';
+	import { X, FileText, Loader2 } from '@lucide/svelte';
+
+	interface PaperlessDoc {
+		id: number;
+		title: string;
+		created: string | null;
+		archiveSerialNumber: string | null;
+	}
+
+	interface Props {
+		open: boolean;
+		onpick: (paperlessId: number) => void | Promise<void>;
+		onclose: () => void;
+	}
+
+	let { open, onpick, onclose }: Props = $props();
+	const locale = getLocale();
+
+	let dialogEl = $state<HTMLElement | null>(null);
+	let triggerEl = $state<HTMLElement | null>(null);
+
+	let docs = $state<PaperlessDoc[]>([]);
+	let query = $state('');
+	let loading = $state(false);
+	let loadingMore = $state(false);
+	let error = $state('');
+	let page = $state(1);
+	let hasNextPage = $state(false);
+	let tagScoped = $state(false);
+	let selecting = $state<number | null>(null);
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const PAGE_SIZE = 60;
+
+	async function loadPage(nextPage: number, append = false) {
+		if (append) loadingMore = true;
+		else loading = true;
+		error = '';
+		try {
+			let qs = `page=${nextPage}&pageSize=${PAGE_SIZE}`;
+			if (query.trim()) qs += `&query=${encodeURIComponent(query.trim())}`;
+			const res = await fetch(`/api/paperless/documents?${qs}`);
+			if (!res.ok) {
+				error = t(locale, 'paperless.picker.loadError');
+				return;
+			}
+			const data = (await res.json()) as {
+				items: PaperlessDoc[];
+				hasNextPage: boolean;
+				tagScoped: boolean;
+			};
+			docs = append ? [...docs, ...data.items] : data.items;
+			hasNextPage = data.hasNextPage;
+			tagScoped = data.tagScoped;
+			page = nextPage;
+		} catch {
+			error = t(locale, 'paperless.picker.loadError');
+		} finally {
+			loading = false;
+			loadingMore = false;
+		}
+	}
+
+	function onQueryInput(e: Event) {
+		query = (e.currentTarget as HTMLInputElement).value;
+		if (debounceTimer) clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(() => loadPage(1, false), 300);
+	}
+
+	$effect(() => {
+		if (open) {
+			triggerEl = document.activeElement as HTMLElement | null;
+			docs = [];
+			query = '';
+			page = 1;
+			hasNextPage = false;
+			error = '';
+			selecting = null;
+			loadPage(1, false);
+			tick().then(() => dialogEl?.focus());
+		} else {
+			tick().then(() => triggerEl?.focus());
+		}
+	});
+
+	$effect(() => () => {
+		if (debounceTimer) clearTimeout(debounceTimer);
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onclose();
+	}
+
+	async function handleScroll(e: Event) {
+		const el = e.currentTarget as HTMLElement;
+		if (loadingMore || !hasNextPage) return;
+		if (el.scrollHeight - el.scrollTop - el.clientHeight < 200) {
+			await loadPage(page + 1, true);
+		}
+	}
+
+	async function pick(id: number) {
+		if (selecting !== null) return;
+		selecting = id;
+		try {
+			await onpick(id);
+		} finally {
+			selecting = null;
+		}
+	}
+</script>
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center p-4"
+		role="presentation"
+		onkeydown={handleKeydown}
+	>
+		<div
+			role="presentation"
+			class="absolute inset-0 bg-black/50"
+			onclick={onclose}
+			onkeydown={() => {}}
+		></div>
+
+		<div
+			bind:this={dialogEl}
+			role="dialog"
+			aria-modal="true"
+			aria-label={t(locale, 'paperless.picker.title')}
+			tabindex="-1"
+			class="relative z-10 w-full max-w-3xl max-h-[85vh] rounded-lg border border-border bg-card shadow-lg flex flex-col"
+		>
+			<div class="flex items-center justify-between gap-3 px-5 py-3 border-b border-border">
+				<div class="min-w-0">
+					<h2 class="font-semibold text-foreground">{t(locale, 'paperless.picker.title')}</h2>
+					{#if tagScoped}
+						<p class="text-xs text-muted-foreground mt-0.5">
+							{t(locale, 'paperless.picker.tagScoped')}
+						</p>
+					{/if}
+				</div>
+				<button
+					type="button"
+					class="rounded-md p-1 hover:bg-accent text-muted-foreground"
+					aria-label={t(locale, 'paperless.picker.close')}
+					onclick={onclose}
+				>
+					<X class="h-4 w-4" />
+				</button>
+			</div>
+
+			<div class="px-5 py-2 border-b border-border">
+				<Input
+					type="search"
+					placeholder={t(locale, 'paperless.picker.searchPlaceholder')}
+					value={query}
+					oninput={onQueryInput}
+				/>
+			</div>
+
+			<div class="flex-1 overflow-y-auto p-4" onscroll={handleScroll}>
+				{#if error}
+					<div
+						role="alert"
+						class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300 mb-3"
+					>
+						{error}
+					</div>
+				{/if}
+
+				{#if loading}
+					<div class="flex items-center justify-center py-16 text-muted-foreground">
+						<Loader2 class="h-6 w-6 animate-spin" />
+					</div>
+				{:else if docs.length === 0}
+					<div class="flex flex-col items-center justify-center py-16 text-muted-foreground">
+						<FileText class="h-10 w-10 mb-3" />
+						<p class="text-sm">{t(locale, 'paperless.picker.empty')}</p>
+					</div>
+				{:else}
+					<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+						{#each docs as doc (doc.id)}
+							<button
+								type="button"
+								class="flex flex-col overflow-hidden rounded-md border border-border bg-stone-50 dark:bg-stone-900 transition-opacity hover:opacity-80 disabled:opacity-50 disabled:cursor-wait text-left"
+								onclick={() => pick(doc.id)}
+								disabled={selecting === doc.id}
+								title={doc.title}
+							>
+								<div class="relative aspect-[3/4] bg-stone-100 dark:bg-stone-800">
+									<img
+										src={`/api/paperless/thumb/${doc.id}`}
+										alt={doc.title}
+										class="w-full h-full object-cover"
+										loading="lazy"
+									/>
+									{#if selecting === doc.id}
+										<div class="absolute inset-0 flex items-center justify-center bg-black/40">
+											<Loader2 class="h-5 w-5 animate-spin text-white" />
+										</div>
+									{/if}
+								</div>
+								<div class="px-2 py-1.5">
+									<p class="text-xs font-medium text-foreground truncate">{doc.title}</p>
+									{#if doc.created}
+										<p class="text-[11px] text-muted-foreground">{doc.created.slice(0, 10)}</p>
+									{/if}
+								</div>
+							</button>
+						{/each}
+					</div>
+
+					{#if loadingMore}
+						<div class="flex items-center justify-center py-4 text-muted-foreground">
+							<Loader2 class="h-4 w-4 animate-spin" />
+						</div>
+					{/if}
+				{/if}
+			</div>
+
+			<div class="flex justify-end gap-2 px-5 py-3 border-t border-border">
+				<Button variant="outline" size="sm" onclick={onclose}>
+					{t(locale, 'paperless.picker.cancel')}
+				</Button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/PaperlessPicker.svelte
+++ b/src/lib/components/PaperlessPicker.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
-	import { tick } from 'svelte';
+	import { tick, untrack } from 'svelte';
 	import { t, getLocale } from '$lib/i18n';
 	import { X, FileText, Loader2 } from '@lucide/svelte';
 
@@ -81,7 +81,10 @@
 			hasNextPage = false;
 			error = '';
 			selecting = null;
-			loadPage(1, false);
+			// untrack: loadPage reads `query` synchronously (before its first
+			// await), which would otherwise make this open-effect depend on
+			// `query` and re-run on every keystroke, clearing the search field.
+			untrack(() => loadPage(1, false));
 			tick().then(() => dialogEl?.focus());
 		} else {
 			tick().then(() => triggerEl?.focus());

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -172,6 +172,7 @@ const messages: Record<keyof Messages, string> = {
 	'nav.journal': 'Tagebuch',
 	'nav.health': 'Gesundheit',
 	'nav.reminders': 'Erinnerungen',
+	'nav.documents': 'Dokumente',
 	'nav.settings': 'Einstellungen',
 	'nav.admin': 'Verwaltung',
 	'nav.signOut': 'Abmelden',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -818,7 +818,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.download': 'Herunterladen',
 	'page.documents.view': 'Ansehen',
 	'page.documents.delete': 'Löschen',
-	'page.documents.deleteConfirm': 'Dieses Dokument löschen?',
 	'page.documents.deleteConfirmBody':
 		'Das Dokument wird aus EinVault entfernt. Paperless-Dokumente werden nicht aus Paperless gelöscht.',
 	'page.documents.editTitle': 'Dokument bearbeiten',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -164,6 +164,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidGifFile': 'Ungültige GIF-Datei',
 	'error.maxMediaExceeded': 'Maximal {max} Fotos oder Videos pro Tag',
 	'error.requestBodyTooLarge': 'Anfrage zu groß',
+	'error.maxDocumentsExceeded': 'Dokumentlimit erreicht (max. {max} pro Begleiter)',
 
 	// Navigation
 	'nav.dashboard': 'Übersicht',
@@ -790,7 +791,53 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Auswahl schließen',
 	'immich.picker.loadError': 'Immich-Bibliothek konnte nicht geladen werden.',
 	'immich.picker.button': 'Aus Immich auswählen',
-	'immich.picker.pickFailed': 'Immich-Inhalt konnte nicht angehängt werden.'
+	'immich.picker.pickFailed': 'Immich-Inhalt konnte nicht angehängt werden.',
+
+	// Paperless picker
+	'paperless.picker.title': 'Aus paperless auswählen',
+	'paperless.picker.tagScoped': 'Es werden Dokumente mit dem konfigurierten Tag angezeigt.',
+	'paperless.picker.empty': 'Keine Dokumente in paperless gefunden.',
+	'paperless.picker.searchPlaceholder': 'Dokumente suchen…',
+	'paperless.picker.cancel': 'Abbrechen',
+	'paperless.picker.close': 'Auswahl schließen',
+	'paperless.picker.loadError': 'paperless-Bibliothek konnte nicht geladen werden.',
+	'paperless.picker.button': 'Aus paperless hinzufügen',
+	'paperless.picker.pickFailed': 'paperless-Dokument konnte nicht angehängt werden.',
+
+	// Page: Documents
+	'page.documents.title': 'Dokumente',
+	'page.documents.empty': 'Noch keine Dokumente.',
+	'page.documents.upload': 'Dokument hochladen',
+	'page.documents.uploading': 'Wird hochgeladen…',
+	'page.documents.dropHint': 'PDF oder Bild, bis zu {max}MB',
+	'page.documents.filterAll': 'Alle Kategorien',
+	'page.documents.linkedEvent': 'Verknüpftes Gesundheitsereignis',
+	'page.documents.noLinkedEvent': 'Nicht verknüpft',
+	'page.documents.download': 'Herunterladen',
+	'page.documents.view': 'Ansehen',
+	'page.documents.delete': 'Löschen',
+	'page.documents.deleteConfirm': 'Dieses Dokument löschen?',
+	'page.documents.deleteConfirmBody':
+		'Das Dokument wird aus EinVault entfernt. paperless-Dokumente werden nicht aus paperless gelöscht.',
+	'page.documents.editTitle': 'Dokument bearbeiten',
+	'page.documents.labelTitle': 'Titel',
+	'page.documents.labelCategory': 'Kategorie',
+	'page.documents.labelDate': 'Dokumentdatum',
+	'page.documents.save': 'Speichern',
+	'page.documents.saveFailed': 'Änderungen konnten nicht gespeichert werden.',
+	'page.documents.uploadFailed': 'Upload fehlgeschlagen.',
+	'page.documents.previewLoading': 'Vorschau wird geladen…',
+	'page.documents.previewFailed': 'Vorschau konnte nicht angezeigt werden. Bitte herunterladen.',
+	'page.documents.pageOf': 'Seite {page} von {total}',
+	'page.documents.fromPaperless': 'paperless',
+
+	// Enum: Document categories
+	'documents.category.receipt': 'Quittung',
+	'documents.category.invoice': 'Rechnung',
+	'documents.category.medical': 'Medizinisch',
+	'documents.category.insurance': 'Versicherung',
+	'documents.category.ownership': 'Eigentum',
+	'documents.category.other': 'Sonstiges'
 
 	// Meta
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -794,15 +794,15 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.pickFailed': 'Immich-Inhalt konnte nicht angehängt werden.',
 
 	// Paperless picker
-	'paperless.picker.title': 'Aus paperless auswählen',
+	'paperless.picker.title': 'Aus Paperless auswählen',
 	'paperless.picker.tagScoped': 'Es werden Dokumente mit dem konfigurierten Tag angezeigt.',
-	'paperless.picker.empty': 'Keine Dokumente in paperless gefunden.',
+	'paperless.picker.empty': 'Keine Dokumente in Paperless gefunden.',
 	'paperless.picker.searchPlaceholder': 'Dokumente suchen…',
 	'paperless.picker.cancel': 'Abbrechen',
 	'paperless.picker.close': 'Auswahl schließen',
-	'paperless.picker.loadError': 'paperless-Bibliothek konnte nicht geladen werden.',
-	'paperless.picker.button': 'Aus paperless hinzufügen',
-	'paperless.picker.pickFailed': 'paperless-Dokument konnte nicht angehängt werden.',
+	'paperless.picker.loadError': 'Paperless-Bibliothek konnte nicht geladen werden.',
+	'paperless.picker.button': 'Aus Paperless hinzufügen',
+	'paperless.picker.pickFailed': 'Paperless-Dokument konnte nicht angehängt werden.',
 
 	// Page: Documents
 	'page.documents.title': 'Dokumente',
@@ -818,7 +818,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.delete': 'Löschen',
 	'page.documents.deleteConfirm': 'Dieses Dokument löschen?',
 	'page.documents.deleteConfirmBody':
-		'Das Dokument wird aus EinVault entfernt. paperless-Dokumente werden nicht aus paperless gelöscht.',
+		'Das Dokument wird aus EinVault entfernt. Paperless-Dokumente werden nicht aus Paperless gelöscht.',
 	'page.documents.editTitle': 'Dokument bearbeiten',
 	'page.documents.labelTitle': 'Titel',
 	'page.documents.labelCategory': 'Kategorie',
@@ -829,7 +829,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.previewLoading': 'Vorschau wird geladen…',
 	'page.documents.previewFailed': 'Vorschau konnte nicht angezeigt werden. Bitte herunterladen.',
 	'page.documents.pageOf': 'Seite {page} von {total}',
-	'page.documents.fromPaperless': 'paperless',
+	'page.documents.fromPaperless': 'Paperless',
 
 	// Enum: Document categories
 	'documents.category.receipt': 'Quittung',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -807,6 +807,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: Documents
 	'page.documents.title': 'Dokumente',
+	'page.documents.archivedNotice': '{name} ist archiviert. Nur-Lese-Modus.',
 	'page.documents.empty': 'Noch keine Dokumente.',
 	'page.documents.upload': 'Dokument hochladen',
 	'page.documents.uploading': 'Wird hochgeladen…',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -757,6 +757,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.close': 'Schließen',
 	'aria.previousMedia': 'Vorheriges Medium',
 	'aria.nextMedia': 'Nächstes Medium',
+	'aria.previousPage': 'Vorherige Seite',
+	'aria.nextPage': 'Nächste Seite',
 	'aria.viewPhoto': '{name}s Foto anzeigen',
 
 	// Email: password reset

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -159,6 +159,7 @@ const messages = {
 	'nav.journal': 'Journal',
 	'nav.health': 'Health',
 	'nav.reminders': 'Reminders',
+	'nav.documents': 'Documents',
 	'nav.settings': 'Settings',
 	'nav.admin': 'Admin',
 	'nav.signOut': 'Sign Out',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -748,6 +748,8 @@ const messages = {
 	'aria.close': 'Close',
 	'aria.previousMedia': 'Previous media',
 	'aria.nextMedia': 'Next media',
+	'aria.previousPage': 'Previous page',
+	'aria.nextPage': 'Next page',
 	'aria.viewPhoto': "View {name}'s photo",
 
 	// Email: password reset

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -151,6 +151,7 @@ const messages = {
 	'error.invalidGifFile': 'Invalid GIF file',
 	'error.maxMediaExceeded': 'Maximum {max} photos or videos per day',
 	'error.requestBodyTooLarge': 'Request body too large',
+	'error.maxDocumentsExceeded': 'Document limit reached (max {max} per companion)',
 
 	// Navigation
 	'nav.dashboard': 'Dashboard',
@@ -782,7 +783,53 @@ const messages = {
 	'immich.picker.close': 'Close picker',
 	'immich.picker.loadError': 'Could not load Immich library.',
 	'immich.picker.button': 'Pick from Immich',
-	'immich.picker.pickFailed': 'Could not attach Immich asset.'
+	'immich.picker.pickFailed': 'Could not attach Immich asset.',
+
+	// Paperless picker
+	'paperless.picker.title': 'Pick from paperless',
+	'paperless.picker.tagScoped': 'Showing documents with the configured tag.',
+	'paperless.picker.empty': 'No documents found in paperless.',
+	'paperless.picker.searchPlaceholder': 'Search documents…',
+	'paperless.picker.cancel': 'Cancel',
+	'paperless.picker.close': 'Close picker',
+	'paperless.picker.loadError': 'Could not load paperless library.',
+	'paperless.picker.button': 'Add from paperless',
+	'paperless.picker.pickFailed': 'Could not attach paperless document.',
+
+	// Page: Documents
+	'page.documents.title': 'Documents',
+	'page.documents.empty': 'No documents yet.',
+	'page.documents.upload': 'Upload document',
+	'page.documents.uploading': 'Uploading…',
+	'page.documents.dropHint': 'PDF or image, up to {max}MB',
+	'page.documents.filterAll': 'All categories',
+	'page.documents.linkedEvent': 'Linked health event',
+	'page.documents.noLinkedEvent': 'Not linked',
+	'page.documents.download': 'Download',
+	'page.documents.view': 'View',
+	'page.documents.delete': 'Delete',
+	'page.documents.deleteConfirm': 'Delete this document?',
+	'page.documents.deleteConfirmBody':
+		'This removes the document from EinVault. Paperless documents are not deleted from paperless.',
+	'page.documents.editTitle': 'Edit document',
+	'page.documents.labelTitle': 'Title',
+	'page.documents.labelCategory': 'Category',
+	'page.documents.labelDate': 'Document date',
+	'page.documents.save': 'Save',
+	'page.documents.saveFailed': 'Could not save changes.',
+	'page.documents.uploadFailed': 'Upload failed.',
+	'page.documents.previewLoading': 'Loading preview…',
+	'page.documents.previewFailed': 'Could not render preview. Use Download instead.',
+	'page.documents.pageOf': 'Page {page} of {total}',
+	'page.documents.fromPaperless': 'paperless',
+
+	// Enum: Document categories
+	'documents.category.receipt': 'Receipt',
+	'documents.category.invoice': 'Invoice',
+	'documents.category.medical': 'Medical',
+	'documents.category.insurance': 'Insurance',
+	'documents.category.ownership': 'Ownership',
+	'documents.category.other': 'Other'
 
 	// Meta
 } as const;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -810,7 +810,6 @@ const messages = {
 	'page.documents.download': 'Download',
 	'page.documents.view': 'View',
 	'page.documents.delete': 'Delete',
-	'page.documents.deleteConfirm': 'Delete this document?',
 	'page.documents.deleteConfirmBody':
 		'This removes the document from EinVault. Paperless documents are not deleted from Paperless.',
 	'page.documents.editTitle': 'Edit document',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -786,15 +786,15 @@ const messages = {
 	'immich.picker.pickFailed': 'Could not attach Immich asset.',
 
 	// Paperless picker
-	'paperless.picker.title': 'Pick from paperless',
+	'paperless.picker.title': 'Pick from Paperless',
 	'paperless.picker.tagScoped': 'Showing documents with the configured tag.',
-	'paperless.picker.empty': 'No documents found in paperless.',
+	'paperless.picker.empty': 'No documents found in Paperless.',
 	'paperless.picker.searchPlaceholder': 'Search documents…',
 	'paperless.picker.cancel': 'Cancel',
 	'paperless.picker.close': 'Close picker',
-	'paperless.picker.loadError': 'Could not load paperless library.',
-	'paperless.picker.button': 'Add from paperless',
-	'paperless.picker.pickFailed': 'Could not attach paperless document.',
+	'paperless.picker.loadError': 'Could not load Paperless library.',
+	'paperless.picker.button': 'Add from Paperless',
+	'paperless.picker.pickFailed': 'Could not attach Paperless document.',
 
 	// Page: Documents
 	'page.documents.title': 'Documents',
@@ -810,7 +810,7 @@ const messages = {
 	'page.documents.delete': 'Delete',
 	'page.documents.deleteConfirm': 'Delete this document?',
 	'page.documents.deleteConfirmBody':
-		'This removes the document from EinVault. Paperless documents are not deleted from paperless.',
+		'This removes the document from EinVault. Paperless documents are not deleted from Paperless.',
 	'page.documents.editTitle': 'Edit document',
 	'page.documents.labelTitle': 'Title',
 	'page.documents.labelCategory': 'Category',
@@ -821,7 +821,7 @@ const messages = {
 	'page.documents.previewLoading': 'Loading preview…',
 	'page.documents.previewFailed': 'Could not render preview. Use Download instead.',
 	'page.documents.pageOf': 'Page {page} of {total}',
-	'page.documents.fromPaperless': 'paperless',
+	'page.documents.fromPaperless': 'Paperless',
 
 	// Enum: Document categories
 	'documents.category.receipt': 'Receipt',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -799,6 +799,7 @@ const messages = {
 
 	// Page: Documents
 	'page.documents.title': 'Documents',
+	'page.documents.archivedNotice': '{name} is archived. Viewing in read-only mode.',
 	'page.documents.empty': 'No documents yet.',
 	'page.documents.upload': 'Upload document',
 	'page.documents.uploading': 'Uploading…',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -794,15 +794,15 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.pickFailed': 'No se pudo adjuntar el elemento de Immich.',
 
 	// Paperless picker
-	'paperless.picker.title': 'Elegir desde paperless',
+	'paperless.picker.title': 'Elegir desde Paperless',
 	'paperless.picker.tagScoped': 'Mostrando documentos con la etiqueta configurada.',
-	'paperless.picker.empty': 'No se encontraron documentos en paperless.',
+	'paperless.picker.empty': 'No se encontraron documentos en Paperless.',
 	'paperless.picker.searchPlaceholder': 'Buscar documentos…',
 	'paperless.picker.cancel': 'Cancelar',
 	'paperless.picker.close': 'Cerrar selector',
-	'paperless.picker.loadError': 'No se pudo cargar la biblioteca de paperless.',
-	'paperless.picker.button': 'Añadir desde paperless',
-	'paperless.picker.pickFailed': 'No se pudo adjuntar el documento de paperless.',
+	'paperless.picker.loadError': 'No se pudo cargar la biblioteca de Paperless.',
+	'paperless.picker.button': 'Añadir desde Paperless',
+	'paperless.picker.pickFailed': 'No se pudo adjuntar el documento de Paperless.',
 
 	// Page: Documents
 	'page.documents.title': 'Documentos',
@@ -818,7 +818,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.delete': 'Eliminar',
 	'page.documents.deleteConfirm': '¿Eliminar este documento?',
 	'page.documents.deleteConfirmBody':
-		'Esto elimina el documento de EinVault. Los documentos de paperless no se eliminan de paperless.',
+		'Esto elimina el documento de EinVault. Los documentos de Paperless no se eliminan de Paperless.',
 	'page.documents.editTitle': 'Editar documento',
 	'page.documents.labelTitle': 'Título',
 	'page.documents.labelCategory': 'Categoría',
@@ -829,7 +829,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.previewLoading': 'Cargando vista previa…',
 	'page.documents.previewFailed': 'No se pudo mostrar la vista previa. Usa Descargar en su lugar.',
 	'page.documents.pageOf': 'Página {page} de {total}',
-	'page.documents.fromPaperless': 'paperless',
+	'page.documents.fromPaperless': 'Paperless',
 
 	// Enum: Document categories
 	'documents.category.receipt': 'Recibo',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -172,6 +172,7 @@ const messages: Record<keyof Messages, string> = {
 	'nav.journal': 'Diario',
 	'nav.health': 'Salud',
 	'nav.reminders': 'Recordatorios',
+	'nav.documents': 'Documentos',
 	'nav.settings': 'Ajustes',
 	'nav.admin': 'Administración',
 	'nav.signOut': 'Cerrar sesión',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -807,6 +807,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: Documents
 	'page.documents.title': 'Documentos',
+	'page.documents.archivedNotice': '{name} está archivado. Modo de solo lectura.',
 	'page.documents.empty': 'Aún no hay documentos.',
 	'page.documents.upload': 'Subir documento',
 	'page.documents.uploading': 'Subiendo…',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -164,6 +164,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidGifFile': 'Archivo GIF no válido',
 	'error.maxMediaExceeded': 'Máximo {max} fotos o vídeos por día',
 	'error.requestBodyTooLarge': 'Solicitud demasiado grande',
+	'error.maxDocumentsExceeded': 'Límite de documentos alcanzado (máx. {max} por compañero)',
 
 	// Navigation
 	'nav.dashboard': 'Panel',
@@ -790,7 +791,53 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Cerrar selector',
 	'immich.picker.loadError': 'No se pudo cargar la biblioteca de Immich.',
 	'immich.picker.button': 'Elegir desde Immich',
-	'immich.picker.pickFailed': 'No se pudo adjuntar el elemento de Immich.'
+	'immich.picker.pickFailed': 'No se pudo adjuntar el elemento de Immich.',
+
+	// Paperless picker
+	'paperless.picker.title': 'Elegir desde paperless',
+	'paperless.picker.tagScoped': 'Mostrando documentos con la etiqueta configurada.',
+	'paperless.picker.empty': 'No se encontraron documentos en paperless.',
+	'paperless.picker.searchPlaceholder': 'Buscar documentos…',
+	'paperless.picker.cancel': 'Cancelar',
+	'paperless.picker.close': 'Cerrar selector',
+	'paperless.picker.loadError': 'No se pudo cargar la biblioteca de paperless.',
+	'paperless.picker.button': 'Añadir desde paperless',
+	'paperless.picker.pickFailed': 'No se pudo adjuntar el documento de paperless.',
+
+	// Page: Documents
+	'page.documents.title': 'Documentos',
+	'page.documents.empty': 'Aún no hay documentos.',
+	'page.documents.upload': 'Subir documento',
+	'page.documents.uploading': 'Subiendo…',
+	'page.documents.dropHint': 'PDF o imagen, hasta {max}MB',
+	'page.documents.filterAll': 'Todas las categorías',
+	'page.documents.linkedEvent': 'Evento de salud vinculado',
+	'page.documents.noLinkedEvent': 'Sin vincular',
+	'page.documents.download': 'Descargar',
+	'page.documents.view': 'Ver',
+	'page.documents.delete': 'Eliminar',
+	'page.documents.deleteConfirm': '¿Eliminar este documento?',
+	'page.documents.deleteConfirmBody':
+		'Esto elimina el documento de EinVault. Los documentos de paperless no se eliminan de paperless.',
+	'page.documents.editTitle': 'Editar documento',
+	'page.documents.labelTitle': 'Título',
+	'page.documents.labelCategory': 'Categoría',
+	'page.documents.labelDate': 'Fecha del documento',
+	'page.documents.save': 'Guardar',
+	'page.documents.saveFailed': 'No se pudieron guardar los cambios.',
+	'page.documents.uploadFailed': 'Error al subir.',
+	'page.documents.previewLoading': 'Cargando vista previa…',
+	'page.documents.previewFailed': 'No se pudo mostrar la vista previa. Usa Descargar en su lugar.',
+	'page.documents.pageOf': 'Página {page} de {total}',
+	'page.documents.fromPaperless': 'paperless',
+
+	// Enum: Document categories
+	'documents.category.receipt': 'Recibo',
+	'documents.category.invoice': 'Factura',
+	'documents.category.medical': 'Médico',
+	'documents.category.insurance': 'Seguro',
+	'documents.category.ownership': 'Propiedad',
+	'documents.category.other': 'Otro'
 
 	// Meta
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -757,6 +757,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.close': 'Cerrar',
 	'aria.previousMedia': 'Contenido anterior',
 	'aria.nextMedia': 'Contenido siguiente',
+	'aria.previousPage': 'Página anterior',
+	'aria.nextPage': 'Página siguiente',
 	'aria.viewPhoto': 'Ver foto de {name}',
 
 	// Email: password reset

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -818,7 +818,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.download': 'Descargar',
 	'page.documents.view': 'Ver',
 	'page.documents.delete': 'Eliminar',
-	'page.documents.deleteConfirm': '¿Eliminar este documento?',
 	'page.documents.deleteConfirmBody':
 		'Esto elimina el documento de EinVault. Los documentos de Paperless no se eliminan de Paperless.',
 	'page.documents.editTitle': 'Editar documento',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -809,6 +809,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: Documents
 	'page.documents.title': 'Documents',
+	'page.documents.archivedNotice': '{name} est archivé. Mode lecture seule.',
 	'page.documents.empty': 'Aucun document pour le moment.',
 	'page.documents.upload': 'Téléverser un document',
 	'page.documents.uploading': 'Téléversement…',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -759,6 +759,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.close': 'Fermer',
 	'aria.previousMedia': 'Média précédent',
 	'aria.nextMedia': 'Média suivant',
+	'aria.previousPage': 'Page précédente',
+	'aria.nextPage': 'Page suivante',
 	'aria.viewPhoto': 'Voir la photo de {name}',
 
 	// Email: password reset

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -796,15 +796,15 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.pickFailed': "Impossible d'attacher l'élément Immich.",
 
 	// Paperless picker
-	'paperless.picker.title': 'Choisir depuis paperless',
+	'paperless.picker.title': 'Choisir depuis Paperless',
 	'paperless.picker.tagScoped': 'Affichage des documents avec le tag configuré.',
-	'paperless.picker.empty': 'Aucun document trouvé dans paperless.',
+	'paperless.picker.empty': 'Aucun document trouvé dans Paperless.',
 	'paperless.picker.searchPlaceholder': 'Rechercher des documents…',
 	'paperless.picker.cancel': 'Annuler',
 	'paperless.picker.close': 'Fermer le sélecteur',
-	'paperless.picker.loadError': 'Impossible de charger la bibliothèque paperless.',
-	'paperless.picker.button': 'Ajouter depuis paperless',
-	'paperless.picker.pickFailed': "Impossible d'attacher le document paperless.",
+	'paperless.picker.loadError': 'Impossible de charger la bibliothèque Paperless.',
+	'paperless.picker.button': 'Ajouter depuis Paperless',
+	'paperless.picker.pickFailed': "Impossible d'attacher le document Paperless.",
 
 	// Page: Documents
 	'page.documents.title': 'Documents',
@@ -820,7 +820,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.delete': 'Supprimer',
 	'page.documents.deleteConfirm': 'Supprimer ce document ?',
 	'page.documents.deleteConfirmBody':
-		"Ce document sera supprimé d'EinVault. Les documents paperless ne sont pas supprimés de paperless.",
+		"Ce document sera supprimé d'EinVault. Les documents Paperless ne sont pas supprimés de Paperless.",
 	'page.documents.editTitle': 'Modifier le document',
 	'page.documents.labelTitle': 'Titre',
 	'page.documents.labelCategory': 'Catégorie',
@@ -831,7 +831,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.previewLoading': "Chargement de l'aperçu…",
 	'page.documents.previewFailed': "Impossible d'afficher l'aperçu. Utilisez Télécharger.",
 	'page.documents.pageOf': 'Page {page} sur {total}',
-	'page.documents.fromPaperless': 'paperless',
+	'page.documents.fromPaperless': 'Paperless',
 
 	// Enum: Document categories
 	'documents.category.receipt': 'Reçu',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -170,6 +170,7 @@ const messages: Record<keyof Messages, string> = {
 	'nav.journal': 'Journal',
 	'nav.health': 'Santé',
 	'nav.reminders': 'Rappels',
+	'nav.documents': 'Documents',
 	'nav.settings': 'Paramètres',
 	'nav.admin': 'Administration',
 	'nav.signOut': 'Se déconnecter',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -162,6 +162,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidGifFile': 'Fichier GIF invalide',
 	'error.maxMediaExceeded': 'Maximum {max} photos ou vidéos par jour',
 	'error.requestBodyTooLarge': 'Requête trop volumineuse',
+	'error.maxDocumentsExceeded': 'Limite de documents atteinte (max {max} par compagnon)',
 
 	// Navigation
 	'nav.dashboard': 'Tableau de bord',
@@ -792,7 +793,53 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Fermer le sélecteur',
 	'immich.picker.loadError': 'Impossible de charger la bibliothèque Immich.',
 	'immich.picker.button': 'Choisir depuis Immich',
-	'immich.picker.pickFailed': "Impossible d'attacher l'élément Immich."
+	'immich.picker.pickFailed': "Impossible d'attacher l'élément Immich.",
+
+	// Paperless picker
+	'paperless.picker.title': 'Choisir depuis paperless',
+	'paperless.picker.tagScoped': 'Affichage des documents avec le tag configuré.',
+	'paperless.picker.empty': 'Aucun document trouvé dans paperless.',
+	'paperless.picker.searchPlaceholder': 'Rechercher des documents…',
+	'paperless.picker.cancel': 'Annuler',
+	'paperless.picker.close': 'Fermer le sélecteur',
+	'paperless.picker.loadError': 'Impossible de charger la bibliothèque paperless.',
+	'paperless.picker.button': 'Ajouter depuis paperless',
+	'paperless.picker.pickFailed': "Impossible d'attacher le document paperless.",
+
+	// Page: Documents
+	'page.documents.title': 'Documents',
+	'page.documents.empty': 'Aucun document pour le moment.',
+	'page.documents.upload': 'Téléverser un document',
+	'page.documents.uploading': 'Téléversement…',
+	'page.documents.dropHint': "PDF ou image, jusqu'à {max}Mo",
+	'page.documents.filterAll': 'Toutes les catégories',
+	'page.documents.linkedEvent': 'Événement de santé lié',
+	'page.documents.noLinkedEvent': 'Non lié',
+	'page.documents.download': 'Télécharger',
+	'page.documents.view': 'Voir',
+	'page.documents.delete': 'Supprimer',
+	'page.documents.deleteConfirm': 'Supprimer ce document ?',
+	'page.documents.deleteConfirmBody':
+		"Ce document sera supprimé d'EinVault. Les documents paperless ne sont pas supprimés de paperless.",
+	'page.documents.editTitle': 'Modifier le document',
+	'page.documents.labelTitle': 'Titre',
+	'page.documents.labelCategory': 'Catégorie',
+	'page.documents.labelDate': 'Date du document',
+	'page.documents.save': 'Enregistrer',
+	'page.documents.saveFailed': "Impossible d'enregistrer les modifications.",
+	'page.documents.uploadFailed': 'Échec du téléversement.',
+	'page.documents.previewLoading': "Chargement de l'aperçu…",
+	'page.documents.previewFailed': "Impossible d'afficher l'aperçu. Utilisez Télécharger.",
+	'page.documents.pageOf': 'Page {page} sur {total}',
+	'page.documents.fromPaperless': 'paperless',
+
+	// Enum: Document categories
+	'documents.category.receipt': 'Reçu',
+	'documents.category.invoice': 'Facture',
+	'documents.category.medical': 'Médical',
+	'documents.category.insurance': 'Assurance',
+	'documents.category.ownership': 'Propriété',
+	'documents.category.other': 'Autre'
 
 	// Meta
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -820,7 +820,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.download': 'Télécharger',
 	'page.documents.view': 'Voir',
 	'page.documents.delete': 'Supprimer',
-	'page.documents.deleteConfirm': 'Supprimer ce document ?',
 	'page.documents.deleteConfirmBody':
 		"Ce document sera supprimé d'EinVault. Les documents Paperless ne sont pas supprimés de Paperless.",
 	'page.documents.editTitle': 'Modifier le document',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -168,6 +168,7 @@ const messages: Record<keyof Messages, string> = {
 	'nav.journal': 'Diario',
 	'nav.health': 'Salute',
 	'nav.reminders': 'Promemoria',
+	'nav.documents': 'Documenti',
 	'nav.settings': 'Impostazioni',
 	'nav.admin': 'Amministrazione',
 	'nav.signOut': 'Esci',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -802,6 +802,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: Documents
 	'page.documents.title': 'Documenti',
+	'page.documents.archivedNotice': '{name} è archiviato. Visualizzazione in sola lettura.',
 	'page.documents.empty': 'Nessun documento ancora.',
 	'page.documents.upload': 'Carica documento',
 	'page.documents.uploading': 'Caricamento…',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -813,7 +813,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.download': 'Scarica',
 	'page.documents.view': 'Visualizza',
 	'page.documents.delete': 'Elimina',
-	'page.documents.deleteConfirm': 'Eliminare questo documento?',
 	'page.documents.deleteConfirmBody':
 		'Il documento verrà rimosso da EinVault. I documenti Paperless non vengono eliminati da Paperless.',
 	'page.documents.editTitle': 'Modifica documento',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -789,15 +789,15 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.pickFailed': "Impossibile allegare l'elemento Immich.",
 
 	// Paperless picker
-	'paperless.picker.title': 'Scegli da paperless',
+	'paperless.picker.title': 'Scegli da Paperless',
 	'paperless.picker.tagScoped': 'Mostrando documenti con il tag configurato.',
-	'paperless.picker.empty': 'Nessun documento trovato in paperless.',
+	'paperless.picker.empty': 'Nessun documento trovato in Paperless.',
 	'paperless.picker.searchPlaceholder': 'Cerca documenti…',
 	'paperless.picker.cancel': 'Annulla',
 	'paperless.picker.close': 'Chiudi selettore',
-	'paperless.picker.loadError': 'Impossibile caricare la libreria paperless.',
-	'paperless.picker.button': 'Aggiungi da paperless',
-	'paperless.picker.pickFailed': 'Impossibile allegare il documento paperless.',
+	'paperless.picker.loadError': 'Impossibile caricare la libreria Paperless.',
+	'paperless.picker.button': 'Aggiungi da Paperless',
+	'paperless.picker.pickFailed': 'Impossibile allegare il documento Paperless.',
 
 	// Page: Documents
 	'page.documents.title': 'Documenti',
@@ -813,7 +813,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.delete': 'Elimina',
 	'page.documents.deleteConfirm': 'Eliminare questo documento?',
 	'page.documents.deleteConfirmBody':
-		'Il documento verrà rimosso da EinVault. I documenti paperless non vengono eliminati da paperless.',
+		'Il documento verrà rimosso da EinVault. I documenti Paperless non vengono eliminati da Paperless.',
 	'page.documents.editTitle': 'Modifica documento',
 	'page.documents.labelTitle': 'Titolo',
 	'page.documents.labelCategory': 'Categoria',
@@ -824,7 +824,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.previewLoading': 'Caricamento anteprima…',
 	'page.documents.previewFailed': "Impossibile visualizzare l'anteprima. Usa Scarica.",
 	'page.documents.pageOf': 'Pagina {page} di {total}',
-	'page.documents.fromPaperless': 'paperless',
+	'page.documents.fromPaperless': 'Paperless',
 
 	// Enum: Document categories
 	'documents.category.receipt': 'Ricevuta',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -160,6 +160,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidGifFile': 'File GIF non valido',
 	'error.maxMediaExceeded': 'Massimo {max} foto o video al giorno',
 	'error.requestBodyTooLarge': 'Corpo della richiesta troppo grande',
+	'error.maxDocumentsExceeded': 'Limite documenti raggiunto (max {max} per compagno)',
 
 	// Navigation
 	'nav.dashboard': 'Bacheca',
@@ -785,7 +786,53 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Chiudi selettore',
 	'immich.picker.loadError': 'Impossibile caricare la libreria Immich.',
 	'immich.picker.button': 'Scegli da Immich',
-	'immich.picker.pickFailed': "Impossibile allegare l'elemento Immich."
+	'immich.picker.pickFailed': "Impossibile allegare l'elemento Immich.",
+
+	// Paperless picker
+	'paperless.picker.title': 'Scegli da paperless',
+	'paperless.picker.tagScoped': 'Mostrando documenti con il tag configurato.',
+	'paperless.picker.empty': 'Nessun documento trovato in paperless.',
+	'paperless.picker.searchPlaceholder': 'Cerca documenti…',
+	'paperless.picker.cancel': 'Annulla',
+	'paperless.picker.close': 'Chiudi selettore',
+	'paperless.picker.loadError': 'Impossibile caricare la libreria paperless.',
+	'paperless.picker.button': 'Aggiungi da paperless',
+	'paperless.picker.pickFailed': 'Impossibile allegare il documento paperless.',
+
+	// Page: Documents
+	'page.documents.title': 'Documenti',
+	'page.documents.empty': 'Nessun documento ancora.',
+	'page.documents.upload': 'Carica documento',
+	'page.documents.uploading': 'Caricamento…',
+	'page.documents.dropHint': 'PDF o immagine, fino a {max}MB',
+	'page.documents.filterAll': 'Tutte le categorie',
+	'page.documents.linkedEvent': 'Evento sanitario collegato',
+	'page.documents.noLinkedEvent': 'Non collegato',
+	'page.documents.download': 'Scarica',
+	'page.documents.view': 'Visualizza',
+	'page.documents.delete': 'Elimina',
+	'page.documents.deleteConfirm': 'Eliminare questo documento?',
+	'page.documents.deleteConfirmBody':
+		'Il documento verrà rimosso da EinVault. I documenti paperless non vengono eliminati da paperless.',
+	'page.documents.editTitle': 'Modifica documento',
+	'page.documents.labelTitle': 'Titolo',
+	'page.documents.labelCategory': 'Categoria',
+	'page.documents.labelDate': 'Data documento',
+	'page.documents.save': 'Salva',
+	'page.documents.saveFailed': 'Impossibile salvare le modifiche.',
+	'page.documents.uploadFailed': 'Caricamento non riuscito.',
+	'page.documents.previewLoading': 'Caricamento anteprima…',
+	'page.documents.previewFailed': "Impossibile visualizzare l'anteprima. Usa Scarica.",
+	'page.documents.pageOf': 'Pagina {page} di {total}',
+	'page.documents.fromPaperless': 'paperless',
+
+	// Enum: Document categories
+	'documents.category.receipt': 'Ricevuta',
+	'documents.category.invoice': 'Fattura',
+	'documents.category.medical': 'Medico',
+	'documents.category.insurance': 'Assicurazione',
+	'documents.category.ownership': 'Proprietà',
+	'documents.category.other': 'Altro'
 
 	// Meta
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -752,6 +752,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.close': 'Chiudi',
 	'aria.previousMedia': 'Contenuto precedente',
 	'aria.nextMedia': 'Contenuto successivo',
+	'aria.previousPage': 'Pagina precedente',
+	'aria.nextPage': 'Pagina successiva',
 	'aria.viewPhoto': 'Vedi la foto di {name}',
 
 	// Email: password reset

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -791,15 +791,15 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.pickFailed': 'Não foi possível anexar o item do Immich.',
 
 	// Paperless picker
-	'paperless.picker.title': 'Escolher do paperless',
+	'paperless.picker.title': 'Escolher do Paperless',
 	'paperless.picker.tagScoped': 'A mostrar documentos com a etiqueta configurada.',
-	'paperless.picker.empty': 'Nenhum documento encontrado no paperless.',
+	'paperless.picker.empty': 'Nenhum documento encontrado no Paperless.',
 	'paperless.picker.searchPlaceholder': 'Pesquisar documentos…',
 	'paperless.picker.cancel': 'Cancelar',
 	'paperless.picker.close': 'Fechar seletor',
-	'paperless.picker.loadError': 'Não foi possível carregar a biblioteca do paperless.',
-	'paperless.picker.button': 'Adicionar do paperless',
-	'paperless.picker.pickFailed': 'Não foi possível anexar o documento do paperless.',
+	'paperless.picker.loadError': 'Não foi possível carregar a biblioteca do Paperless.',
+	'paperless.picker.button': 'Adicionar do Paperless',
+	'paperless.picker.pickFailed': 'Não foi possível anexar o documento do Paperless.',
 
 	// Page: Documents
 	'page.documents.title': 'Documentos',
@@ -815,7 +815,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.delete': 'Eliminar',
 	'page.documents.deleteConfirm': 'Eliminar este documento?',
 	'page.documents.deleteConfirmBody':
-		'O documento será removido do EinVault. Os documentos do paperless não são eliminados do paperless.',
+		'O documento será removido do EinVault. Os documentos do Paperless não são eliminados do Paperless.',
 	'page.documents.editTitle': 'Editar documento',
 	'page.documents.labelTitle': 'Título',
 	'page.documents.labelCategory': 'Categoria',
@@ -826,7 +826,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.previewLoading': 'A carregar pré-visualização…',
 	'page.documents.previewFailed': 'Não foi possível mostrar a pré-visualização. Use Transferir.',
 	'page.documents.pageOf': 'Página {page} de {total}',
-	'page.documents.fromPaperless': 'paperless',
+	'page.documents.fromPaperless': 'Paperless',
 
 	// Enum: Document categories
 	'documents.category.receipt': 'Recibo',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -169,6 +169,7 @@ const messages: Record<keyof Messages, string> = {
 	'nav.journal': 'Diário',
 	'nav.health': 'Saúde',
 	'nav.reminders': 'Lembretes',
+	'nav.documents': 'Documentos',
 	'nav.settings': 'Definições',
 	'nav.admin': 'Administração',
 	'nav.signOut': 'Terminar sessão',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -161,6 +161,7 @@ const messages: Record<keyof Messages, string> = {
 	'error.invalidGifFile': 'Ficheiro GIF inválido',
 	'error.maxMediaExceeded': 'Máximo de {max} fotos ou vídeos por dia',
 	'error.requestBodyTooLarge': 'Pedido demasiado grande',
+	'error.maxDocumentsExceeded': 'Limite de documentos atingido (máx. {max} por companheiro)',
 
 	// Navigation
 	'nav.dashboard': 'Painel',
@@ -787,7 +788,53 @@ const messages: Record<keyof Messages, string> = {
 	'immich.picker.close': 'Fechar seletor',
 	'immich.picker.loadError': 'Não foi possível carregar a biblioteca do Immich.',
 	'immich.picker.button': 'Escolher do Immich',
-	'immich.picker.pickFailed': 'Não foi possível anexar o item do Immich.'
+	'immich.picker.pickFailed': 'Não foi possível anexar o item do Immich.',
+
+	// Paperless picker
+	'paperless.picker.title': 'Escolher do paperless',
+	'paperless.picker.tagScoped': 'A mostrar documentos com a etiqueta configurada.',
+	'paperless.picker.empty': 'Nenhum documento encontrado no paperless.',
+	'paperless.picker.searchPlaceholder': 'Pesquisar documentos…',
+	'paperless.picker.cancel': 'Cancelar',
+	'paperless.picker.close': 'Fechar seletor',
+	'paperless.picker.loadError': 'Não foi possível carregar a biblioteca do paperless.',
+	'paperless.picker.button': 'Adicionar do paperless',
+	'paperless.picker.pickFailed': 'Não foi possível anexar o documento do paperless.',
+
+	// Page: Documents
+	'page.documents.title': 'Documentos',
+	'page.documents.empty': 'Ainda não há documentos.',
+	'page.documents.upload': 'Carregar documento',
+	'page.documents.uploading': 'A carregar…',
+	'page.documents.dropHint': 'PDF ou imagem, até {max}MB',
+	'page.documents.filterAll': 'Todas as categorias',
+	'page.documents.linkedEvent': 'Evento de saúde associado',
+	'page.documents.noLinkedEvent': 'Sem associação',
+	'page.documents.download': 'Transferir',
+	'page.documents.view': 'Ver',
+	'page.documents.delete': 'Eliminar',
+	'page.documents.deleteConfirm': 'Eliminar este documento?',
+	'page.documents.deleteConfirmBody':
+		'O documento será removido do EinVault. Os documentos do paperless não são eliminados do paperless.',
+	'page.documents.editTitle': 'Editar documento',
+	'page.documents.labelTitle': 'Título',
+	'page.documents.labelCategory': 'Categoria',
+	'page.documents.labelDate': 'Data do documento',
+	'page.documents.save': 'Guardar',
+	'page.documents.saveFailed': 'Não foi possível guardar as alterações.',
+	'page.documents.uploadFailed': 'Falha no carregamento.',
+	'page.documents.previewLoading': 'A carregar pré-visualização…',
+	'page.documents.previewFailed': 'Não foi possível mostrar a pré-visualização. Use Transferir.',
+	'page.documents.pageOf': 'Página {page} de {total}',
+	'page.documents.fromPaperless': 'paperless',
+
+	// Enum: Document categories
+	'documents.category.receipt': 'Recibo',
+	'documents.category.invoice': 'Fatura',
+	'documents.category.medical': 'Médico',
+	'documents.category.insurance': 'Seguro',
+	'documents.category.ownership': 'Propriedade',
+	'documents.category.other': 'Outro'
 
 	// Meta
 } satisfies Record<keyof Messages, string>;

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -815,7 +815,6 @@ const messages: Record<keyof Messages, string> = {
 	'page.documents.download': 'Transferir',
 	'page.documents.view': 'Ver',
 	'page.documents.delete': 'Eliminar',
-	'page.documents.deleteConfirm': 'Eliminar este documento?',
 	'page.documents.deleteConfirmBody':
 		'O documento será removido do EinVault. Os documentos do Paperless não são eliminados do Paperless.',
 	'page.documents.editTitle': 'Editar documento',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -804,6 +804,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: Documents
 	'page.documents.title': 'Documentos',
+	'page.documents.archivedNotice': '{name} está arquivado. Modo de leitura.',
 	'page.documents.empty': 'Ainda não há documentos.',
 	'page.documents.upload': 'Carregar documento',
 	'page.documents.uploading': 'A carregar…',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -754,6 +754,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.close': 'Fechar',
 	'aria.previousMedia': 'Mídia anterior',
 	'aria.nextMedia': 'Próxima mídia',
+	'aria.previousPage': 'Página anterior',
+	'aria.nextPage': 'Próxima página',
 	'aria.viewPhoto': 'Ver foto de {name}',
 
 	// Email: password reset

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -270,6 +270,50 @@ export const healthEvents = sqliteTable(
 	})
 );
 
+// companion documents (issue #95)
+
+export const documents = sqliteTable(
+	'documents',
+	{
+		id: text('id').primaryKey(),
+		companionId: text('companion_id')
+			.notNull()
+			.references(() => companions.id, { onDelete: 'cascade' }),
+		// Optional link to a health event of the SAME companion. App code
+		// validates the companion match on every write (SQLite can't express
+		// the composite constraint cleanly).
+		healthEventId: text('health_event_id').references(() => healthEvents.id, {
+			onDelete: 'set null'
+		}),
+		// `{documentId}.{ext}` — server-generated, never derived from the
+		// uploaded filename. Used in /api/documents URLs.
+		filename: text('filename').notNull(),
+		provider: text('provider', { enum: ['local', 's3', 'paperless'] })
+			.notNull()
+			.default('local'),
+		storageKey: text('storage_key').notNull(),
+		title: text('title').notNull(),
+		category: text('category', {
+			enum: ['receipt', 'invoice', 'medical', 'insurance', 'ownership', 'other']
+		})
+			.notNull()
+			.default('other'),
+		// User-set document date (receipt date), not upload date. YYYY-MM-DD.
+		documentDate: text('document_date'),
+		originalName: text('original_name'),
+		mimeType: text('mime_type').notNull(),
+		sizeBytes: integer('size_bytes'),
+		createdAt: integer('created_at', { mode: 'timestamp' })
+			.notNull()
+			.default(sql`(unixepoch())`),
+		uploadedBy: text('uploaded_by').references(() => users.id, { onDelete: 'set null' })
+	},
+	(t) => ({
+		companionIdx: index('document_companion_idx').on(t.companionId),
+		healthEventIdx: index('document_health_event_idx').on(t.healthEventId)
+	})
+);
+
 export const weightEntries = sqliteTable(
 	'weight_entries',
 	{
@@ -404,6 +448,7 @@ export type Companion = typeof companions.$inferSelect;
 export type JournalEntry = typeof journalEntries.$inferSelect;
 export type JournalPhoto = typeof journalPhotos.$inferSelect;
 export type HealthEvent = typeof healthEvents.$inferSelect;
+export type Document = typeof documents.$inferSelect;
 export type WeightEntry = typeof weightEntries.$inferSelect;
 export type DailyEvent = typeof dailyEvents.$inferSelect;
 export type Reminder = typeof reminders.$inferSelect;
@@ -468,8 +513,18 @@ export const dailyEventsRelations = relations(dailyEvents, ({ one }) => ({
 	logger: one(users, { fields: [dailyEvents.loggedBy], references: [users.id] })
 }));
 
-export const healthEventsRelations = relations(healthEvents, ({ one }) => ({
-	logger: one(users, { fields: [healthEvents.loggedBy], references: [users.id] })
+export const healthEventsRelations = relations(healthEvents, ({ one, many }) => ({
+	logger: one(users, { fields: [healthEvents.loggedBy], references: [users.id] }),
+	documents: many(documents)
+}));
+
+export const documentsRelations = relations(documents, ({ one }) => ({
+	companion: one(companions, { fields: [documents.companionId], references: [companions.id] }),
+	healthEvent: one(healthEvents, {
+		fields: [documents.healthEventId],
+		references: [healthEvents.id]
+	}),
+	uploader: one(users, { fields: [documents.uploadedBy], references: [users.id] })
 }));
 
 export const weightEntriesRelations = relations(weightEntries, ({ one }) => ({

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -130,10 +130,10 @@ export function logVideoTranscodeBootStatus(): void {
 // always honor the per-row provider column, so switching here only affects
 // new writes — existing 'local' rows keep streaming from disk.
 //
-// Immich is intentionally excluded from this set: it's a read-only reference
-// layer, never a write destination. The type derives from StorageProvider so
-// adding a provider to the union forces an update here.
-export type StorageBackendName = Exclude<StorageProvider, 'immich'>;
+// Immich and paperless are intentionally excluded from this set: both are
+// read-only reference layers, never write destinations. The type derives from
+// StorageProvider so adding a provider to the union forces an update here.
+export type StorageBackendName = Exclude<StorageProvider, 'immich' | 'paperless'>;
 const ALLOWED_BACKENDS: readonly StorageBackendName[] = ['local', 's3'];
 
 const rawStorageBackend = (env.STORAGE_BACKEND ?? 'local').toLowerCase();
@@ -249,6 +249,85 @@ export function logImmichBootStatus(): void {
 		);
 	}
 }
+
+// Paperless-ngx integration is a read-only reference layer, NOT a write
+// destination — same model as Immich. When configured, users can pick
+// documents from their paperless library to attach to a companion. EinVault
+// stores a reference (provider='paperless', storage_key='paperless:{id}') and
+// proxies reads through the server using the API token. EinVault never
+// uploads to or deletes from paperless.
+export interface PaperlessConfig {
+	url: string;
+	token: string;
+	// Optional tag id (paperless tag PK). When set, the picker search AND the
+	// from-paperless import only accept documents carrying this tag. This is
+	// the EinVault-side scope guard; operators should ALSO use a dedicated
+	// paperless user whose object permissions are limited to that tag.
+	tagId: number | null;
+}
+
+const PAPERLESS_REQUIRED_VARS = ['PAPERLESS_URL', 'PAPERLESS_API_TOKEN'] as const;
+
+function readPaperlessConfig(): {
+	config: PaperlessConfig | null;
+	missing: string[];
+	invalid: boolean;
+} {
+	const rawUrl = env.PAPERLESS_URL?.trim();
+	const token = env.PAPERLESS_API_TOKEN?.trim();
+	const missing = PAPERLESS_REQUIRED_VARS.filter((name) => !env[name]?.trim());
+	if (missing.length === PAPERLESS_REQUIRED_VARS.length)
+		return { config: null, missing, invalid: false };
+	if (missing.length > 0) return { config: null, missing, invalid: false };
+	try {
+		// Validate at boot so a typo'd URL fails loudly, mirroring readNtfyConfig.
+		const url = new URL(rawUrl!);
+		const tagIdRaw = env.PAPERLESS_TAG_ID?.trim();
+		const tagId = tagIdRaw ? Number(tagIdRaw) : null;
+		return {
+			config: {
+				url: `${url.origin}${url.pathname.replace(/\/$/, '')}`,
+				token: token!,
+				tagId: Number.isInteger(tagId) && tagId! > 0 ? tagId : null
+			},
+			missing: [],
+			invalid: false
+		};
+	} catch {
+		return { config: null, missing: [], invalid: true };
+	}
+}
+
+const paperlessResult = readPaperlessConfig();
+export const PAPERLESS_CONFIG = paperlessResult.config;
+
+export function logPaperlessBootStatus(): void {
+	if (paperlessResult.invalid) {
+		console.warn(
+			`[paperless] PAPERLESS_URL='${env.PAPERLESS_URL}' is not a valid URL. Integration disabled.`
+		);
+		return;
+	}
+	if (
+		paperlessResult.missing.length > 0 &&
+		paperlessResult.missing.length < PAPERLESS_REQUIRED_VARS.length
+	) {
+		console.warn(
+			`[paperless] Partial config detected (missing: ${paperlessResult.missing.join(', ')}). Integration disabled. Set both PAPERLESS_URL and PAPERLESS_API_TOKEN to enable.`
+		);
+		return;
+	}
+	if (PAPERLESS_CONFIG) {
+		console.info(
+			`[paperless] enabled url=${PAPERLESS_CONFIG.url}${PAPERLESS_CONFIG.tagId ? ` tag=${PAPERLESS_CONFIG.tagId}` : ' (no tag scope — entire library visible to members)'}`
+		);
+	}
+}
+
+// Hard cap on document rows per companion (uploads AND paperless references).
+// Guards the shared data volume: a full disk breaks SQLite WAL writes for the
+// whole app, not just uploads.
+export const MAX_DOCUMENTS_PER_COMPANION = envInt(env.MAX_DOCUMENTS_PER_COMPANION, 200);
 
 // Optional SMTP email (issue #12). Off unless SMTP_HOST and SMTP_FROM are both
 // set (same gating convention as OIDC and Immich). Used for the forgot-password

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -130,7 +130,7 @@ export function logVideoTranscodeBootStatus(): void {
 // always honor the per-row provider column, so switching here only affects
 // new writes — existing 'local' rows keep streaming from disk.
 //
-// Immich and paperless are intentionally excluded from this set: both are
+// Immich and Paperless are intentionally excluded from this set: both are
 // read-only reference layers, never write destinations. The type derives from
 // StorageProvider so adding a provider to the union forces an update here.
 export type StorageBackendName = Exclude<StorageProvider, 'immich' | 'paperless'>;
@@ -252,17 +252,17 @@ export function logImmichBootStatus(): void {
 
 // Paperless-ngx integration is a read-only reference layer, NOT a write
 // destination — same model as Immich. When configured, users can pick
-// documents from their paperless library to attach to a companion. EinVault
+// documents from their Paperless library to attach to a companion. EinVault
 // stores a reference (provider='paperless', storage_key='paperless:{id}') and
 // proxies reads through the server using the API token. EinVault never
-// uploads to or deletes from paperless.
+// uploads to or deletes from Paperless.
 export interface PaperlessConfig {
 	url: string;
 	token: string;
-	// Optional tag id (paperless tag PK). When set, the picker search AND the
+	// Optional tag ID (Paperless tag PK). When set, the picker search AND the
 	// from-paperless import only accept documents carrying this tag. This is
 	// the EinVault-side scope guard; operators should ALSO use a dedicated
-	// paperless user whose object permissions are limited to that tag.
+	// Paperless user whose object permissions are limited to that tag.
 	tagId: number | null;
 }
 
@@ -324,7 +324,7 @@ export function logPaperlessBootStatus(): void {
 	}
 }
 
-// Hard cap on document rows per companion (uploads AND paperless references).
+// Hard cap on document rows per companion (uploads AND Paperless references).
 // Guards the shared data volume: a full disk breaks SQLite WAL writes for the
 // whole app, not just uploads.
 export const MAX_DOCUMENTS_PER_COMPANION = envInt(env.MAX_DOCUMENTS_PER_COMPANION, 200);

--- a/src/lib/server/storage/index.ts
+++ b/src/lib/server/storage/index.ts
@@ -1,7 +1,8 @@
-import { IMMICH_CONFIG, S3_CONFIG, STORAGE_BACKEND } from '$lib/server/env';
+import { IMMICH_CONFIG, PAPERLESS_CONFIG, S3_CONFIG, STORAGE_BACKEND } from '$lib/server/env';
 import { LocalBackend } from './local';
 import { createS3Backend } from './s3';
 import { createImmichBackend, createImmichClient, type ImmichClient } from './immich';
+import { createPaperlessBackend, createPaperlessClient, type PaperlessClient } from './paperless';
 import type { StorageBackend, StorageProvider } from './types';
 
 export type {
@@ -16,6 +17,9 @@ export type {
 export { immichKey, ASSET_ID_RE as IMMICH_ASSET_ID_RE } from './immich';
 export type { ImmichAssetSummary, ImmichClient } from './immich';
 
+export { paperlessKey, DOC_ID_RE as PAPERLESS_DOC_ID_RE } from './paperless';
+export type { PaperlessDocSummary, PaperlessClient } from './paperless';
+
 const backends: Partial<Record<StorageProvider, StorageBackend>> = {
 	local: LocalBackend
 };
@@ -28,6 +32,12 @@ let immichClient: ImmichClient | null = null;
 if (IMMICH_CONFIG) {
 	backends.immich = createImmichBackend(IMMICH_CONFIG);
 	immichClient = createImmichClient(IMMICH_CONFIG);
+}
+
+let paperlessClient: PaperlessClient | null = null;
+if (PAPERLESS_CONFIG) {
+	backends.paperless = createPaperlessBackend(PAPERLESS_CONFIG);
+	paperlessClient = createPaperlessClient(PAPERLESS_CONFIG);
 }
 
 /**
@@ -52,6 +62,14 @@ export function getImmichClient(): ImmichClient | null {
 
 export function isImmichEnabled(): boolean {
 	return immichClient !== null;
+}
+
+export function getPaperlessClient(): PaperlessClient | null {
+	return paperlessClient;
+}
+
+export function isPaperlessEnabled(): boolean {
+	return paperlessClient !== null;
 }
 
 export { STORAGE_BACKEND };

--- a/src/lib/server/storage/mime.ts
+++ b/src/lib/server/storage/mime.ts
@@ -71,3 +71,78 @@ export function safeExtFromMime(mime: string, originalFileName: string | null | 
 	if (mime === 'image/heic') return 'heic';
 	return 'jpg';
 }
+
+// Mime types accepted for companion documents (issue #95). PDFs and the
+// photo formats people scan receipts with. No SVG (active content), no
+// office formats (no inline preview, larger parse surface).
+export const ALLOWED_DOCUMENT_MIME = [
+	'application/pdf',
+	'image/jpeg',
+	'image/png',
+	'image/webp',
+	'image/heic'
+] as const;
+
+export function isAllowedDocumentMime(mime: string | null | undefined): boolean {
+	return !!mime && (ALLOWED_DOCUMENT_MIME as readonly string[]).includes(mime);
+}
+
+// Strict mime -> extension map for document storage keys. Deliberately NOT
+// safeExtFromMime: that helper prefers the filename-hinted extension, which
+// for documents would let 'report.html' uploaded as application/pdf get an
+// .html extension on disk and in URLs.
+export function documentExtFromMime(mime: string): string {
+	switch (mime) {
+		case 'application/pdf':
+			return 'pdf';
+		case 'image/jpeg':
+			return 'jpg';
+		case 'image/png':
+			return 'png';
+		case 'image/webp':
+			return 'webp';
+		case 'image/heic':
+			return 'heic';
+		default:
+			return 'bin';
+	}
+}
+
+// Magic-byte sniff confirming an accepted document mime matches its bytes,
+// mirroring looksLikeVideo. Requiring %PDF- at offset 0 (the spec allows up
+// to 1024, but real producers emit 0) kills HTML-prefix PDF polyglots.
+export function looksLikeDocument(bytes: Uint8Array, mime: string): boolean {
+	if (mime === 'application/pdf') {
+		return (
+			bytes.length >= 5 &&
+			bytes[0] === 0x25 && // %
+			bytes[1] === 0x50 && // P
+			bytes[2] === 0x44 && // D
+			bytes[3] === 0x46 && // F
+			bytes[4] === 0x2d // -
+		);
+	}
+	if (mime === 'image/jpeg') {
+		return bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+	}
+	if (mime === 'image/png') {
+		const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+		return bytes.length >= 8 && sig.every((b, i) => bytes[i] === b);
+	}
+	if (mime === 'image/webp') {
+		return (
+			bytes.length >= 12 &&
+			String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]) === 'RIFF' &&
+			String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11]) === 'WEBP'
+		);
+	}
+	if (mime === 'image/heic') {
+		// ISO BMFF: bytes 4..8 = 'ftyp', brand at 8..12.
+		if (bytes.length < 12) return false;
+		const box = String.fromCharCode(bytes[4], bytes[5], bytes[6], bytes[7]);
+		if (box !== 'ftyp') return false;
+		const brand = String.fromCharCode(bytes[8], bytes[9], bytes[10], bytes[11]);
+		return ['heic', 'heix', 'mif1', 'msf1', 'heim', 'heis'].includes(brand);
+	}
+	return false;
+}

--- a/src/lib/server/storage/paperless.ts
+++ b/src/lib/server/storage/paperless.ts
@@ -64,17 +64,20 @@ export function createPaperlessBackend(config: PaperlessConfig): StorageBackend 
 			if (!res.ok || !res.body) {
 				throw await logAndSanitize(`get doc=${docId}`, res, 'Paperless document fetch failed');
 			}
-			// Omit size when upstream is chunked (no content-length): emitting 0
-			// would make the serving route send Content-Length: 0 and truncate
-			// the body. size=0 is treated as "unknown" by the documents route.
-			const length = Number(res.headers.get('content-length') ?? 0);
+			// Always report size 0 (= "unknown", so the serving route omits
+			// Content-Length and streams the body). The upstream content-length
+			// reflects the COMPRESSED body when a reverse proxy in front of
+			// paperless gzips the response; undici transparently decompresses
+			// res.body, so passing that length through truncates the document
+			// (e.g. a 18049-byte PDF capped at the 17040-byte gzipped length,
+			// breaking pdf.js with "Invalid PDF structure").
 			const etag = res.headers.get('etag') ?? `"paperless-${docId}"`;
 			const lastModified = res.headers.get('last-modified');
 			return {
 				kind: 'stream',
 				stream: res.body,
 				stat: {
-					size: Number.isFinite(length) && length > 0 ? length : 0,
+					size: 0,
 					etag,
 					mtime: lastModified ? new Date(lastModified) : new Date(0)
 				}
@@ -190,8 +193,10 @@ export function createPaperlessClient(config: PaperlessConfig): PaperlessClient 
 
 		async fetchThumbnail(docId: string) {
 			if (!DOC_ID_RE.test(docId)) return new Response(null, { status: 404 });
+			// Accept: '*/*' — paperless's DRF thumb endpoint does content
+			// negotiation and returns 406 to a narrowed 'image/*' Accept.
 			return fetch(`${config.url}/api/documents/${docId}/thumb/`, {
-				headers: { Authorization: `Token ${config.token}`, Accept: 'image/*' },
+				headers: { Authorization: `Token ${config.token}`, Accept: '*/*' },
 				redirect: 'error',
 				signal: timeoutSignal()
 			});

--- a/src/lib/server/storage/paperless.ts
+++ b/src/lib/server/storage/paperless.ts
@@ -1,0 +1,200 @@
+import type { PaperlessConfig } from '$lib/server/env';
+import type { GetResult, StorageBackend } from './types';
+
+const KEY_PREFIX = 'paperless:';
+// Paperless document ids are integer PKs. Pin the format so a stored row
+// referencing '1/../../users' can never sneak through parseKey into a URL.
+export const DOC_ID_RE = /^\d{1,10}$/;
+
+// Default timeout for any single paperless HTTP call. A hung paperless must
+// not pin request workers, especially on the streaming download path.
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+export function paperlessKey(docId: string | number): string {
+	return `${KEY_PREFIX}${docId}`;
+}
+
+function parseKey(key: string): string {
+	if (!key.startsWith(KEY_PREFIX)) {
+		throw new Error(`Paperless storage key must start with '${KEY_PREFIX}'`);
+	}
+	const id = key.slice(KEY_PREFIX.length);
+	if (!DOC_ID_RE.test(id)) {
+		throw new Error('Invalid paperless document id in key');
+	}
+	return id;
+}
+
+function timeoutSignal(ms = DEFAULT_TIMEOUT_MS): AbortSignal {
+	return AbortSignal.timeout(ms);
+}
+
+// Log full upstream context server-side; return a short generic message so
+// callers (and any error.message that bubbles into a response) cannot leak
+// the API token or internal paths.
+async function logAndSanitize(label: string, res: Response, hint: string): Promise<Error> {
+	const body = await res.text().catch(() => '');
+	console.error(`[paperless] ${label} status=${res.status} body=${body.slice(0, 500)}`);
+	return new Error(`${hint} (${res.status})`);
+}
+
+export function createPaperlessBackend(config: PaperlessConfig): StorageBackend {
+	return {
+		provider: 'paperless',
+
+		async put() {
+			throw new Error(
+				'Paperless backend is read-only: use the from-paperless endpoint to reference an existing document.'
+			);
+		},
+
+		async get(key: string): Promise<GetResult | null> {
+			const docId = parseKey(key);
+			// Serve the archived version (PDF/A with OCR layer) — paperless's
+			// /download/ default. Image originals arrive as PDFs too, so every
+			// paperless row previews uniformly via pdf.js.
+			const res = await fetch(`${config.url}/api/documents/${docId}/download/`, {
+				headers: { Authorization: `Token ${config.token}` },
+				// Never follow redirects: a redirecting reverse proxy in front of
+				// paperless must not receive (or bounce) the Authorization header.
+				redirect: 'error',
+				signal: timeoutSignal()
+			});
+			if (res.status === 404) return null;
+			if (!res.ok || !res.body) {
+				throw await logAndSanitize(`get doc=${docId}`, res, 'Paperless document fetch failed');
+			}
+			// Omit size when upstream is chunked (no content-length): emitting 0
+			// would make the serving route send Content-Length: 0 and truncate
+			// the body. size=0 is treated as "unknown" by the documents route.
+			const length = Number(res.headers.get('content-length') ?? 0);
+			const etag = res.headers.get('etag') ?? `"paperless-${docId}"`;
+			const lastModified = res.headers.get('last-modified');
+			return {
+				kind: 'stream',
+				stream: res.body,
+				stat: {
+					size: Number.isFinite(length) && length > 0 ? length : 0,
+					etag,
+					mtime: lastModified ? new Date(lastModified) : new Date(0)
+				}
+			};
+		},
+
+		async delete() {
+			// Intentional no-op. EinVault stores a reference to a paperless
+			// document; removing the reference must not delete the user's
+			// document from their paperless archive.
+		}
+	};
+}
+
+export interface PaperlessDocSummary {
+	id: number;
+	title: string;
+	created: string | null;
+	documentType: number | null;
+	archiveSerialNumber: string | null;
+	// Mime of the ORIGINAL file. The archived version (what we serve) is
+	// always PDF when present.
+	originalMimeType: string;
+	hasArchiveVersion: boolean;
+	tags: number[];
+}
+
+export interface PaperlessClient {
+	searchDocuments(opts: { query: string; page: number; pageSize: number }): Promise<{
+		items: PaperlessDocSummary[];
+		hasNextPage: boolean;
+	}>;
+	getDocument(docId: string): Promise<PaperlessDocSummary | null>;
+	fetchThumbnail(docId: string): Promise<Response>;
+}
+
+interface PaperlessDocResponse {
+	id: number;
+	title?: string;
+	created?: string;
+	document_type?: number | null;
+	archive_serial_number?: string | null;
+	mime_type?: string;
+	archived_file_name?: string | null;
+	tags?: number[];
+}
+
+interface PaperlessListResponse {
+	count?: number;
+	next?: string | null;
+	results?: PaperlessDocResponse[];
+}
+
+// Strip a document down to picker-safe fields. NEVER include `content` or
+// `__search_hit__` from the upstream response: those carry the OCR'd full
+// text of the document — a corpus-wide data leak if proxied to members.
+function summarize(d: PaperlessDocResponse): PaperlessDocSummary {
+	return {
+		id: d.id,
+		title: d.title ?? '',
+		created: d.created ?? null,
+		documentType: d.document_type ?? null,
+		archiveSerialNumber: d.archive_serial_number ?? null,
+		originalMimeType: d.mime_type ?? 'application/octet-stream',
+		hasArchiveVersion: !!d.archived_file_name,
+		tags: d.tags ?? []
+	};
+}
+
+export function createPaperlessClient(config: PaperlessConfig): PaperlessClient {
+	function headers(): Record<string, string> {
+		return { Authorization: `Token ${config.token}`, Accept: 'application/json' };
+	}
+
+	return {
+		async searchDocuments({ query, page, pageSize }) {
+			// URLSearchParams so a crafted query string cannot inject parameters
+			// (e.g. '&fields=content&page_size=100000') into the upstream URL.
+			const params = new URLSearchParams({
+				page: String(page),
+				page_size: String(pageSize),
+				ordering: '-created'
+			});
+			if (query) params.set('query', query);
+			if (config.tagId !== null) params.set('tags__id__all', String(config.tagId));
+			const res = await fetch(`${config.url}/api/documents/?${params}`, {
+				headers: headers(),
+				redirect: 'error',
+				signal: timeoutSignal()
+			});
+			if (!res.ok) {
+				throw await logAndSanitize('search', res, 'Paperless search failed');
+			}
+			const body = (await res.json()) as PaperlessListResponse;
+			const items = (body.results ?? []).map(summarize);
+			return { items, hasNextPage: !!body.next };
+		},
+
+		async getDocument(docId: string) {
+			if (!DOC_ID_RE.test(docId)) return null;
+			const res = await fetch(`${config.url}/api/documents/${docId}/`, {
+				headers: headers(),
+				redirect: 'error',
+				signal: timeoutSignal()
+			});
+			if (res.status === 404) return null;
+			if (!res.ok) {
+				throw await logAndSanitize(`getDocument=${docId}`, res, 'Paperless document fetch failed');
+			}
+			const body = (await res.json()) as PaperlessDocResponse;
+			return summarize(body);
+		},
+
+		async fetchThumbnail(docId: string) {
+			if (!DOC_ID_RE.test(docId)) return new Response(null, { status: 404 });
+			return fetch(`${config.url}/api/documents/${docId}/thumb/`, {
+				headers: { Authorization: `Token ${config.token}`, Accept: 'image/*' },
+				redirect: 'error',
+				signal: timeoutSignal()
+			});
+		}
+	};
+}

--- a/src/lib/server/storage/paperless.ts
+++ b/src/lib/server/storage/paperless.ts
@@ -6,7 +6,7 @@ const KEY_PREFIX = 'paperless:';
 // referencing '1/../../users' can never sneak through parseKey into a URL.
 export const DOC_ID_RE = /^\d{1,10}$/;
 
-// Default timeout for any single paperless HTTP call. A hung paperless must
+// Default timeout for any single Paperless HTTP call. A hung Paperless must
 // not pin request workers, especially on the streaming download path.
 const DEFAULT_TIMEOUT_MS = 8_000;
 
@@ -20,7 +20,7 @@ function parseKey(key: string): string {
 	}
 	const id = key.slice(KEY_PREFIX.length);
 	if (!DOC_ID_RE.test(id)) {
-		throw new Error('Invalid paperless document id in key');
+		throw new Error('Invalid Paperless document id in key');
 	}
 	return id;
 }
@@ -50,13 +50,13 @@ export function createPaperlessBackend(config: PaperlessConfig): StorageBackend 
 
 		async get(key: string): Promise<GetResult | null> {
 			const docId = parseKey(key);
-			// Serve the archived version (PDF/A with OCR layer) — paperless's
+			// Serve the archived version (PDF/A with OCR layer) — Paperless's
 			// /download/ default. Image originals arrive as PDFs too, so every
-			// paperless row previews uniformly via pdf.js.
+			// Paperless row previews uniformly via pdf.js.
 			const res = await fetch(`${config.url}/api/documents/${docId}/download/`, {
 				headers: { Authorization: `Token ${config.token}` },
 				// Never follow redirects: a redirecting reverse proxy in front of
-				// paperless must not receive (or bounce) the Authorization header.
+				// Paperless must not receive (or bounce) the Authorization header.
 				redirect: 'error',
 				signal: timeoutSignal()
 			});
@@ -67,7 +67,7 @@ export function createPaperlessBackend(config: PaperlessConfig): StorageBackend 
 			// Always report size 0 (= "unknown", so the serving route omits
 			// Content-Length and streams the body). The upstream content-length
 			// reflects the COMPRESSED body when a reverse proxy in front of
-			// paperless gzips the response; undici transparently decompresses
+			// Paperless gzips the response; undici transparently decompresses
 			// res.body, so passing that length through truncates the document
 			// (e.g. a 18049-byte PDF capped at the 17040-byte gzipped length,
 			// breaking pdf.js with "Invalid PDF structure").
@@ -85,9 +85,9 @@ export function createPaperlessBackend(config: PaperlessConfig): StorageBackend 
 		},
 
 		async delete() {
-			// Intentional no-op. EinVault stores a reference to a paperless
+			// Intentional no-op. EinVault stores a reference to a Paperless
 			// document; removing the reference must not delete the user's
-			// document from their paperless archive.
+			// document from their Paperless archive.
 		}
 	};
 }
@@ -193,7 +193,7 @@ export function createPaperlessClient(config: PaperlessConfig): PaperlessClient 
 
 		async fetchThumbnail(docId: string) {
 			if (!DOC_ID_RE.test(docId)) return new Response(null, { status: 404 });
-			// Accept: '*/*' — paperless's DRF thumb endpoint does content
+			// Accept: '*/*' — Paperless's DRF thumb endpoint does content
 			// negotiation and returns 406 to a narrowed 'image/*' Accept.
 			return fetch(`${config.url}/api/documents/${docId}/thumb/`, {
 				headers: { Authorization: `Token ${config.token}`, Accept: '*/*' },

--- a/src/lib/server/storage/types.ts
+++ b/src/lib/server/storage/types.ts
@@ -1,4 +1,4 @@
-export type StorageProvider = 'local' | 's3' | 'immich';
+export type StorageProvider = 'local' | 's3' | 'immich' | 'paperless';
 
 export interface PutInput {
 	key: string;

--- a/src/routes/(app)/(companion)/[companionId]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/+page.server.ts
@@ -19,7 +19,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		upcomingReminders,
 		recentWeights,
 		todayJournal,
-		activeCaretakerShift
+		activeCaretakerShift,
+		recentDocuments
 	] = await Promise.all([
 		db.query.healthEvents.findMany({
 			where: eq(schema.healthEvents.companionId, params.companionId),
@@ -76,7 +77,12 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 			.innerJoin(schema.users, eq(schema.users.id, schema.caretakerShifts.userId))
 			.where(and(lte(schema.caretakerShifts.startAt, now), gte(schema.caretakerShifts.endAt, now)))
 			.limit(1)
-			.then((rows) => rows[0] ?? null)
+			.then((rows) => rows[0] ?? null),
+		db.query.documents.findMany({
+			where: eq(schema.documents.companionId, params.companionId),
+			orderBy: (d, { desc }) => [desc(d.createdAt)],
+			limit: 5
+		})
 	]);
 
 	return {
@@ -86,7 +92,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		upcomingReminders,
 		recentWeights,
 		todayJournal,
-		activeCaretakerShift
+		activeCaretakerShift,
+		recentDocuments
 	};
 };
 

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -19,6 +19,7 @@
 		Pencil,
 		UserCheck,
 		NotebookPen,
+		FileText,
 		X,
 		CheckCheck
 	} from '@lucide/svelte';
@@ -27,6 +28,7 @@
 	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { t, getLocale } from '$lib/i18n';
+	import type { MessageKey } from '$lib/i18n/en';
 	import { createPendingDismissals } from '$lib/pendingDismiss.svelte';
 	import { registerDismissForm } from '$lib/actions/registerDismissForm';
 	import { clearSubmittingFlag } from '$lib/clearSubmittingFlag';
@@ -40,7 +42,8 @@
 		upcomingReminders,
 		recentWeights,
 		todayJournal,
-		activeCaretakerShift
+		activeCaretakerShift,
+		recentDocuments
 	} = $derived(data);
 
 	const locale = getLocale();
@@ -856,6 +859,49 @@
 								</div>
 							{/if}
 						</button>
+					{/each}
+				</div>
+			{/if}
+		</CardContent>
+	</Card>
+
+	<!-- Recent documents -->
+	<Card>
+		<CardHeader class="pb-3">
+			<div class="flex items-center justify-between">
+				<CardTitle class="text-sm font-semibold flex items-center gap-2">
+					<FileText class="h-4 w-4" />
+					{t(locale, 'page.documents.title')}
+				</CardTitle>
+				<Button
+					href="/{companion.id}/documents"
+					variant="ghost"
+					size="sm"
+					class="h-7 text-xs text-primary px-2"
+				>
+					{t(locale, 'page.dashboard.healthViewAll')}
+				</Button>
+			</div>
+		</CardHeader>
+		<CardContent class="pt-0">
+			{#if recentDocuments.length === 0}
+				<p class="text-sm italic text-muted-foreground">
+					{t(locale, 'page.documents.empty')}
+				</p>
+			{:else}
+				<div class="space-y-1">
+					{#each recentDocuments as doc (doc.id)}
+						<a
+							href="/{companion.id}/documents"
+							class="block w-full rounded-md px-2 py-1.5 -mx-2 hover:bg-accent transition-colors text-left"
+						>
+							<div class="flex items-center justify-between gap-3 text-sm">
+								<span class="truncate text-foreground text-sm">{doc.title}</span>
+								<Badge variant="bark" class="capitalize"
+									>{t(locale, `documents.category.${doc.category}` as MessageKey)}</Badge
+								>
+							</div>
+						</a>
 					{/each}
 				</div>
 			{/if}

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.server.ts
@@ -23,7 +23,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		db.query.healthEvents.findMany({
 			where: eq(schema.healthEvents.companionId, params.companionId),
 			orderBy: (h, { desc }) => [desc(h.occurredAt)],
-			columns: { id: true, title: true, occurredAt: true }
+			columns: { id: true, title: true, type: true, occurredAt: true }
 		})
 	]);
 

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.server.ts
@@ -1,0 +1,31 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { db, schema } from '$lib/server/db';
+import { eq } from 'drizzle-orm';
+import { UPLOAD_MAX_MB } from '$lib/server/env';
+
+export const load: PageServerLoad = async ({ params, locals, parent }) => {
+	if (!locals.user) redirect(302, '/auth/login');
+	// Documents are owner-private; caretakers never reach this route group,
+	// but a defense-in-depth redirect costs nothing.
+	if (locals.user.role === 'caretaker') redirect(302, '/care');
+	const { companion } = await parent();
+
+	const [documents, healthEvents] = await Promise.all([
+		db.query.documents.findMany({
+			where: eq(schema.documents.companionId, params.companionId),
+			orderBy: (d, { desc }) => [desc(d.createdAt)],
+			with: {
+				healthEvent: { columns: { id: true, title: true } },
+				uploader: { columns: { displayName: true } }
+			}
+		}),
+		db.query.healthEvents.findMany({
+			where: eq(schema.healthEvents.companionId, params.companionId),
+			orderBy: (h, { desc }) => [desc(h.occurredAt)],
+			columns: { id: true, title: true, occurredAt: true }
+		})
+	]);
+
+	return { companion, documents, healthEvents, uploadMaxMb: UPLOAD_MAX_MB };
+};

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
@@ -1,0 +1,338 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import PaperlessPicker from '$lib/components/PaperlessPicker.svelte';
+	import DocumentPreview from '$lib/components/DocumentPreview.svelte';
+	import { t, getLocale } from '$lib/i18n';
+	import type { MessageKey } from '$lib/i18n/en';
+	import { FileText, Upload, Download, Trash2, Pencil, Loader2 } from '@lucide/svelte';
+
+	let { data } = $props();
+	const locale = getLocale();
+	const categoryLabel = (c: string) => t(locale, `documents.category.${c}` as MessageKey);
+
+	const CATEGORIES = ['receipt', 'invoice', 'medical', 'insurance', 'ownership', 'other'] as const;
+
+	type Doc = (typeof data.documents)[number];
+	const docUrl = (doc: Doc) => `/api/documents/${data.companion.id}/${doc.filename}`;
+
+	let uploading = $state(false);
+	let uploadError = $state('');
+	let pickerOpen = $state(false);
+	let filter = $state('all');
+	let editingId = $state<string | null>(null);
+	let editTitle = $state('');
+	let editCategory = $state('other');
+	let editDate = $state('');
+	let editHealthEventId = $state('');
+	let saveError = $state('');
+	let deleteTarget = $state<Doc | null>(null);
+	let preview = $state<Doc | null>(null);
+	let fileInput = $state<HTMLInputElement | null>(null);
+
+	const filtered = $derived(
+		filter === 'all' ? data.documents : data.documents.filter((d) => d.category === filter)
+	);
+
+	async function upload(files: FileList | null) {
+		if (!files || files.length === 0) return;
+		uploading = true;
+		uploadError = '';
+		try {
+			for (const file of files) {
+				const form = new FormData();
+				form.set('file', file);
+				const res = await fetch(`/api/companions/${data.companion.id}/documents`, {
+					method: 'POST',
+					body: form
+				});
+				if (!res.ok) {
+					const body = await res.json().catch(() => null);
+					uploadError = body?.message ?? t(locale, 'page.documents.uploadFailed');
+					break;
+				}
+			}
+			await invalidateAll();
+		} finally {
+			uploading = false;
+			if (fileInput) fileInput.value = '';
+		}
+	}
+
+	async function pickFromPaperless(paperlessId: number) {
+		const res = await fetch(`/api/companions/${data.companion.id}/documents/from-paperless`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ paperlessId })
+		});
+		if (!res.ok) {
+			uploadError = t(locale, 'paperless.picker.pickFailed');
+			return;
+		}
+		pickerOpen = false;
+		await invalidateAll();
+	}
+
+	function startEdit(doc: Doc) {
+		editingId = doc.id;
+		editTitle = doc.title;
+		editCategory = doc.category;
+		editDate = doc.documentDate ?? '';
+		editHealthEventId = doc.healthEventId ?? '';
+		saveError = '';
+	}
+
+	async function saveEdit() {
+		if (!editingId) return;
+		const res = await fetch(`/api/companions/${data.companion.id}/documents/${editingId}`, {
+			method: 'PATCH',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				title: editTitle,
+				category: editCategory,
+				documentDate: editDate || null,
+				healthEventId: editHealthEventId || null
+			})
+		});
+		if (!res.ok) {
+			saveError = t(locale, 'page.documents.saveFailed');
+			return;
+		}
+		editingId = null;
+		await invalidateAll();
+	}
+
+	async function confirmDelete() {
+		if (!deleteTarget) return;
+		await fetch(`/api/companions/${data.companion.id}/documents/${deleteTarget.id}`, {
+			method: 'DELETE'
+		});
+		deleteTarget = null;
+		await invalidateAll();
+	}
+
+	function formatSize(bytes: number | null): string {
+		if (!bytes) return '';
+		if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+	}
+</script>
+
+<svelte:head>
+	<title>{t(locale, 'page.documents.title')} · {data.companion.name}</title>
+</svelte:head>
+
+<div class="max-w-3xl mx-auto px-4 py-6 space-y-4">
+	<Card>
+		<CardHeader class="flex flex-row items-center justify-between">
+			<CardTitle>{t(locale, 'page.documents.title')}</CardTitle>
+			<div class="flex items-center gap-2">
+				{#if data.paperlessEnabled}
+					<Button variant="outline" size="sm" onclick={() => (pickerOpen = true)}>
+						<FileText class="h-4 w-4 mr-1.5" />
+						{t(locale, 'paperless.picker.button')}
+					</Button>
+				{/if}
+				<Button size="sm" disabled={uploading} onclick={() => fileInput?.click()}>
+					{#if uploading}
+						<Loader2 class="h-4 w-4 mr-1.5 animate-spin" />
+						{t(locale, 'page.documents.uploading')}
+					{:else}
+						<Upload class="h-4 w-4 mr-1.5" />
+						{t(locale, 'page.documents.upload')}
+					{/if}
+				</Button>
+				<input
+					bind:this={fileInput}
+					type="file"
+					accept="application/pdf,image/jpeg,image/png,image/webp,image/heic"
+					multiple
+					class="hidden"
+					onchange={(e) => upload(e.currentTarget.files)}
+				/>
+			</div>
+		</CardHeader>
+		<CardContent class="space-y-3">
+			<p class="text-xs text-muted-foreground">
+				{t(locale, 'page.documents.dropHint', { max: data.uploadMaxMb })}
+			</p>
+
+			{#if uploadError}
+				<div
+					role="alert"
+					class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
+				>
+					{uploadError}
+				</div>
+			{/if}
+
+			<select
+				class="h-9 rounded-md border border-input bg-background px-3 text-sm"
+				bind:value={filter}
+				aria-label={t(locale, 'page.documents.filterAll')}
+			>
+				<option value="all">{t(locale, 'page.documents.filterAll')}</option>
+				{#each CATEGORIES as c (c)}
+					<option value={c}>{categoryLabel(c)}</option>
+				{/each}
+			</select>
+
+			{#if filtered.length === 0}
+				<p class="text-sm text-muted-foreground py-8 text-center">
+					{t(locale, 'page.documents.empty')}
+				</p>
+			{:else}
+				<ul class="divide-y divide-border">
+					{#each filtered as doc (doc.id)}
+						<li class="py-3">
+							{#if editingId === doc.id}
+								<div class="space-y-2">
+									<div>
+										<Label for="doc-title-{doc.id}">{t(locale, 'page.documents.labelTitle')}</Label>
+										<Input
+											id="doc-title-{doc.id}"
+											value={editTitle}
+											oninput={(e) => (editTitle = e.currentTarget.value)}
+											maxlength={255}
+										/>
+									</div>
+									<div class="flex gap-2">
+										<div>
+											<Label for="doc-cat-{doc.id}"
+												>{t(locale, 'page.documents.labelCategory')}</Label
+											>
+											<select
+												id="doc-cat-{doc.id}"
+												class="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+												bind:value={editCategory}
+											>
+												{#each CATEGORIES as c (c)}
+													<option value={c}>{categoryLabel(c)}</option>
+												{/each}
+											</select>
+										</div>
+										<div>
+											<Label for="doc-date-{doc.id}">{t(locale, 'page.documents.labelDate')}</Label>
+											<Input
+												id="doc-date-{doc.id}"
+												type="date"
+												value={editDate}
+												oninput={(e) => (editDate = e.currentTarget.value)}
+											/>
+										</div>
+									</div>
+									<div>
+										<Label for="doc-event-{doc.id}">{t(locale, 'page.documents.linkedEvent')}</Label
+										>
+										<select
+											id="doc-event-{doc.id}"
+											class="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+											bind:value={editHealthEventId}
+										>
+											<option value="">{t(locale, 'page.documents.noLinkedEvent')}</option>
+											{#each data.healthEvents as event (event.id)}
+												<option value={event.id}>{event.title}</option>
+											{/each}
+										</select>
+									</div>
+									{#if saveError}
+										<p class="text-sm text-red-600 dark:text-red-400">{saveError}</p>
+									{/if}
+									<div class="flex gap-2">
+										<Button size="sm" onclick={saveEdit}>{t(locale, 'page.documents.save')}</Button>
+										<Button variant="outline" size="sm" onclick={() => (editingId = null)}>
+											{t(locale, 'common.cancel')}
+										</Button>
+									</div>
+								</div>
+							{:else}
+								<div class="flex items-center gap-3">
+									<button
+										type="button"
+										class="flex items-center gap-3 flex-1 min-w-0 text-left hover:opacity-75"
+										onclick={() => (preview = doc)}
+										aria-label={t(locale, 'page.documents.view')}
+									>
+										<FileText class="h-5 w-5 shrink-0 text-muted-foreground" />
+										<div class="min-w-0">
+											<p class="text-sm font-medium text-foreground truncate">{doc.title}</p>
+											<p
+												class="text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap mt-0.5"
+											>
+												<Badge variant="secondary">{categoryLabel(doc.category)}</Badge>
+												{#if doc.provider === 'paperless'}
+													<Badge variant="outline"
+														>{t(locale, 'page.documents.fromPaperless')}</Badge
+													>
+												{/if}
+												{#if doc.documentDate}<span>{doc.documentDate}</span>{/if}
+												{#if doc.sizeBytes}<span>{formatSize(doc.sizeBytes)}</span>{/if}
+												{#if doc.healthEvent}<span>· {doc.healthEvent.title}</span>{/if}
+											</p>
+										</div>
+									</button>
+									<div class="flex items-center gap-1 shrink-0">
+										<a
+											href={`${docUrl(doc)}?download`}
+											class="rounded-md p-1.5 hover:bg-accent text-muted-foreground"
+											aria-label={t(locale, 'page.documents.download')}
+										>
+											<Download class="h-4 w-4" />
+										</a>
+										<button
+											type="button"
+											class="rounded-md p-1.5 hover:bg-accent text-muted-foreground"
+											aria-label={t(locale, 'page.documents.editTitle')}
+											onclick={() => startEdit(doc)}
+										>
+											<Pencil class="h-4 w-4" />
+										</button>
+										<button
+											type="button"
+											class="rounded-md p-1.5 hover:bg-accent text-red-600 dark:text-red-400"
+											aria-label={t(locale, 'page.documents.delete')}
+											onclick={() => (deleteTarget = doc)}
+										>
+											<Trash2 class="h-4 w-4" />
+										</button>
+									</div>
+								</div>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</CardContent>
+	</Card>
+</div>
+
+{#if data.paperlessEnabled}
+	<PaperlessPicker
+		open={pickerOpen}
+		onpick={pickFromPaperless}
+		onclose={() => (pickerOpen = false)}
+	/>
+{/if}
+
+{#if preview}
+	<DocumentPreview
+		open={true}
+		url={docUrl(preview)}
+		mimeType={preview.mimeType}
+		title={preview.title}
+		onclose={() => (preview = null)}
+	/>
+{/if}
+
+<ConfirmDialog
+	open={deleteTarget !== null}
+	message={t(locale, 'page.documents.deleteConfirmBody')}
+	confirmLabel={t(locale, 'page.documents.delete')}
+	onconfirm={confirmDelete}
+	oncancel={() => (deleteTarget = null)}
+/>

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
@@ -270,7 +270,7 @@
 								<div class="flex items-center gap-3">
 									<button
 										type="button"
-										class="flex items-center gap-3 flex-1 min-w-0 text-left hover:opacity-75"
+										class="flex items-center gap-3 flex-1 min-w-0 text-left rounded-md px-2 py-1 -mx-2 hover:bg-accent transition-colors"
 										onclick={() => (preview = doc)}
 										aria-label={t(locale, 'page.documents.view')}
 									>

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
@@ -134,9 +134,9 @@
 
 <div class="max-w-3xl mx-auto px-4 py-6 space-y-4">
 	<Card>
-		<CardHeader class="flex flex-row items-center justify-between">
+		<CardHeader class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 			<CardTitle>{t(locale, 'page.documents.title')}</CardTitle>
-			<div class="flex items-center gap-2">
+			<div class="flex flex-wrap items-center gap-2">
 				{#if data.paperlessEnabled}
 					<Button variant="outline" size="sm" onclick={() => (pickerOpen = true)}>
 						<FileText class="h-4 w-4 mr-1.5" />

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
@@ -3,7 +3,8 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card/index.js';
+	import { Card, CardContent } from '$lib/components/ui/card/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import PaperlessPicker from '$lib/components/PaperlessPicker.svelte';
@@ -132,10 +133,18 @@
 	<title>{t(locale, 'page.documents.title')} · {data.companion.name}</title>
 </svelte:head>
 
-<div class="max-w-3xl mx-auto px-4 py-6 space-y-4">
-	<Card>
-		<CardHeader class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-			<CardTitle>{t(locale, 'page.documents.title')}</CardTitle>
+<div class="space-y-6 pb-20 md:pb-0">
+	{#if !data.companion.isActive}
+		<div class="rounded-lg bg-muted/50 px-4 py-2.5 text-sm text-muted-foreground mb-4">
+			{t(locale, 'page.documents.archivedNotice', { name: data.companion.name })}
+		</div>
+	{/if}
+
+	<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+		<h1 class="font-display text-2xl font-bold text-foreground">
+			{t(locale, 'page.documents.title')}
+		</h1>
+		{#if data.companion.isActive !== false}
 			<div class="flex flex-wrap items-center gap-2">
 				{#if data.paperlessEnabled}
 					<Button variant="outline" size="sm" onclick={() => (pickerOpen = true)}>
@@ -161,19 +170,21 @@
 					onchange={(e) => upload(e.currentTarget.files)}
 				/>
 			</div>
-		</CardHeader>
-		<CardContent class="space-y-3">
-			<p class="text-xs text-muted-foreground">
-				{t(locale, 'page.documents.dropHint', { max: data.uploadMaxMb })}
-			</p>
+		{/if}
+	</div>
 
-			{#if uploadError}
-				<div
-					role="alert"
-					class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
-				>
-					{uploadError}
-				</div>
+	{#if uploadError}
+		<Alert variant="destructive">
+			<AlertDescription>{uploadError}</AlertDescription>
+		</Alert>
+	{/if}
+
+	<Card>
+		<CardContent class="space-y-3 pt-6">
+			{#if data.companion.isActive !== false}
+				<p class="text-xs text-muted-foreground">
+					{t(locale, 'page.documents.dropHint', { max: data.uploadMaxMb })}
+				</p>
 			{/if}
 
 			<select

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
@@ -9,12 +9,17 @@
 	import PaperlessPicker from '$lib/components/PaperlessPicker.svelte';
 	import DocumentPreview from '$lib/components/DocumentPreview.svelte';
 	import { t, getLocale } from '$lib/i18n';
+	import { healthTypeLabel } from '$lib/i18n/labels';
 	import type { MessageKey } from '$lib/i18n/en';
+	import { localDateISO } from '$lib/date';
 	import { FileText, Upload, Download, Trash2, Pencil, Loader2 } from '@lucide/svelte';
 
 	let { data } = $props();
 	const locale = getLocale();
 	const categoryLabel = (c: string) => t(locale, `documents.category.${c}` as MessageKey);
+	// Type · date · title — title alone is often ambiguous across visits.
+	const healthEventLabel = (e: (typeof data.healthEvents)[number]) =>
+		`${healthTypeLabel(locale, e.type)} · ${localDateISO(e.occurredAt)} · ${e.title}`;
 
 	const CATEGORIES = ['receipt', 'invoice', 'medical', 'insurance', 'ownership', 'other'] as const;
 
@@ -236,7 +241,7 @@
 										>
 											<option value="">{t(locale, 'page.documents.noLinkedEvent')}</option>
 											{#each data.healthEvents as event (event.id)}
-												<option value={event.id}>{event.title}</option>
+												<option value={event.id}>{healthEventLabel(event)}</option>
 											{/each}
 										</select>
 									</div>

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.server.ts
@@ -11,7 +11,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	if (!locals.user) redirect(302, '/auth/login');
 	const { companion } = await parent();
 
-	const [healthEvents, weightEntries] = await Promise.all([
+	const [healthEvents, weightEntries, linkedDocuments] = await Promise.all([
 		db.query.healthEvents.findMany({
 			where: eq(schema.healthEvents.companionId, params.companionId),
 			orderBy: (h, { desc }) => [desc(h.occurredAt)],
@@ -21,10 +21,14 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 			where: eq(schema.weightEntries.companionId, params.companionId),
 			orderBy: (w, { desc }) => [desc(w.recordedAt)],
 			with: { logger: { columns: { displayName: true } } }
+		}),
+		db.query.documents.findMany({
+			where: eq(schema.documents.companionId, params.companionId),
+			columns: { id: true, title: true, healthEventId: true, filename: true }
 		})
 	]);
 
-	return { companion, healthEvents, weightEntries };
+	return { companion, healthEvents, weightEntries, linkedDocuments };
 };
 
 export const actions: Actions = {

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -871,12 +871,11 @@
 										{#if data.linkedDocuments.some((d) => d.healthEventId === event.id)}
 											<div class="mt-1 flex flex-wrap gap-2">
 												{#each data.linkedDocuments.filter((d) => d.healthEventId === event.id) as doc (doc.id)}
-													<a
-														href={`/${data.companion.id}/documents`}
-														class="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+													<span
+														class="inline-flex items-center gap-1 text-xs text-muted-foreground"
 													>
 														<FileText class="h-3 w-3" />{doc.title}
-													</a>
+													</span>
 												{/each}
 											</div>
 										{/if}

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -12,7 +12,7 @@
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Select } from '$lib/components/ui/select/index.js';
 	import { Separator } from '$lib/components/ui/separator/index.js';
-	import { Scale, Plus, Pencil, Trash2, X } from '@lucide/svelte';
+	import { Scale, Plus, Pencil, Trash2, X, FileText } from '@lucide/svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { tick } from 'svelte';
@@ -867,6 +867,18 @@
 											<p class="text-sm mt-1 text-muted-foreground">
 												{stripMarkdown(event.notes)}
 											</p>
+										{/if}
+										{#if data.linkedDocuments.some((d) => d.healthEventId === event.id)}
+											<div class="mt-1 flex flex-wrap gap-2">
+												{#each data.linkedDocuments.filter((d) => d.healthEventId === event.id) as doc (doc.id)}
+													<a
+														href={`/${data.companion.id}/documents`}
+														class="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+													>
+														<FileText class="h-3 w-3" />{doc.title}
+													</a>
+												{/each}
+											</div>
 										{/if}
 										<ByLine user={event.logger} class="mt-0.5" />
 									</div>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -12,6 +12,7 @@
 		NotebookPen,
 		HeartPulse,
 		Bell,
+		FileText,
 		Settings,
 		LogOut,
 		ShieldCheck
@@ -56,6 +57,11 @@
 						href: `/${activeCompanion.id}/reminders`,
 						label: t(locale, 'nav.reminders'),
 						icon: Bell
+					},
+					{
+						href: `/${activeCompanion.id}/documents`,
+						label: t(locale, 'nav.documents'),
+						icon: FileText
 					}
 				]
 			: []
@@ -183,7 +189,7 @@
 							<span class="hidden sm:inline">{t(locale, 'nav.admin')}</span>
 						</Button>
 					{/if}
-					<Button href="/settings" variant="ghost" size="sm" class="hidden md:inline-flex gap-1.5">
+					<Button href="/settings" variant="ghost" size="sm" class="gap-1.5">
 						<Settings class="h-4 w-4" />
 						<span class="hidden sm:inline">{t(locale, 'nav.settings')}</span>
 					</Button>
@@ -258,18 +264,6 @@
 						{item.label}
 					</a>
 				{/each}
-				<a
-					href="/settings"
-					aria-current={page.url.pathname.startsWith('/settings') ? 'page' : undefined}
-					class="flex flex-1 flex-col items-center gap-0.5 py-3 text-xs font-medium transition-colors {page.url.pathname.startsWith(
-						'/settings'
-					)
-						? 'text-primary'
-						: 'text-muted-foreground'}"
-				>
-					<Settings class="h-5 w-5" />
-					{t(locale, 'nav.settings')}
-				</a>
 			</div>
 		</nav>
 	{/if}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -4,7 +4,7 @@ import { db, schema } from '$lib/server/db';
 import { version } from '../../package.json';
 import { t } from '$lib/i18n';
 import { resolveReminderUndoSeconds } from '$lib/server/env';
-import { isImmichEnabled } from '$lib/server/storage';
+import { isImmichEnabled, isPaperlessEnabled } from '$lib/server/storage';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
 	const isApiRoute = url.pathname.startsWith('/api');
@@ -40,6 +40,7 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 		year: new Date().getFullYear(),
 		reminderUndoSeconds: resolveReminderUndoSeconds(locals.user?.reminderUndoSeconds ?? null),
 		// Caretakers don't get the picker — the underlying endpoints reject them.
-		immichEnabled: isImmichEnabled() && locals.user?.role !== 'caretaker'
+		immichEnabled: isImmichEnabled() && locals.user?.role !== 'caretaker',
+		paperlessEnabled: isPaperlessEnabled() && locals.user?.role !== 'caretaker'
 	};
 };

--- a/src/routes/api/companions/[companionId]/documents/+server.ts
+++ b/src/routes/api/companions/[companionId]/documents/+server.ts
@@ -15,6 +15,10 @@ import {
 import { isValidDate } from '$lib/server/validation';
 
 const MAX_DOCUMENT_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
+// Bound decoded pixels so a small, highly-compressible image can't decode to
+// sharp's ~268MP default and pressure memory. 50MP comfortably covers a
+// high-DPI document scan while capping the per-request decode buffer.
+const MAX_DECODE_PIXELS = 50_000_000;
 const CATEGORIES = ['receipt', 'invoice', 'medical', 'insurance', 'ownership', 'other'] as const;
 type Category = (typeof CATEGORIES)[number];
 
@@ -119,7 +123,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		// Lossless re-encode: launders structure, strips EXIF, keeps receipts
 		// crisp. Larger resize cap than journal photos — these must stay legible.
 		try {
-			processed = await sharp(raw)
+			processed = await sharp(raw, { limitInputPixels: MAX_DECODE_PIXELS })
 				.resize(4096, 4096, { fit: 'inside', withoutEnlargement: true })
 				.png()
 				.toBuffer();
@@ -132,7 +136,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		// renderable format. sharp without libheif throws on HEIC: surface as
 		// invalid file type rather than a 500.
 		try {
-			processed = await sharp(raw)
+			processed = await sharp(raw, { limitInputPixels: MAX_DECODE_PIXELS })
 				.rotate()
 				.resize(4096, 4096, { fit: 'inside', withoutEnlargement: true })
 				.jpeg({ quality: 90 })

--- a/src/routes/api/companions/[companionId]/documents/+server.ts
+++ b/src/routes/api/companions/[companionId]/documents/+server.ts
@@ -1,0 +1,213 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t, type Locale } from '$lib/i18n';
+import { db, schema } from '$lib/server/db';
+import { eq, and, count, desc } from 'drizzle-orm';
+import { generateId } from '$lib/server/utils';
+import sharp from 'sharp';
+import { getStorage, STORAGE_BACKEND } from '$lib/server/storage';
+import { MAX_DOCUMENTS_PER_COMPANION, UPLOAD_MAX_MB } from '$lib/server/env';
+import {
+	documentExtFromMime,
+	isAllowedDocumentMime,
+	looksLikeDocument
+} from '$lib/server/storage/mime';
+import { isValidDate } from '$lib/server/validation';
+
+const MAX_DOCUMENT_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
+const CATEGORIES = ['receipt', 'invoice', 'medical', 'insurance', 'ownership', 'other'] as const;
+type Category = (typeof CATEGORIES)[number];
+
+// NOT exported: SvelteKit only allows HTTP-verb exports from +server.ts.
+function documentKey(companionId: string, filename: string): string {
+	return `documents/${companionId}/${filename}`;
+}
+
+function parseCategory(raw: unknown): Category {
+	return CATEGORIES.includes(raw as Category) ? (raw as Category) : 'other';
+}
+
+// Reject a healthEventId that does not belong to this companion. Without
+// this check a member could link a document to ANOTHER companion's health
+// event (cross-companion leak when listed from the event side).
+async function validateHealthEventId(
+	raw: unknown,
+	companionId: string,
+	locale: Locale
+): Promise<string | null> {
+	if (raw === null || raw === undefined || raw === '') return null;
+	if (typeof raw !== 'string') error(400, t(locale, 'error.eventNotFound'));
+	const event = await db.query.healthEvents.findFirst({
+		where: and(eq(schema.healthEvents.id, raw), eq(schema.healthEvents.companionId, companionId)),
+		columns: { id: true }
+	});
+	if (!event) error(404, t(locale, 'error.eventNotFound'));
+	return event.id;
+}
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+	// Documents are owner-private (receipts, invoices, ownership papers):
+	// members and admins only, caretakers excluded everywhere.
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const companion = await db.query.companions.findFirst({
+		where: eq(schema.companions.id, params.companionId),
+		columns: { id: true }
+	});
+	if (!companion) error(404, t(locals.locale, 'error.companionNotFound'));
+
+	const rows = await db.query.documents.findMany({
+		where: eq(schema.documents.companionId, params.companionId),
+		orderBy: [desc(schema.documents.createdAt)],
+		with: {
+			healthEvent: { columns: { id: true, title: true } },
+			uploader: { columns: { displayName: true } }
+		}
+	});
+
+	return json({
+		documents: rows.map((r) => ({
+			...r,
+			url: `/api/documents/${params.companionId}/${r.filename}`
+		}))
+	});
+};
+
+export const POST: RequestHandler = async ({ request, params, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+	const { companionId } = params;
+
+	const companion = await db.query.companions.findFirst({
+		where: eq(schema.companions.id, companionId),
+		columns: { id: true }
+	});
+	if (!companion) error(404, t(locals.locale, 'error.companionNotFound'));
+
+	const formData = await request.formData();
+	const file = formData.get('file') as File | null;
+	if (!file || file.size === 0) error(400, t(locals.locale, 'error.noFileProvided'));
+	if (!isAllowedDocumentMime(file.type)) error(400, t(locals.locale, 'error.invalidFileType'));
+	if (file.size > MAX_DOCUMENT_SIZE)
+		error(400, t(locals.locale, 'error.fileTooLarge', { max: UPLOAD_MAX_MB }));
+
+	const raw = Buffer.from(await file.arrayBuffer());
+	// Reject mislabeled bytes before trusting the client mime (PDFs are
+	// stored as-is; HTML-prefix polyglots must die here).
+	if (!looksLikeDocument(raw, file.type)) error(400, t(locals.locale, 'error.invalidFileType'));
+
+	const titleRaw = String(formData.get('title') ?? '').trim();
+	const category = parseCategory(formData.get('category'));
+	const documentDateRaw = String(formData.get('documentDate') ?? '').trim();
+	const documentDate = isValidDate(documentDateRaw) ? documentDateRaw : null;
+	const healthEventId = await validateHealthEventId(
+		formData.get('healthEventId'),
+		companionId,
+		locals.locale
+	);
+
+	const documentId = generateId(15);
+	let processed: Buffer;
+	let mimeType: string;
+	if (file.type === 'application/pdf') {
+		// PDFs cannot be re-encoded; stored as-is. Serving-side hardening
+		// (CSP sandbox, nosniff, DB-row content type) covers them.
+		processed = raw;
+		mimeType = 'application/pdf';
+	} else if (file.type === 'image/png') {
+		// Lossless re-encode: launders structure, strips EXIF, keeps receipts
+		// crisp. Larger resize cap than journal photos — these must stay legible.
+		try {
+			processed = await sharp(raw)
+				.resize(4096, 4096, { fit: 'inside', withoutEnlargement: true })
+				.png()
+				.toBuffer();
+		} catch {
+			error(400, t(locals.locale, 'error.invalidFileType'));
+		}
+		mimeType = 'image/png';
+	} else {
+		// jpeg / webp / heic -> JPEG q90. Also converts HEIC to a universally
+		// renderable format. sharp without libheif throws on HEIC: surface as
+		// invalid file type rather than a 500.
+		try {
+			processed = await sharp(raw)
+				.rotate()
+				.resize(4096, 4096, { fit: 'inside', withoutEnlargement: true })
+				.jpeg({ quality: 90 })
+				.toBuffer();
+		} catch {
+			error(400, t(locals.locale, 'error.invalidFileType'));
+		}
+		mimeType = 'image/jpeg';
+	}
+
+	const ext = documentExtFromMime(mimeType);
+	const filename = `${documentId}.${ext}`;
+	const key = documentKey(companionId, filename);
+	const title = (titleRaw || file.name || filename).slice(0, 255);
+	const originalName = (file.name || '').slice(0, 255) || null;
+	const uploadedBy = locals.user.id;
+
+	try {
+		await getStorage().put({ key, body: processed, contentType: mimeType });
+	} catch (err) {
+		console.error('[documents] storage put failed:', err);
+		error(502, t(locals.locale, 'error.fileNotFound'));
+	}
+
+	// Count + insert in one immediate transaction so two concurrent uploads
+	// cannot both pass the cap check (from-immich TOCTOU pattern).
+	const result = db.transaction(
+		(tx) => {
+			const rows = tx
+				.select({ value: count() })
+				.from(schema.documents)
+				.where(eq(schema.documents.companionId, companionId))
+				.all();
+			const docCount = rows[0]?.value ?? 0;
+			if (docCount >= MAX_DOCUMENTS_PER_COMPANION) return { ok: false as const };
+			tx.insert(schema.documents)
+				.values({
+					id: documentId,
+					companionId,
+					healthEventId,
+					filename,
+					provider: STORAGE_BACKEND,
+					storageKey: key,
+					title,
+					category,
+					documentDate,
+					originalName,
+					mimeType,
+					sizeBytes: processed.length,
+					uploadedBy
+				})
+				.run();
+			return { ok: true as const };
+		},
+		{ behavior: 'immediate' }
+	);
+
+	if (!result.ok) {
+		// Cap hit after the object was stored: remove the orphan.
+		await getStorage()
+			.delete(key)
+			.catch((err) => console.warn(`[documents] orphan cleanup failed for ${key}:`, err));
+		error(
+			400,
+			t(locals.locale, 'error.maxDocumentsExceeded', { max: MAX_DOCUMENTS_PER_COMPANION })
+		);
+	}
+
+	const created = await db.query.documents.findFirst({
+		where: eq(schema.documents.id, documentId),
+		with: {
+			healthEvent: { columns: { id: true, title: true } },
+			uploader: { columns: { displayName: true } }
+		}
+	});
+
+	return json({ ...created, url: `/api/documents/${companionId}/${filename}` });
+};

--- a/src/routes/api/companions/[companionId]/documents/[documentId]/+server.ts
+++ b/src/routes/api/companions/[companionId]/documents/[documentId]/+server.ts
@@ -1,0 +1,109 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { db, schema } from '$lib/server/db';
+import { eq, and } from 'drizzle-orm';
+import { getStorage } from '$lib/server/storage';
+import { isValidDate } from '$lib/server/validation';
+
+const CATEGORIES = ['receipt', 'invoice', 'medical', 'insurance', 'ownership', 'other'] as const;
+type Category = (typeof CATEGORIES)[number];
+
+export const PATCH: RequestHandler = async ({ request, params, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const doc = await db.query.documents.findFirst({
+		where: eq(schema.documents.id, params.documentId)
+	});
+	// 404 (not 403) so document ids are not probeable across companions.
+	if (!doc || doc.companionId !== params.companionId)
+		error(404, t(locals.locale, 'error.notFound'));
+
+	const contentLength = parseInt(request.headers.get('content-length') ?? '0');
+	if (contentLength > 10_000) error(400, t(locals.locale, 'error.requestBodyTooLarge'));
+
+	const body = (await request.json().catch(() => null)) as {
+		title?: unknown;
+		category?: unknown;
+		documentDate?: unknown;
+		healthEventId?: unknown;
+	} | null;
+	if (!body) error(400, t(locals.locale, 'error.notFound'));
+
+	// Strict field allowlist. storageKey/provider/mimeType must never be
+	// client-writable: a repointed storageKey is an arbitrary-read primitive
+	// through the serving route.
+	const updates: Partial<typeof schema.documents.$inferInsert> = {};
+
+	if (body.title !== undefined) {
+		const title = String(body.title).trim().slice(0, 255);
+		if (!title) error(400, t(locals.locale, 'error.titleAndTypeRequired'));
+		updates.title = title;
+	}
+	if (body.category !== undefined) {
+		if (!CATEGORIES.includes(body.category as Category))
+			error(400, t(locals.locale, 'error.notFound'));
+		updates.category = body.category as Category;
+	}
+	if (body.documentDate !== undefined) {
+		if (body.documentDate === null || body.documentDate === '') {
+			updates.documentDate = null;
+		} else if (typeof body.documentDate === 'string' && isValidDate(body.documentDate)) {
+			updates.documentDate = body.documentDate;
+		} else {
+			error(400, t(locals.locale, 'error.invalidDate'));
+		}
+	}
+	if (body.healthEventId !== undefined) {
+		if (body.healthEventId === null || body.healthEventId === '') {
+			updates.healthEventId = null;
+		} else if (typeof body.healthEventId === 'string') {
+			// Re-validate companion ownership on EVERY set, not just create.
+			const event = await db.query.healthEvents.findFirst({
+				where: and(
+					eq(schema.healthEvents.id, body.healthEventId),
+					eq(schema.healthEvents.companionId, params.companionId)
+				),
+				columns: { id: true }
+			});
+			if (!event) error(404, t(locals.locale, 'error.eventNotFound'));
+			updates.healthEventId = event.id;
+		} else {
+			error(400, t(locals.locale, 'error.eventNotFound'));
+		}
+	}
+
+	if (Object.keys(updates).length > 0) {
+		await db.update(schema.documents).set(updates).where(eq(schema.documents.id, doc.id));
+	}
+
+	const updated = await db.query.documents.findFirst({
+		where: eq(schema.documents.id, doc.id),
+		with: { healthEvent: { columns: { id: true, title: true } } }
+	});
+	return json({ ...updated, url: `/api/documents/${params.companionId}/${doc.filename}` });
+};
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const doc = await db.query.documents.findFirst({
+		where: eq(schema.documents.id, params.documentId)
+	});
+	if (!doc || doc.companionId !== params.companionId)
+		error(404, t(locals.locale, 'error.notFound'));
+
+	// Paperless backend delete is an intentional no-op (reference only).
+	// Delete the DB row unconditionally: an orphaned object is recoverable,
+	// a stuck row is not (journal-photos DELETE rationale).
+	try {
+		await getStorage(doc.provider).delete(doc.storageKey);
+	} catch (err) {
+		console.warn(`[documents] failed to delete object ${doc.storageKey}:`, err);
+	}
+	await db.delete(schema.documents).where(eq(schema.documents.id, doc.id));
+
+	return json({ success: true });
+};

--- a/src/routes/api/companions/[companionId]/documents/from-paperless/+server.ts
+++ b/src/routes/api/companions/[companionId]/documents/from-paperless/+server.ts
@@ -1,0 +1,127 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { db, schema } from '$lib/server/db';
+import { eq, and, count } from 'drizzle-orm';
+import { generateId } from '$lib/server/utils';
+import { getPaperlessClient, paperlessKey, PAPERLESS_DOC_ID_RE } from '$lib/server/storage';
+import { documentExtFromMime, isAllowedDocumentMime } from '$lib/server/storage/mime';
+import { MAX_DOCUMENTS_PER_COMPANION, PAPERLESS_CONFIG } from '$lib/server/env';
+import { isValidDate } from '$lib/server/validation';
+
+const CATEGORIES = ['receipt', 'invoice', 'medical', 'insurance', 'ownership', 'other'] as const;
+type Category = (typeof CATEGORIES)[number];
+
+export const POST: RequestHandler = async ({ request, params, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const client = getPaperlessClient();
+	if (!client || !PAPERLESS_CONFIG) error(404, t(locals.locale, 'error.notFound'));
+
+	const { companionId } = params;
+	const body = (await request.json().catch(() => null)) as {
+		paperlessId?: unknown;
+		category?: unknown;
+	} | null;
+	const paperlessId = String(body?.paperlessId ?? '').trim();
+	if (!PAPERLESS_DOC_ID_RE.test(paperlessId)) {
+		error(400, t(locals.locale, 'error.invalidFileType'));
+	}
+	const category: Category = CATEGORIES.includes(body?.category as Category)
+		? (body!.category as Category)
+		: 'other';
+
+	const companion = await db.query.companions.findFirst({
+		where: eq(schema.companions.id, companionId),
+		columns: { id: true }
+	});
+	if (!companion) error(404, t(locals.locale, 'error.companionNotFound'));
+
+	const doc = await client.getDocument(paperlessId);
+	if (!doc) error(404, t(locals.locale, 'error.notFound'));
+
+	// The import endpoint is the security boundary — the picker is advisory.
+	// Enforce the tag scope here even though the search proxy also filters.
+	if (PAPERLESS_CONFIG.tagId !== null && !doc.tags.includes(PAPERLESS_CONFIG.tagId)) {
+		error(404, t(locals.locale, 'error.notFound'));
+	}
+
+	// We serve the archived version (always PDF) when paperless has one;
+	// otherwise the original must itself be an allowed type.
+	const mimeType = doc.hasArchiveVersion ? 'application/pdf' : doc.originalMimeType;
+	if (!isAllowedDocumentMime(mimeType)) {
+		error(400, t(locals.locale, 'error.invalidFileType'));
+	}
+
+	const documentId = generateId(15);
+	// Ext matches what we actually serve: pdf for archived versions, the
+	// original's ext for the rare no-archive case.
+	const filename = `${documentId}.${documentExtFromMime(mimeType)}`;
+	const title = (doc.title || filename).slice(0, 255);
+	// paperless `created` is an ISO datetime; keep the date part, but don't
+	// trust upstream format blindly.
+	const createdDate = doc.created?.slice(0, 10) ?? '';
+	const documentDate = isValidDate(createdDate) ? createdDate : null;
+	const uploadedBy = locals.user.id;
+
+	const result = db.transaction(
+		(tx) => {
+			// Idempotency guard: the same paperless doc twice on one companion
+			// is almost certainly a double-click.
+			const dupe = tx
+				.select({ id: schema.documents.id })
+				.from(schema.documents)
+				.where(
+					and(
+						eq(schema.documents.companionId, companionId),
+						eq(schema.documents.storageKey, paperlessKey(paperlessId))
+					)
+				)
+				.all();
+			if (dupe.length > 0) return { ok: true as const, existingId: dupe[0].id };
+			const rows = tx
+				.select({ value: count() })
+				.from(schema.documents)
+				.where(eq(schema.documents.companionId, companionId))
+				.all();
+			const docCount = rows[0]?.value ?? 0;
+			if (docCount >= MAX_DOCUMENTS_PER_COMPANION) return { ok: false as const };
+			tx.insert(schema.documents)
+				.values({
+					id: documentId,
+					companionId,
+					filename,
+					provider: 'paperless',
+					storageKey: paperlessKey(paperlessId),
+					title,
+					category,
+					documentDate,
+					originalName: null,
+					mimeType,
+					sizeBytes: null,
+					uploadedBy
+				})
+				.run();
+			return { ok: true as const, existingId: null };
+		},
+		{ behavior: 'immediate' }
+	);
+
+	if (!result.ok) {
+		error(
+			400,
+			t(locals.locale, 'error.maxDocumentsExceeded', { max: MAX_DOCUMENTS_PER_COMPANION })
+		);
+	}
+
+	const finalId = result.existingId ?? documentId;
+	const created = await db.query.documents.findFirst({
+		where: eq(schema.documents.id, finalId),
+		with: { healthEvent: { columns: { id: true, title: true } } }
+	});
+	// Dupe-path row can vanish between tx commit and this read.
+	if (!created) error(404, t(locals.locale, 'error.notFound'));
+
+	return json({ ...created, url: `/api/documents/${companionId}/${created.filename}` });
+};

--- a/src/routes/api/companions/[companionId]/documents/from-paperless/+server.ts
+++ b/src/routes/api/companions/[companionId]/documents/from-paperless/+server.ts
@@ -47,7 +47,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		error(404, t(locals.locale, 'error.notFound'));
 	}
 
-	// We serve the archived version (always PDF) when paperless has one;
+	// We serve the archived version (always PDF) when Paperless has one;
 	// otherwise the original must itself be an allowed type.
 	const mimeType = doc.hasArchiveVersion ? 'application/pdf' : doc.originalMimeType;
 	if (!isAllowedDocumentMime(mimeType)) {
@@ -59,7 +59,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	// original's ext for the rare no-archive case.
 	const filename = `${documentId}.${documentExtFromMime(mimeType)}`;
 	const title = (doc.title || filename).slice(0, 255);
-	// paperless `created` is an ISO datetime; keep the date part, but don't
+	// Paperless `created` is an ISO datetime; keep the date part, but don't
 	// trust upstream format blindly.
 	const createdDate = doc.created?.slice(0, 10) ?? '';
 	const documentDate = isValidDate(createdDate) ? createdDate : null;
@@ -67,7 +67,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	const result = db.transaction(
 		(tx) => {
-			// Idempotency guard: the same paperless doc twice on one companion
+			// Idempotency guard: the same Paperless doc twice on one companion
 			// is almost certainly a double-click.
 			const dupe = tx
 				.select({ id: schema.documents.id })

--- a/src/routes/api/documents/[...path]/+server.ts
+++ b/src/routes/api/documents/[...path]/+server.ts
@@ -1,0 +1,101 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { db, schema } from '$lib/server/db';
+import { eq } from 'drizzle-orm';
+import { getStorage, type GetResult } from '$lib/server/storage';
+
+// RFC 5987 encoding for the attachment filename. The raw originalName is
+// user-controlled and must never land unencoded in a header value.
+function contentDisposition(
+	mode: 'inline' | 'attachment',
+	serverName: string,
+	originalName: string | null
+): string {
+	if (mode === 'inline') return `inline; filename="${serverName}"`;
+	const fallback = (originalName ?? serverName)
+		.replace(/[^\x20-\x7e]/g, '_')
+		.replace(/["\\]/g, '_');
+	const encoded = encodeURIComponent(originalName ?? serverName);
+	return `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+}
+
+export const GET: RequestHandler = async ({ params, url, locals, request }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	// Documents are owner-private — stricter than /api/photos, which lets
+	// assigned caretakers read. Do NOT copy the assignment-check logic.
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const segments = (params.path ?? '').split('/');
+	if (segments.length !== 2) error(404, t(locals.locale, 'error.notFound'));
+	const [urlCompanionId, filename] = segments;
+
+	// Filename is server-generated `{documentId}.{ext}` — parse the id and
+	// look the row up by primary key, then verify the URL's claims against
+	// the row. Storage is only ever touched via row.storageKey.
+	const documentId = filename.split('.')[0] ?? '';
+	const doc = await db.query.documents.findFirst({
+		where: eq(schema.documents.id, documentId)
+	});
+	if (!doc || doc.filename !== filename || doc.companionId !== urlCompanionId) {
+		error(404, t(locals.locale, 'error.notFound'));
+	}
+
+	const ifNoneMatch = request.headers.get('if-none-match');
+	let res: GetResult | null;
+	try {
+		res = await getStorage(doc.provider).get(doc.storageKey, { ifNoneMatch });
+	} catch (err) {
+		if (err instanceof Error && err.message.includes('escapes upload root')) {
+			error(403, t(locals.locale, 'error.forbidden'));
+		}
+		console.error(`[documents] storage error provider=${doc.provider} key=${doc.storageKey}:`, err);
+		error(502, t(locals.locale, 'error.fileNotFound'));
+	}
+	if (!res) error(404, t(locals.locale, 'error.fileNotFound'));
+
+	if (res.kind === 'notModified') {
+		return new Response(null, { status: 304, headers: { ETag: res.etag } });
+	}
+
+	if (res.kind === 'redirect') {
+		// S3 presigned URL. S3 serves the Content-Type set at PUT; our CSP
+		// does not travel with the redirect — accepted tradeoff (photos do
+		// the same).
+		return new Response(null, {
+			status: 302,
+			headers: {
+				Location: res.url,
+				'Cache-Control': `private, max-age=${res.cacheSeconds}`,
+				'Referrer-Policy': 'no-referrer'
+			}
+		});
+	}
+
+	const wantDownload = url.searchParams.has('download');
+	const cacheControl =
+		doc.provider === 'paperless' ? 'private, max-age=300' : 'private, max-age=31536000, immutable';
+
+	const headers: Record<string, string> = {
+		// Always from the validated DB column — never from the filename or
+		// upstream response headers.
+		'Content-Type': doc.mimeType,
+		'Cache-Control': cacheControl,
+		ETag: res.stat.etag,
+		'X-Content-Type-Options': 'nosniff',
+		// Opaque-origin every byte response: even if a future bug serves
+		// attacker bytes as HTML, scripts/forms/plugins are inert. (App-page
+		// CSP does not apply to non-HTML +server responses.)
+		'Content-Security-Policy': 'sandbox',
+		'Content-Disposition': contentDisposition(
+			wantDownload ? 'attachment' : 'inline',
+			doc.filename,
+			doc.originalName
+		)
+	};
+
+	// Paperless streams may be chunked with unknown length; emitting
+	// Content-Length: 0 would truncate the body, so only set it when known.
+	if (res.stat.size > 0) headers['Content-Length'] = String(res.stat.size);
+	return new Response(res.stream, { headers });
+};

--- a/src/routes/api/paperless/documents/+server.ts
+++ b/src/routes/api/paperless/documents/+server.ts
@@ -1,0 +1,45 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { PAPERLESS_CONFIG } from '$lib/server/env';
+import { getPaperlessClient } from '$lib/server/storage';
+
+const DEFAULT_PAGE_SIZE = 60;
+const MAX_PAGE_SIZE = 200;
+const MAX_QUERY_LENGTH = 200;
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const client = getPaperlessClient();
+	if (!client || !PAPERLESS_CONFIG) error(404, t(locals.locale, 'error.notFound'));
+
+	const query = (url.searchParams.get('query') ?? '').slice(0, MAX_QUERY_LENGTH);
+	const page = Math.max(1, Math.trunc(Number(url.searchParams.get('page')) || 1));
+	const pageSizeRaw = Math.trunc(Number(url.searchParams.get('pageSize')) || DEFAULT_PAGE_SIZE);
+	const pageSize = Math.min(MAX_PAGE_SIZE, Math.max(1, pageSizeRaw));
+
+	let result;
+	try {
+		result = await client.searchDocuments({ query, page, pageSize });
+	} catch (err) {
+		console.error('[paperless-search]', err);
+		error(502, t(locals.locale, 'paperless.picker.loadError'));
+	}
+
+	// Summaries only — the client already strips `content`/`__search_hit__`,
+	// but keep the explicit projection here as the second guard.
+	return json({
+		items: result.items.map((d) => ({
+			id: d.id,
+			title: d.title,
+			created: d.created,
+			archiveSerialNumber: d.archiveSerialNumber
+		})),
+		hasNextPage: result.hasNextPage,
+		page,
+		pageSize,
+		tagScoped: PAPERLESS_CONFIG.tagId !== null
+	});
+};

--- a/src/routes/api/paperless/thumb/[docId]/+server.ts
+++ b/src/routes/api/paperless/thumb/[docId]/+server.ts
@@ -1,0 +1,39 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { getPaperlessClient, PAPERLESS_DOC_ID_RE } from '$lib/server/storage';
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const client = getPaperlessClient();
+	if (!client) error(404, t(locals.locale, 'error.notFound'));
+
+	const docId = params.docId;
+	if (!PAPERLESS_DOC_ID_RE.test(docId)) error(404, t(locals.locale, 'error.notFound'));
+
+	let res: Response;
+	try {
+		res = await client.fetchThumbnail(docId);
+	} catch (err) {
+		console.error(`[paperless-thumb] upstream fetch failed doc=${docId}:`, err);
+		error(502, t(locals.locale, 'error.fileNotFound'));
+	}
+	if (res.status === 404) error(404, t(locals.locale, 'error.notFound'));
+	if (!res.ok || !res.body) {
+		console.error(`[paperless-thumb] upstream status=${res.status} doc=${docId}`);
+		error(502, t(locals.locale, 'error.fileNotFound'));
+	}
+
+	// Headers built from scratch — never pass upstream headers through.
+	const contentType = res.headers.get('content-type') ?? 'image/webp';
+	const headers: Record<string, string> = {
+		'Content-Type': contentType.startsWith('image/') ? contentType : 'image/webp',
+		'Cache-Control': 'private, max-age=300',
+		'X-Content-Type-Options': 'nosniff',
+		'Content-Security-Policy': 'sandbox'
+	};
+
+	return new Response(res.body, { headers });
+};


### PR DESCRIPTION
Closes #95.

Adds per-companion document storage with optional import from a Paperless-ngx instance, requested in #95 (receipts, invoices, vaccination records, and other paperwork).

## What's included

- A Documents tab on each companion. Members and admins can upload PDFs and images (JPEG, PNG, WebP, HEIC) up to `UPLOAD_MAX_MB`, sort them into categories (receipt, invoice, medical, insurance, ownership, other), set a document date, and link a document to a health event.
- Read-only import from Paperless-ngx, modeled on the existing Immich integration. The picker searches Paperless and attaches a document by reference; the file stays in Paperless and EinVault proxies reads through the server using the token. Gated on `PAPERLESS_URL` + `PAPERLESS_API_TOKEN`, with optional `PAPERLESS_TAG_ID` scoping enforced at import time.
- In-browser PDF preview via pdf.js, with image previews inline.
- Documents in the main nav. To keep the mobile bottom bar at five tabs, Settings moved from the bottom bar to the top bar on mobile.

## Storage and serving

- Uploaded images are re-encoded with sharp (metadata stripped, decode bounded to 50MP); PDFs are stored as received. Reuses the existing local/S3 storage layer; Paperless is a read-only reference provider.
- The serving route looks up by document id, re-verifies the companion, and sets `Content-Type` from the database, `X-Content-Type-Options: nosniff`, and `Content-Security-Policy: sandbox`. Caretakers have no access to documents.

## Notes

- Schema change: new `documents` table (migration `0019`).
- New env vars documented in the README, `.env.example`, and both compose files: `PAPERLESS_URL`, `PAPERLESS_API_TOKEN`, `PAPERLESS_TAG_ID`, `MAX_DOCUMENTS_PER_COMPANION`.
- `npm run check` and `npm run lint` are clean. There is no test runner in the repo; the server paths were verified end to end against a live Paperless instance (upload, magic-byte rejection, serving headers, edit, delete, access control, and the Paperless search/thumbnail/download proxies).
- Known limitation: scanned PDFs that use JBIG2 or JPEG2000 make pdf.js instantiate WebAssembly, which the current CSP (`script-src 'self'`) blocks, so those fall back to download instead of inline preview. Enabling preview for them would mean adding `'wasm-unsafe-eval'` to `script-src`; left out of this PR as a separate CSP decision.
