### PR TITLE
ci: add job timeouts, type-check, and supply-chain hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,10 @@ build/
 .git/
 .gitignore
 
+# Credentials (never copy into build layers)
+.npmrc
+.netrc
+
 # Docs/meta
 README.md
 *.md

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Lint
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:
@@ -10,6 +12,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -18,3 +21,4 @@ jobs:
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npm run lint
+      - run: npm run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,6 +32,7 @@ jobs:
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npm run lint
+      - run: npm run check
 
   # Each architecture builds natively (arm64 on an arm runner, no QEMU) and
   # pushes by digest; the merge job below stitches the digests into one
@@ -48,6 +50,7 @@ jobs:
             arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -55,6 +58,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Build context only, no git operations: don't leave the token in
+          # .git/config where `COPY . .` could pull it into a build layer.
+          persist-credentials: false
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -121,6 +128,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: build
     permissions:
       contents: read
@@ -180,6 +188,7 @@ jobs:
   # branch and tag runs at the same time.
   promote:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     needs: lint
     if: github.ref_type == 'tag'
     permissions:


### PR DESCRIPTION
DevOps and security review of the release pipeline surfaced a set of hardening and efficiency gaps. None were broken or insecure; these close the real ones.

- **Job timeouts.** No job had `timeout-minutes`, so the default 360-minute timeout let a hung Buildx/Trivy/registry step bill for hours (worse on the arm64 runner). Added `timeout-minutes` to every job: lint 10, build 30, merge 15, promote 40, and the Lint workflow 10.
- **Type-check in CI.** CI only ran `npm run lint` (prettier + eslint). `npm run check` (svelte-check / TypeScript) ran nowhere, so type errors only surfaced late, inside the Docker build. Added it to the Lint workflow and the tag-gate lint job.
- **Duplicate lint runs.** The Lint workflow triggered on unscoped `push:` and `pull_request:`, so a PR branch linted twice on the same commit. Scoped `push:` to `main`.
- **persist-credentials.** The build checkout left the token in `.git/config`; `COPY . .` only stayed safe via the single `.dockerignore` `.git/` line. Set `persist-credentials: false` (the checkout is a build context, no git ops).
- **.dockerignore.** Added `.npmrc` and `.netrc` as defense in depth so a stray credential file can never enter a build layer.
