### PR TITLE
Expand unit coverage and add service fakes for e2e

### DIFF
--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown, stripMarkdown } from './markdown';
+
+describe('renderMarkdown', () => {
+	it('renders basic markdown', () => {
+		const html = renderMarkdown('**bold** and *em* and `code`');
+		expect(html).toContain('<strong>bold</strong>');
+		expect(html).toContain('<em>em</em>');
+		expect(html).toContain('<code>code</code>');
+	});
+
+	it('strips raw HTML blocks entirely', () => {
+		const html = renderMarkdown('before\n\n<script>alert(1)</script>\n\nafter');
+		expect(html).not.toContain('<script');
+		expect(html).not.toContain('alert(1)');
+	});
+
+	it('neutralizes javascript: links', () => {
+		const html = renderMarkdown('[click](javascript:alert(1))');
+		expect(html).not.toContain('javascript:');
+	});
+
+	it('keeps safe links but only href/rel attributes', () => {
+		const html = renderMarkdown('[ok](https://example.com)');
+		expect(html).toContain('href="https://example.com"');
+	});
+
+	it('strips event handlers and disallowed tags injected via inline HTML', () => {
+		const html = renderMarkdown('<img src=x onerror=alert(1)> and <iframe src="x"></iframe>');
+		expect(html).not.toContain('<img');
+		expect(html).not.toContain('onerror');
+		expect(html).not.toContain('<iframe');
+	});
+
+	it('blocks data attributes', () => {
+		const html = renderMarkdown('<p data-evil="1">x</p>');
+		expect(html).not.toContain('data-evil');
+	});
+});
+
+describe('stripMarkdown', () => {
+	it('removes markdown syntax characters and trims', () => {
+		expect(stripMarkdown('# Head **bold** `code` [link](x)')).toBe('Head bold code link(x)');
+		expect(stripMarkdown('  > quoted  ')).toBe('quoted');
+	});
+});

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -17,12 +17,17 @@ describe('renderMarkdown', () => {
 
 	it('neutralizes javascript: links', () => {
 		const html = renderMarkdown('[click](javascript:alert(1))');
-		expect(html).not.toContain('javascript:');
+		expect(html.toLowerCase()).not.toContain('javascript:');
+		const mixed = renderMarkdown('[click](JaVaScRiPt:alert(1))');
+		expect(mixed.toLowerCase()).not.toContain('javascript:');
 	});
 
 	it('keeps safe links but only href/rel attributes', () => {
-		const html = renderMarkdown('[ok](https://example.com)');
+		const html = renderMarkdown('[ok](https://example.com "tip")');
 		expect(html).toContain('href="https://example.com"');
+		// title comes from markdown but is not in ALLOWED_ATTR; a config
+		// regression would let it through.
+		expect(html).not.toContain('title=');
 	});
 
 	it('strips event handlers and disallowed tags injected via inline HTML', () => {

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { canModifyPhoto } from './permissions';
+
+const admin = { id: 'a1', role: 'admin' } as const;
+const member = { id: 'm1', role: 'member' } as const;
+
+describe('canModifyPhoto', () => {
+	it('rejects missing user', () => {
+		expect(canModifyPhoto(null, { loggedBy: 'm1' })).toBe(false);
+		expect(canModifyPhoto(undefined, { loggedBy: 'm1' })).toBe(false);
+	});
+
+	it('admin can modify any photo, including legacy null-loggedBy rows', () => {
+		expect(canModifyPhoto(admin, { loggedBy: 'someone-else' })).toBe(true);
+		expect(canModifyPhoto(admin, { loggedBy: null })).toBe(true);
+	});
+
+	it('non-admin can modify only own photos', () => {
+		expect(canModifyPhoto(member, { loggedBy: 'm1' })).toBe(true);
+		expect(canModifyPhoto(member, { loggedBy: 'other' })).toBe(false);
+		expect(canModifyPhoto(member, { loggedBy: null })).toBe(false);
+	});
+});

--- a/src/lib/reminderRecurrence.test.ts
+++ b/src/lib/reminderRecurrence.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { packMonthDay, unpackMonthDay, daysInMonth, clampDayOfMonth } from './reminderRecurrence';
+
+describe('packMonthDay / unpackMonthDay', () => {
+	it('round-trips every calendar day', () => {
+		for (let m = 0; m < 12; m++) {
+			for (let d = 1; d <= 31; d++) {
+				expect(unpackMonthDay(packMonthDay(m, d))).toEqual({ monthIdx: m, day: d });
+			}
+		}
+	});
+
+	it('packs Feb 29 distinctly from Mar 1 (leap-year safety)', () => {
+		expect(packMonthDay(1, 29)).not.toBe(packMonthDay(2, 1));
+		expect(packMonthDay(1, 29)).toBe(229);
+		expect(packMonthDay(2, 1)).toBe(301);
+	});
+});
+
+describe('daysInMonth', () => {
+	it('knows month lengths', () => {
+		expect(daysInMonth(2026, 0)).toBe(31); // Jan
+		expect(daysInMonth(2026, 3)).toBe(30); // Apr
+	});
+
+	it('handles leap years', () => {
+		expect(daysInMonth(2024, 1)).toBe(29); // 2024 leap
+		expect(daysInMonth(2026, 1)).toBe(28); // 2026 not
+		expect(daysInMonth(2000, 1)).toBe(29); // divisible by 400
+		expect(daysInMonth(1900, 1)).toBe(28); // divisible by 100, not 400
+	});
+});
+
+describe('clampDayOfMonth', () => {
+	it('passes through valid days', () => {
+		expect(clampDayOfMonth(2026, 0, 31)).toBe(31);
+		expect(clampDayOfMonth(2026, 0, 1)).toBe(1);
+	});
+
+	it('clamps day 31 to short months', () => {
+		expect(clampDayOfMonth(2026, 1, 31)).toBe(28); // Feb non-leap
+		expect(clampDayOfMonth(2024, 1, 31)).toBe(29); // Feb leap
+		expect(clampDayOfMonth(2026, 3, 31)).toBe(30); // Apr
+	});
+});

--- a/src/lib/server/auth/oidc-state-cookie.test.ts
+++ b/src/lib/server/auth/oidc-state-cookie.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import type { Cookies } from '@sveltejs/kit';
+import {
+	setOidcStateCookie,
+	readAndClearOidcStateCookie,
+	type OidcStatePayload
+} from './oidc-state';
+
+function fakeCookies() {
+	const jar = new Map<string, string>();
+	const cookies = {
+		get: (name: string) => jar.get(name),
+		set: (name: string, value: string, _opts: unknown) => {
+			jar.set(name, value);
+		}
+	} as unknown as Cookies;
+	return { cookies, jar };
+}
+
+const payload: OidcStatePayload = {
+	state: 'state-123',
+	nonce: 'nonce-456',
+	codeVerifier: 'verifier-789',
+	returnTo: '/care',
+	createdAt: 1750000000000
+};
+
+describe('oidc state cookie', () => {
+	it('round-trips a payload', async () => {
+		const { cookies } = fakeCookies();
+		await setOidcStateCookie(cookies, payload, false);
+		const read = await readAndClearOidcStateCookie(cookies, false);
+		expect(read).toEqual(payload);
+	});
+
+	it('clears the cookie on read (single use)', async () => {
+		const { cookies, jar } = fakeCookies();
+		await setOidcStateCookie(cookies, payload, false);
+		await readAndClearOidcStateCookie(cookies, false);
+		expect(jar.get('einvault_oidc_state')).toBe('');
+		expect(await readAndClearOidcStateCookie(cookies, false)).toBeNull();
+	});
+
+	it('rejects a tampered payload', async () => {
+		const { cookies, jar } = fakeCookies();
+		await setOidcStateCookie(cookies, payload, false);
+		const raw = jar.get('einvault_oidc_state')!;
+		const [encoded, sig] = [
+			raw.slice(0, raw.lastIndexOf('.')),
+			raw.slice(raw.lastIndexOf('.') + 1)
+		];
+		const tampered = encoded.slice(0, -2) + 'xx' + '.' + sig;
+		jar.set('einvault_oidc_state', tampered);
+		expect(await readAndClearOidcStateCookie(cookies, false)).toBeNull();
+	});
+
+	it('rejects a missing or malformed cookie', async () => {
+		const { cookies, jar } = fakeCookies();
+		expect(await readAndClearOidcStateCookie(cookies, false)).toBeNull();
+		jar.set('einvault_oidc_state', 'no-dot-separator');
+		expect(await readAndClearOidcStateCookie(cookies, false)).toBeNull();
+	});
+
+	it('rejects a signed payload whose returnTo is invalid', async () => {
+		const { cookies } = fakeCookies();
+		await setOidcStateCookie(cookies, { ...payload, returnTo: 'https://evil.example.com' }, false);
+		expect(await readAndClearOidcStateCookie(cookies, false)).toBeNull();
+	});
+});

--- a/src/lib/server/auth/session.test.ts
+++ b/src/lib/server/auth/session.test.ts
@@ -5,7 +5,9 @@ import {
 	generateSessionToken,
 	createSession,
 	validateSessionToken,
-	invalidateSession
+	invalidateSession,
+	invalidateAllUserSessions,
+	cleanupExpiredSessions
 } from './session';
 
 async function insertUser(id: string, opts: { isActive?: boolean } = {}) {
@@ -81,5 +83,45 @@ describe('validateSessionToken', () => {
 		const result = await validateSessionToken(token);
 		expect(result).not.toBeNull();
 		expect(result!.session.expiresAt.getTime()).toBeGreaterThan(nearExpiry.getTime());
+	});
+});
+
+describe('invalidateAllUserSessions', () => {
+	it('removes every session for that user only', async () => {
+		await insertUser('u6');
+		await insertUser('u7');
+		const t1 = generateSessionToken();
+		const t2 = generateSessionToken();
+		const t3 = generateSessionToken();
+		await createSession(t1, 'u6');
+		await createSession(t2, 'u6');
+		await createSession(t3, 'u7');
+
+		await invalidateAllUserSessions('u6');
+
+		expect(await validateSessionToken(t1)).toBeNull();
+		expect(await validateSessionToken(t2)).toBeNull();
+		expect((await validateSessionToken(t3))!.user.id).toBe('u7');
+	});
+});
+
+describe('cleanupExpiredSessions', () => {
+	it('removes only expired rows', async () => {
+		await insertUser('u8');
+		const live = generateSessionToken();
+		const dead = generateSessionToken();
+		const liveSession = await createSession(live, 'u8');
+		const deadSession = await createSession(dead, 'u8');
+		await db
+			.update(schema.sessions)
+			.set({ expiresAt: new Date(Date.now() - 1000) })
+			.where(eq(schema.sessions.id, deadSession.id));
+
+		await cleanupExpiredSessions();
+
+		const rows = await db.query.sessions.findMany();
+		const ids = rows.map((r) => r.id);
+		expect(ids).toContain(liveSession.id);
+		expect(ids).not.toContain(deadSession.id);
 	});
 });

--- a/src/lib/server/journal.test.ts
+++ b/src/lib/server/journal.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { db, schema } from '$lib/server/db';
+import { upsertJournalEntry, getEnrichedJournalEntries } from './journal';
+
+describe('journal', () => {
+	beforeAll(async () => {
+		await db.insert(schema.users).values({
+			id: 'u-j',
+			username: 'journal-user',
+			displayName: 'J User',
+			role: 'member'
+		} as typeof schema.users.$inferInsert);
+		await db.insert(schema.companions).values({
+			id: 'c-j',
+			name: 'Journie'
+		} as typeof schema.companions.$inferInsert);
+	});
+
+	it('creates a new entry on first write for a date', async () => {
+		await upsertJournalEntry('c-j', '2026-03-01', 'first body', 'good', 'u-j');
+		const row = await db.query.journalEntries.findFirst({
+			where: and(
+				eq(schema.journalEntries.companionId, 'c-j'),
+				eq(schema.journalEntries.date, '2026-03-01')
+			)
+		});
+		expect(row).toMatchObject({ body: 'first body', mood: 'good', loggedBy: 'u-j' });
+	});
+
+	it('updates in place on second write for the same date (no duplicate row)', async () => {
+		await upsertJournalEntry('c-j', '2026-03-01', 'second body', 'meh', 'u-j');
+		const rows = await db.query.journalEntries.findMany({
+			where: and(
+				eq(schema.journalEntries.companionId, 'c-j'),
+				eq(schema.journalEntries.date, '2026-03-01')
+			)
+		});
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({ body: 'second body', mood: 'meh' });
+		expect(rows[0].updatedAt).not.toBeNull();
+	});
+
+	it('coerces null body to empty string', async () => {
+		await upsertJournalEntry('c-j', '2026-03-02', null, null, 'u-j');
+		const row = await db.query.journalEntries.findFirst({
+			where: and(
+				eq(schema.journalEntries.companionId, 'c-j'),
+				eq(schema.journalEntries.date, '2026-03-02')
+			)
+		});
+		expect(row!.body).toBe('');
+		expect(row!.mood).toBeNull();
+	});
+
+	it('paginates with hasMore and oldestDate', async () => {
+		for (let d = 1; d <= 5; d++) {
+			await upsertJournalEntry('c-j', `2026-04-0${d}`, `day ${d}`, null, 'u-j');
+		}
+		const page = await getEnrichedJournalEntries('c-j', { limit: 3 });
+		expect(page.entries).toHaveLength(3);
+		expect(page.hasMore).toBe(true);
+		expect(page.entries[0].date > page.entries[2].date).toBe(true); // newest first
+		expect(page.oldestDate).toBe(page.entries[2].date);
+
+		const rest = await getEnrichedJournalEntries('c-j', { limit: 50, before: page.oldestDate! });
+		expect(rest.entries.every((e) => e.date < page.oldestDate!)).toBe(true);
+		expect(rest.hasMore).toBe(false);
+	});
+});

--- a/src/lib/server/permissions.test.ts
+++ b/src/lib/server/permissions.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { db, schema } from '$lib/server/db';
+import { assertCanEditCompanion } from './permissions';
+
+type Locals = Parameters<typeof assertCanEditCompanion>[0];
+
+function locals(user: { id: string; role: 'admin' | 'member' | 'caretaker' } | null): Locals {
+	return { user, session: null, locale: 'en' } as unknown as Locals;
+}
+
+async function statusOf(p: Promise<void>): Promise<number | 'ok'> {
+	try {
+		await p;
+		return 'ok';
+	} catch (e) {
+		return (e as { status: number }).status;
+	}
+}
+
+describe('assertCanEditCompanion', () => {
+	beforeAll(async () => {
+		await db.insert(schema.users).values([
+			{ id: 'adm', username: 'adm', displayName: 'A', role: 'admin' },
+			{ id: 'mem', username: 'mem', displayName: 'M', role: 'member' },
+			{ id: 'ct-in', username: 'ctin', displayName: 'C1', role: 'caretaker' },
+			{ id: 'ct-out', username: 'ctout', displayName: 'C2', role: 'caretaker' }
+		] as (typeof schema.users.$inferInsert)[]);
+		await db.insert(schema.companions).values({
+			id: 'comp1',
+			name: 'Comp'
+		} as typeof schema.companions.$inferInsert);
+		await db.insert(schema.companionCaretakers).values({
+			companionId: 'comp1',
+			userId: 'ct-in'
+		} as typeof schema.companionCaretakers.$inferInsert);
+	});
+
+	it('401 for anonymous', async () => {
+		expect(await statusOf(assertCanEditCompanion(locals(null), 'comp1'))).toBe(401);
+	});
+
+	it('allows admins and members', async () => {
+		expect(
+			await statusOf(assertCanEditCompanion(locals({ id: 'adm', role: 'admin' }), 'comp1'))
+		).toBe('ok');
+		expect(
+			await statusOf(assertCanEditCompanion(locals({ id: 'mem', role: 'member' }), 'comp1'))
+		).toBe('ok');
+	});
+
+	it('allows assigned caretakers, 403 for unassigned', async () => {
+		expect(
+			await statusOf(assertCanEditCompanion(locals({ id: 'ct-in', role: 'caretaker' }), 'comp1'))
+		).toBe('ok');
+		expect(
+			await statusOf(assertCanEditCompanion(locals({ id: 'ct-out', role: 'caretaker' }), 'comp1'))
+		).toBe(403);
+	});
+});

--- a/src/lib/server/reminderUndo.test.ts
+++ b/src/lib/server/reminderUndo.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: new Proxy({} as Record<string, string | undefined>, {
+		get: (_, key: string) => process.env[key]
+	})
+}));
+
+async function loadEnvModule() {
+	vi.resetModules();
+	return await import('$lib/server/env');
+}
+
+describe('reminder undo resolution', () => {
+	beforeEach(() => {
+		delete process.env.REMINDER_UNDO_SECONDS;
+	});
+
+	it('defaults to 7 when unset', async () => {
+		const mod = await loadEnvModule();
+		expect(mod.REMINDER_UNDO_SECONDS_DEFAULT).toBe(7);
+	});
+
+	it('honors the env override and clamps it to the max', async () => {
+		process.env.REMINDER_UNDO_SECONDS = '15';
+		expect((await loadEnvModule()).REMINDER_UNDO_SECONDS_DEFAULT).toBe(15);
+
+		process.env.REMINDER_UNDO_SECONDS = '999';
+		expect((await loadEnvModule()).REMINDER_UNDO_SECONDS_DEFAULT).toBe(60);
+	});
+
+	it('falls back to default for junk env values', async () => {
+		process.env.REMINDER_UNDO_SECONDS = 'banana';
+		expect((await loadEnvModule()).REMINDER_UNDO_SECONDS_DEFAULT).toBe(7);
+
+		process.env.REMINDER_UNDO_SECONDS = '-3';
+		expect((await loadEnvModule()).REMINDER_UNDO_SECONDS_DEFAULT).toBe(7);
+	});
+
+	it('resolveReminderUndoSeconds prefers a valid user pref, clamped', async () => {
+		const mod = await loadEnvModule();
+		expect(mod.resolveReminderUndoSeconds(3)).toBe(3);
+		expect(mod.resolveReminderUndoSeconds(0)).toBe(0);
+		expect(mod.resolveReminderUndoSeconds(999)).toBe(60);
+	});
+
+	it('resolveReminderUndoSeconds falls back to the site default for null/undefined/invalid', async () => {
+		process.env.REMINDER_UNDO_SECONDS = '12';
+		const mod = await loadEnvModule();
+		expect(mod.resolveReminderUndoSeconds(null)).toBe(12);
+		expect(mod.resolveReminderUndoSeconds(undefined)).toBe(12);
+		expect(mod.resolveReminderUndoSeconds(2.5)).toBe(12);
+		expect(mod.resolveReminderUndoSeconds(-1)).toBe(12);
+	});
+});

--- a/src/lib/server/reminders.test.ts
+++ b/src/lib/server/reminders.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, schema } from '$lib/server/db';
+import { computeNextDueAt, completeReminder } from './reminders';
+
+type Reminder = typeof schema.reminders.$inferSelect;
+
+function reminder(partial: Partial<Reminder>): Reminder {
+	return {
+		isRecurring: true,
+		recurrenceUnit: 'day',
+		recurrenceInterval: 1,
+		recurrenceAnchor: 'interval',
+		recurrenceAnchorValue: null,
+		dueAt: new Date(2026, 0, 15, 9, 0, 0),
+		...partial
+	} as Reminder;
+}
+
+describe('computeNextDueAt', () => {
+	it('returns null for non-recurring reminders', () => {
+		expect(computeNextDueAt(reminder({ isRecurring: false }))).toBeNull();
+	});
+
+	it('returns null for missing or invalid interval', () => {
+		expect(computeNextDueAt(reminder({ recurrenceInterval: null }))).toBeNull();
+		expect(computeNextDueAt(reminder({ recurrenceInterval: 0 }))).toBeNull();
+		expect(computeNextDueAt(reminder({ recurrenceUnit: null }))).toBeNull();
+	});
+
+	it('advances days and weeks, preserving wall-clock time', () => {
+		const daily = computeNextDueAt(reminder({ recurrenceUnit: 'day', recurrenceInterval: 3 }));
+		expect(daily).toEqual(new Date(2026, 0, 18, 9, 0, 0));
+
+		const weekly = computeNextDueAt(reminder({ recurrenceUnit: 'week', recurrenceInterval: 2 }));
+		expect(weekly).toEqual(new Date(2026, 0, 29, 9, 0, 0));
+	});
+
+	it('clamps monthly advancement into short months', () => {
+		const next = computeNextDueAt(
+			reminder({
+				recurrenceUnit: 'month',
+				recurrenceInterval: 1,
+				dueAt: new Date(2026, 0, 31, 9, 0, 0)
+			})
+		);
+		expect(next).toEqual(new Date(2026, 1, 28, 9, 0, 0)); // Feb 2026 non-leap
+	});
+
+	it('recovers the anchored day after a short month (no drift)', () => {
+		// Series anchored to day 31; advancing FROM the clamped Feb 28 must land
+		// back on Mar 31, not Mar 28.
+		const next = computeNextDueAt(
+			reminder({
+				recurrenceUnit: 'month',
+				recurrenceInterval: 1,
+				recurrenceAnchorValue: 31,
+				dueAt: new Date(2026, 1, 28, 9, 0, 0)
+			})
+		);
+		expect(next).toEqual(new Date(2026, 2, 31, 9, 0, 0));
+	});
+
+	it('handles month intervals that cross a year boundary', () => {
+		const next = computeNextDueAt(
+			reminder({
+				recurrenceUnit: 'month',
+				recurrenceInterval: 3,
+				dueAt: new Date(2026, 10, 15, 9, 0, 0) // Nov 15
+			})
+		);
+		expect(next).toEqual(new Date(2027, 1, 15, 9, 0, 0)); // Feb 15 next year
+	});
+
+	it('yearly Feb 29 clamps in non-leap years and recovers in leap years', () => {
+		// packMonthDay(1, 29) = 229
+		const fromLeap = computeNextDueAt(
+			reminder({
+				recurrenceUnit: 'year',
+				recurrenceInterval: 1,
+				recurrenceAnchor: 'day_of_year',
+				recurrenceAnchorValue: 229,
+				dueAt: new Date(2024, 1, 29, 9, 0, 0)
+			})
+		);
+		expect(fromLeap).toEqual(new Date(2025, 1, 28, 9, 0, 0));
+
+		const intoLeap = computeNextDueAt(
+			reminder({
+				recurrenceUnit: 'year',
+				recurrenceInterval: 1,
+				recurrenceAnchor: 'day_of_year',
+				recurrenceAnchorValue: 229,
+				dueAt: new Date(2027, 1, 28, 9, 0, 0)
+			})
+		);
+		expect(intoLeap).toEqual(new Date(2028, 1, 29, 9, 0, 0));
+	});
+});
+
+describe('completeReminder', () => {
+	beforeAll(async () => {
+		await db.insert(schema.users).values({
+			id: 'u-rem',
+			username: 'rem-user',
+			displayName: 'Rem User',
+			role: 'member'
+		} as typeof schema.users.$inferInsert);
+		await db.insert(schema.companions).values({
+			id: 'c-rem',
+			name: 'Remmy'
+		} as typeof schema.companions.$inferInsert);
+	});
+
+	it('marks complete and inserts the next instance with seriesId', async () => {
+		await db.insert(schema.reminders).values({
+			id: 'r1',
+			companionId: 'c-rem',
+			title: 'Pill',
+			type: 'medication',
+			dueAt: new Date(2026, 0, 15, 9, 0, 0),
+			isRecurring: true,
+			recurrenceUnit: 'day',
+			recurrenceInterval: 1,
+			loggedBy: 'u-rem'
+		} as typeof schema.reminders.$inferInsert);
+		const row = await db.query.reminders.findFirst({ where: eq(schema.reminders.id, 'r1') });
+
+		completeReminder(row!, 'u-rem');
+
+		const done = await db.query.reminders.findFirst({ where: eq(schema.reminders.id, 'r1') });
+		expect(done!.completedAt).not.toBeNull();
+		expect(done!.completedBy).toBe('u-rem');
+
+		const all = await db.query.reminders.findMany({
+			where: eq(schema.reminders.companionId, 'c-rem')
+		});
+		const next = all.find((r) => r.id !== 'r1');
+		expect(next).toBeDefined();
+		expect(next!.seriesId).toBe('r1'); // first completion seeds seriesId from origin id
+		expect(next!.completedAt).toBeNull();
+		expect(next!.dueAt).toEqual(new Date(2026, 0, 16, 9, 0, 0));
+	});
+
+	it('does not insert a next instance for non-recurring reminders', async () => {
+		await db.insert(schema.reminders).values({
+			id: 'r2',
+			companionId: 'c-rem',
+			title: 'One-off',
+			type: 'other',
+			dueAt: new Date(2026, 0, 20, 9, 0, 0),
+			isRecurring: false,
+			loggedBy: 'u-rem'
+		} as typeof schema.reminders.$inferInsert);
+		const row = await db.query.reminders.findFirst({ where: eq(schema.reminders.id, 'r2') });
+		const countBefore = (await db.query.reminders.findMany()).length;
+
+		completeReminder(row!, 'u-rem');
+
+		expect((await db.query.reminders.findMany()).length).toBe(countBefore);
+	});
+});

--- a/tests/fakes/immich.test.ts
+++ b/tests/fakes/immich.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startImmichFake, makeImmichAsset, type ImmichFake } from './immich';
+
+describe('immich fake', () => {
+	let fake: ImmichFake;
+	const auth = () => ({ 'x-api-key': fake.apiKey });
+
+	beforeAll(async () => {
+		fake = await startImmichFake();
+		fake.setAssets([makeImmichAsset('a1'), makeImmichAsset('a2'), makeImmichAsset('a3')]);
+	});
+	afterAll(async () => {
+		await fake.stop();
+	});
+
+	it('rejects a wrong api key', async () => {
+		const res = await fetch(`${fake.url}/api/assets/a1`, { headers: { 'x-api-key': 'wrong' } });
+		expect(res.status).toBe(401);
+	});
+
+	it('paginates search/metadata', async () => {
+		const res = await fetch(`${fake.url}/api/search/metadata`, {
+			method: 'POST',
+			headers: { ...auth(), 'content-type': 'application/json' },
+			body: JSON.stringify({ page: 1, size: 2, type: 'IMAGE', order: 'desc' })
+		});
+		const body = (await res.json()) as { assets: { items: unknown[]; nextPage: string | null } };
+		expect(body.assets.items).toHaveLength(2);
+		expect(body.assets.nextPage).toBe('2');
+	});
+
+	it('serves album contents, single assets, and image bytes', async () => {
+		const album = await fetch(`${fake.url}/api/albums/alb-1`, { headers: auth() });
+		expect(((await album.json()) as { assets: unknown[] }).assets).toHaveLength(3);
+
+		const asset = await fetch(`${fake.url}/api/assets/a2`, { headers: auth() });
+		expect(((await asset.json()) as { id: string }).id).toBe('a2');
+
+		const thumb = await fetch(`${fake.url}/api/assets/a2/thumbnail?size=preview`, {
+			headers: auth()
+		});
+		expect(thumb.headers.get('content-type')).toBe('image/png');
+		expect((await thumb.arrayBuffer()).byteLength).toBe(fake.imageBytes.length);
+
+		expect((await fetch(`${fake.url}/api/assets/missing`, { headers: auth() })).status).toBe(404);
+	});
+});

--- a/tests/fakes/immich.ts
+++ b/tests/fakes/immich.ts
@@ -1,0 +1,134 @@
+/**
+ * Minimal Immich API fake for unit and e2e tests.
+ *
+ * App env wiring for specs that exercise Immich storage:
+ *   STORAGE_BACKEND=immich
+ *   IMMICH_URL=<fake.url>              (e.g. http://127.0.0.1:<port>)
+ *   IMMICH_API_KEY=immich-test-key
+ *   IMMICH_ALBUM_ID=<albumId>          (optional; omit to use search/metadata mode)
+ */
+
+import http from 'node:http';
+import type { Fake } from './types';
+
+export interface ImmichAsset {
+	id: string;
+	originalFileName: string;
+	originalMimeType: string;
+	fileSizeInByte: number;
+	thumbhash: string | null;
+	fileCreatedAt: string;
+	type: 'IMAGE' | 'VIDEO';
+}
+
+export interface ImmichFake extends Fake {
+	port: number;
+	apiKey: string;
+	/** Replace the asset library (also used for album contents). */
+	setAssets(assets: ImmichAsset[]): void;
+	/** Raw bytes served for thumbnail/original requests. */
+	imageBytes: Buffer;
+}
+
+// 1x1 transparent PNG.
+const PNG = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+	'base64'
+);
+
+export function makeImmichAsset(id: string, overrides?: Partial<ImmichAsset>): ImmichAsset {
+	return {
+		id,
+		originalFileName: `${id}.png`,
+		originalMimeType: 'image/png',
+		fileSizeInByte: PNG.length,
+		thumbhash: null,
+		fileCreatedAt: '2026-01-01T00:00:00.000Z',
+		type: 'IMAGE',
+		...overrides
+	};
+}
+
+export async function startImmichFake(apiKey = 'immich-test-key'): Promise<ImmichFake> {
+	let assets: ImmichAsset[] = [];
+
+	const server = http.createServer((req, res) => {
+		if (req.headers['x-api-key'] !== apiKey) {
+			res.writeHead(401, { 'content-type': 'application/json' }).end('{"message":"unauthorized"}');
+			return;
+		}
+		const url = new URL(req.url!, 'http://localhost');
+		const json = (status: number, body: unknown) =>
+			res.writeHead(status, { 'content-type': 'application/json' }).end(JSON.stringify(body));
+
+		if (req.method === 'POST' && url.pathname === '/api/search/metadata') {
+			const chunks: Buffer[] = [];
+			req.on('data', (c) => chunks.push(c));
+			req.on('end', () => {
+				const body = JSON.parse(Buffer.concat(chunks).toString() || '{}') as {
+					page?: number;
+					size?: number;
+				};
+				const page = body.page ?? 1;
+				const size = body.size ?? 100;
+				const items = assets.slice((page - 1) * size, page * size);
+				const hasNext = page * size < assets.length;
+				json(200, { assets: { items, nextPage: hasNext ? String(page + 1) : null } });
+			});
+			return;
+		}
+
+		const albumMatch = /^\/api\/albums\/([^/]+)$/.exec(url.pathname);
+		if (req.method === 'GET' && albumMatch) {
+			json(200, { id: albumMatch[1], assets });
+			return;
+		}
+
+		const bytesMatch = /^\/api\/assets\/([^/]+)\/(thumbnail|original)$/.exec(url.pathname);
+		if (req.method === 'GET' && bytesMatch) {
+			const asset = assets.find((a) => a.id === bytesMatch[1]);
+			if (!asset) {
+				json(404, { message: 'not found' });
+				return;
+			}
+			res.writeHead(200, { 'content-type': 'image/png', 'content-length': PNG.length });
+			res.end(PNG);
+			return;
+		}
+
+		const assetMatch = /^\/api\/assets\/([^/]+)$/.exec(url.pathname);
+		if (req.method === 'GET' && assetMatch) {
+			const asset = assets.find((a) => a.id === assetMatch[1]);
+			if (!asset) {
+				json(404, { message: 'not found' });
+				return;
+			}
+			json(200, asset);
+			return;
+		}
+
+		json(404, { message: 'unknown endpoint' });
+	});
+
+	const port = await new Promise<number>((resolve, reject) => {
+		server.listen(0, '127.0.0.1', () => {
+			const addr = server.address();
+			if (addr && typeof addr === 'object') resolve(addr.port);
+			else reject(new Error('immich fake: no port'));
+		});
+	});
+
+	return {
+		url: `http://127.0.0.1:${port}`,
+		port,
+		apiKey,
+		imageBytes: PNG,
+		setAssets(next) {
+			assets = next;
+		},
+		reset() {
+			assets = [];
+		},
+		stop: () => new Promise((resolve) => server.close(() => resolve()))
+	};
+}

--- a/tests/fakes/ntfy.test.ts
+++ b/tests/fakes/ntfy.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startNtfyFake, type NtfyFake } from './ntfy';
+
+describe('ntfy fake', () => {
+	let fake: NtfyFake;
+	beforeAll(async () => {
+		fake = await startNtfyFake();
+	});
+	afterAll(async () => {
+		await fake.stop();
+	});
+
+	it('records a publish with auth header and resolves waiters', async () => {
+		const waiting = fake.waitForPublish((p) => p.topic === 'topic-a', 5000);
+		const res = await fetch(fake.url, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json', authorization: 'Bearer tok-1' },
+			body: JSON.stringify({ topic: 'topic-a', title: 'T', message: 'M', click: 'http://x' })
+		});
+		expect(res.ok).toBe(true);
+		const pub = await waiting;
+		expect(pub).toMatchObject({
+			topic: 'topic-a',
+			title: 'T',
+			message: 'M',
+			click: 'http://x',
+			authorization: 'Bearer tok-1'
+		});
+	});
+
+	it('rejects non-POST and malformed bodies', async () => {
+		expect((await fetch(fake.url)).status).toBe(405);
+		expect((await fetch(fake.url, { method: 'POST', body: 'not json' })).status).toBe(400);
+	});
+
+	it('reset clears recorded publishes', async () => {
+		fake.reset();
+		expect(fake.publishes).toHaveLength(0);
+	});
+});

--- a/tests/fakes/ntfy.ts
+++ b/tests/fakes/ntfy.ts
@@ -1,0 +1,90 @@
+import http from 'node:http';
+import type { Fake } from './types';
+
+export interface NtfyPublish {
+	topic: string;
+	title?: string;
+	message?: string;
+	click?: string;
+	authorization: string | null;
+}
+
+export interface NtfyFake extends Fake {
+	port: number;
+	publishes: NtfyPublish[];
+	/** Resolves when a captured publish matches; rejects after timeoutMs. */
+	waitForPublish(match: (p: NtfyPublish) => boolean, timeoutMs?: number): Promise<NtfyPublish>;
+}
+
+export async function startNtfyFake(): Promise<NtfyFake> {
+	const publishes: NtfyPublish[] = [];
+	const waiters: Array<{ match: (p: NtfyPublish) => boolean; resolve: (p: NtfyPublish) => void }> =
+		[];
+
+	const server = http.createServer((req, res) => {
+		if (req.method !== 'POST') {
+			res.writeHead(405).end();
+			return;
+		}
+		const chunks: Buffer[] = [];
+		req.on('data', (c) => chunks.push(c));
+		req.on('end', () => {
+			try {
+				const body = JSON.parse(Buffer.concat(chunks).toString()) as Omit<
+					NtfyPublish,
+					'authorization'
+				>;
+				const publish: NtfyPublish = {
+					...body,
+					authorization: req.headers.authorization ?? null
+				};
+				publishes.push(publish);
+				for (let i = waiters.length - 1; i >= 0; i--) {
+					if (waiters[i].match(publish)) {
+						waiters[i].resolve(publish);
+						waiters.splice(i, 1);
+					}
+				}
+				res.writeHead(200, { 'content-type': 'application/json' }).end('{}');
+			} catch {
+				res.writeHead(400).end();
+			}
+		});
+	});
+
+	const port = await new Promise<number>((resolve, reject) => {
+		server.listen(0, '127.0.0.1', () => {
+			const addr = server.address();
+			if (addr && typeof addr === 'object') resolve(addr.port);
+			else reject(new Error('ntfy fake: no port'));
+		});
+	});
+
+	return {
+		url: `http://127.0.0.1:${port}`,
+		port,
+		publishes,
+		waitForPublish(match, timeoutMs = 15_000) {
+			const existing = publishes.find(match);
+			if (existing) return Promise.resolve(existing);
+			return new Promise((resolve, reject) => {
+				const timer = setTimeout(
+					() => reject(new Error('ntfy fake: timed out waiting for publish')),
+					timeoutMs
+				);
+				waiters.push({
+					match,
+					resolve: (p) => {
+						clearTimeout(timer);
+						resolve(p);
+					}
+				});
+			});
+		},
+		reset() {
+			publishes.length = 0;
+			waiters.length = 0;
+		},
+		stop: () => new Promise((resolve) => server.close(() => resolve()))
+	};
+}

--- a/tests/fakes/paperless.test.ts
+++ b/tests/fakes/paperless.test.ts
@@ -31,12 +31,16 @@ describe('paperless fake', () => {
 		expect(taggedBody.results[0]).not.toHaveProperty('content');
 
 		const queried = await fetch(`${fake.url}/api/documents/?query=insurance`, { headers: auth() });
-		expect(((await queried.json()) as { results: unknown[] }).results).toHaveLength(1);
+		const queriedBody = (await queried.json()) as { results: { title: string }[] };
+		expect(queriedBody.results).toHaveLength(1);
+		expect(queriedBody.results[0].title).toBe('Insurance policy');
 	});
 
 	it('serves detail, download bytes, and thumbnails', async () => {
 		const detail = await fetch(`${fake.url}/api/documents/1/`, { headers: auth() });
-		expect(((await detail.json()) as { title: string }).title).toBe('Vaccination record');
+		const detailBody = (await detail.json()) as Record<string, unknown>;
+		expect(detailBody.title).toBe('Vaccination record');
+		expect(detailBody).not.toHaveProperty('content');
 
 		const dl = await fetch(`${fake.url}/api/documents/1/download/`, { headers: auth() });
 		expect(dl.headers.get('content-type')).toBe('application/pdf');

--- a/tests/fakes/paperless.test.ts
+++ b/tests/fakes/paperless.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startPaperlessFake, makePaperlessDoc, type PaperlessFake } from './paperless';
+
+describe('paperless fake', () => {
+	let fake: PaperlessFake;
+	const auth = () => ({ authorization: `Token ${fake.token}` });
+
+	beforeAll(async () => {
+		fake = await startPaperlessFake();
+		fake.setDocuments([
+			makePaperlessDoc(1, { title: 'Vaccination record', tags: [7] }),
+			makePaperlessDoc(2, { title: 'Insurance policy', tags: [7] }),
+			makePaperlessDoc(3, { title: 'Receipt', tags: [9] })
+		]);
+	});
+	afterAll(async () => {
+		await fake.stop();
+	});
+
+	it('rejects a wrong token', async () => {
+		const res = await fetch(`${fake.url}/api/documents/`, {
+			headers: { authorization: 'Token wrong' }
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it('filters by tag and query, never exposes content in listings', async () => {
+		const tagged = await fetch(`${fake.url}/api/documents/?tags__id__all=7`, { headers: auth() });
+		const taggedBody = (await tagged.json()) as { results: Record<string, unknown>[] };
+		expect(taggedBody.results).toHaveLength(2);
+		expect(taggedBody.results[0]).not.toHaveProperty('content');
+
+		const queried = await fetch(`${fake.url}/api/documents/?query=insurance`, { headers: auth() });
+		expect(((await queried.json()) as { results: unknown[] }).results).toHaveLength(1);
+	});
+
+	it('serves detail, download bytes, and thumbnails', async () => {
+		const detail = await fetch(`${fake.url}/api/documents/1/`, { headers: auth() });
+		expect(((await detail.json()) as { title: string }).title).toBe('Vaccination record');
+
+		const dl = await fetch(`${fake.url}/api/documents/1/download/`, { headers: auth() });
+		expect(dl.headers.get('content-type')).toBe('application/pdf');
+		expect((await dl.text()).startsWith('%PDF')).toBe(true);
+
+		const thumb = await fetch(`${fake.url}/api/documents/1/thumb/`, { headers: auth() });
+		expect(thumb.headers.get('content-type')).toBe('image/png');
+
+		expect((await fetch(`${fake.url}/api/documents/99/`, { headers: auth() })).status).toBe(404);
+	});
+});

--- a/tests/fakes/paperless.ts
+++ b/tests/fakes/paperless.ts
@@ -1,0 +1,131 @@
+/**
+ * Minimal Paperless-ngx API fake for unit and e2e tests.
+ *
+ * App env wiring for specs that exercise the Paperless storage backend or the
+ * document picker:
+ *   PAPERLESS_URL=<fake.url>                  (e.g. http://127.0.0.1:<port>)
+ *   PAPERLESS_API_TOKEN=paperless-test-token
+ *   PAPERLESS_TAG_ID=<tagId>                  (optional; omit to search all docs)
+ */
+
+import http from 'node:http';
+import type { Fake } from './types';
+
+export interface PaperlessDoc {
+	id: number;
+	title: string;
+	created: string;
+	document_type: number | null;
+	archive_serial_number: string | null;
+	mime_type: string;
+	archived_file_name: string;
+	tags: number[];
+	/** Fake-only: bytes served by /download/. */
+	content: Buffer;
+}
+
+export interface PaperlessFake extends Fake {
+	port: number;
+	token: string;
+	setDocuments(docs: PaperlessDoc[]): void;
+}
+
+const PDF = Buffer.from('%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF\n');
+const PNG = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+	'base64'
+);
+
+export function makePaperlessDoc(id: number, overrides?: Partial<PaperlessDoc>): PaperlessDoc {
+	return {
+		id,
+		title: `Document ${id}`,
+		created: '2026-01-01T00:00:00Z',
+		document_type: null,
+		archive_serial_number: null,
+		mime_type: 'application/pdf',
+		archived_file_name: `doc-${id}.pdf`,
+		tags: [],
+		content: PDF,
+		...overrides
+	};
+}
+
+export async function startPaperlessFake(token = 'paperless-test-token'): Promise<PaperlessFake> {
+	let docs: PaperlessDoc[] = [];
+
+	const server = http.createServer((req, res) => {
+		if (req.headers.authorization !== `Token ${token}`) {
+			res.writeHead(401, { 'content-type': 'application/json' }).end('{"detail":"unauthorized"}');
+			return;
+		}
+		const url = new URL(req.url!, 'http://localhost');
+		const json = (status: number, body: unknown) =>
+			res.writeHead(status, { 'content-type': 'application/json' }).end(JSON.stringify(body));
+		const summarize = ({ content: _content, ...rest }: PaperlessDoc) => rest;
+
+		if (req.method === 'GET' && url.pathname === '/api/documents/') {
+			const page = Number(url.searchParams.get('page') ?? '1');
+			const size = Number(url.searchParams.get('page_size') ?? '25');
+			const query = url.searchParams.get('query')?.toLowerCase();
+			const tag = url.searchParams.get('tags__id__all');
+
+			let filtered = docs;
+			if (tag) filtered = filtered.filter((d) => d.tags.includes(Number(tag)));
+			if (query) filtered = filtered.filter((d) => d.title.toLowerCase().includes(query));
+
+			const results = filtered.slice((page - 1) * size, page * size).map(summarize);
+			const hasNext = page * size < filtered.length;
+			json(200, {
+				count: filtered.length,
+				next: hasNext ? `${url.pathname}?page=${page + 1}` : null,
+				results
+			});
+			return;
+		}
+
+		const detail = /^\/api\/documents\/(\d+)\/(download\/|thumb\/)?$/.exec(url.pathname);
+		if (req.method === 'GET' && detail) {
+			const doc = docs.find((d) => d.id === Number(detail[1]));
+			if (!doc) {
+				json(404, { detail: 'Not found.' });
+				return;
+			}
+			if (detail[2] === 'download/') {
+				res.writeHead(200, { 'content-type': doc.mime_type, etag: '"fake"' });
+				res.end(doc.content);
+				return;
+			}
+			if (detail[2] === 'thumb/') {
+				res.writeHead(200, { 'content-type': 'image/png' });
+				res.end(PNG);
+				return;
+			}
+			json(200, summarize(doc));
+			return;
+		}
+
+		json(404, { detail: 'unknown endpoint' });
+	});
+
+	const port = await new Promise<number>((resolve, reject) => {
+		server.listen(0, '127.0.0.1', () => {
+			const addr = server.address();
+			if (addr && typeof addr === 'object') resolve(addr.port);
+			else reject(new Error('paperless fake: no port'));
+		});
+	});
+
+	return {
+		url: `http://127.0.0.1:${port}`,
+		port,
+		token,
+		setDocuments(next) {
+			docs = next;
+		},
+		reset() {
+			docs = [];
+		},
+		stop: () => new Promise((resolve) => server.close(() => resolve()))
+	};
+}

--- a/tests/fakes/paperless.ts
+++ b/tests/fakes/paperless.ts
@@ -76,9 +76,11 @@ export async function startPaperlessFake(token = 'paperless-test-token'): Promis
 
 			const results = filtered.slice((page - 1) * size, page * size).map(summarize);
 			const hasNext = page * size < filtered.length;
+			const nextParams = new URLSearchParams(url.searchParams);
+			nextParams.set('page', String(page + 1));
 			json(200, {
 				count: filtered.length,
-				next: hasNext ? `${url.pathname}?page=${page + 1}` : null,
+				next: hasNext ? `${url.pathname}?${nextParams}` : null,
 				results
 			});
 			return;

--- a/tests/fakes/s3.test.ts
+++ b/tests/fakes/s3.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { startS3Fake, type S3Fake } from './s3';
+
+describe('s3 fake', () => {
+	let fake: S3Fake;
+	let base: string;
+	beforeAll(async () => {
+		fake = await startS3Fake();
+		base = `${fake.url}/${fake.bucket}`;
+	});
+	afterAll(async () => {
+		await fake.stop();
+	});
+
+	it('PUT stores, GET serves with content-type', async () => {
+		const put = await fetch(`${base}/photos/a%20b.jpg`, {
+			method: 'PUT',
+			headers: { 'content-type': 'image/jpeg' },
+			body: new Uint8Array(Buffer.from('jpegbytes'))
+		});
+		expect(put.ok).toBe(true);
+		expect(fake.objects.has('photos/a b.jpg')).toBe(true);
+
+		const get = await fetch(`${base}/photos/a%20b.jpg?X-Amz-Expires=300&X-Amz-Signature=ignored`);
+		expect(get.status).toBe(200);
+		expect(get.headers.get('content-type')).toBe('image/jpeg');
+		expect(await get.text()).toBe('jpegbytes');
+	});
+
+	it('serves single-range 206 responses', async () => {
+		await fetch(`${base}/video.mp4`, {
+			method: 'PUT',
+			body: new Uint8Array(Buffer.from('0123456789'))
+		});
+		const part = await fetch(`${base}/video.mp4`, { headers: { range: 'bytes=2-5' } });
+		expect(part.status).toBe(206);
+		expect(part.headers.get('content-range')).toBe('bytes 2-5/10');
+		expect(await part.text()).toBe('2345');
+
+		const tail = await fetch(`${base}/video.mp4`, { headers: { range: 'bytes=8-' } });
+		expect(tail.status).toBe(206);
+		expect(await tail.text()).toBe('89');
+
+		const bad = await fetch(`${base}/video.mp4`, { headers: { range: 'bytes=99-' } });
+		expect(bad.status).toBe(416);
+	});
+
+	it('GET 404s on missing keys, DELETE is idempotent', async () => {
+		expect((await fetch(`${base}/nope`)).status).toBe(404);
+		expect((await fetch(`${base}/nope`, { method: 'DELETE' })).status).toBe(204);
+	});
+
+	it('404s outside the bucket', async () => {
+		expect((await fetch(`${fake.url}/other-bucket/key`)).status).toBe(404);
+	});
+});

--- a/tests/fakes/s3.ts
+++ b/tests/fakes/s3.ts
@@ -1,0 +1,116 @@
+/**
+ * Minimal path-style S3 fake for unit and e2e tests.
+ *
+ * App env wiring for e2e specs that exercise S3 storage:
+ *   STORAGE_BACKEND=s3
+ *   S3_ENDPOINT=<fake.url>           (e.g. http://127.0.0.1:<port>)
+ *   S3_BUCKET=einvault-test
+ *   S3_REGION=auto
+ *   S3_ACCESS_KEY_ID=test
+ *   S3_SECRET_ACCESS_KEY=test
+ *   S3_FORCE_PATH_STYLE=true
+ */
+
+import http from 'node:http';
+import type { Fake } from './types';
+
+export interface S3Object {
+	body: Buffer;
+	contentType: string;
+}
+
+export interface S3Fake extends Fake {
+	port: number;
+	bucket: string;
+	/** key → object. Inspect or pre-seed directly. */
+	objects: Map<string, S3Object>;
+}
+
+const BUCKET = 'einvault-test';
+
+export async function startS3Fake(): Promise<S3Fake> {
+	const objects = new Map<string, S3Object>();
+
+	const server = http.createServer((req, res) => {
+		const url = new URL(req.url!, 'http://localhost');
+		const prefix = `/${BUCKET}/`;
+		if (!url.pathname.startsWith(prefix)) {
+			res.writeHead(404).end('<Error><Code>NoSuchBucket</Code></Error>');
+			return;
+		}
+		const key = decodeURIComponent(url.pathname.slice(prefix.length));
+
+		if (req.method === 'PUT') {
+			const chunks: Buffer[] = [];
+			req.on('data', (c) => chunks.push(c));
+			req.on('end', () => {
+				objects.set(key, {
+					body: Buffer.concat(chunks),
+					contentType: req.headers['content-type'] ?? 'application/octet-stream'
+				});
+				res.writeHead(200, { etag: '"fake"' }).end();
+			});
+			return;
+		}
+
+		if (req.method === 'DELETE') {
+			objects.delete(key); // S3 DELETE is idempotent: 204 even if absent
+			res.writeHead(204).end();
+			return;
+		}
+
+		if (req.method === 'GET' || req.method === 'HEAD') {
+			const obj = objects.get(key);
+			if (!obj) {
+				res.writeHead(404).end('<Error><Code>NoSuchKey</Code></Error>');
+				return;
+			}
+			const range = req.headers.range;
+			const m = range ? /^bytes=(\d+)-(\d*)$/.exec(range) : null;
+			if (m) {
+				const start = Number(m[1]);
+				const end = m[2] ? Math.min(Number(m[2]), obj.body.length - 1) : obj.body.length - 1;
+				if (start > end || start >= obj.body.length) {
+					res.writeHead(416, { 'content-range': `bytes */${obj.body.length}` }).end();
+					return;
+				}
+				res.writeHead(206, {
+					'content-type': obj.contentType,
+					'content-length': end - start + 1,
+					'content-range': `bytes ${start}-${end}/${obj.body.length}`,
+					'accept-ranges': 'bytes'
+				});
+				res.end(req.method === 'HEAD' ? undefined : obj.body.subarray(start, end + 1));
+				return;
+			}
+			res.writeHead(200, {
+				'content-type': obj.contentType,
+				'content-length': obj.body.length,
+				'accept-ranges': 'bytes'
+			});
+			res.end(req.method === 'HEAD' ? undefined : obj.body);
+			return;
+		}
+
+		res.writeHead(405).end();
+	});
+
+	const port = await new Promise<number>((resolve, reject) => {
+		server.listen(0, '127.0.0.1', () => {
+			const addr = server.address();
+			if (addr && typeof addr === 'object') resolve(addr.port);
+			else reject(new Error('s3 fake: no port'));
+		});
+	});
+
+	return {
+		url: `http://127.0.0.1:${port}`,
+		port,
+		bucket: BUCKET,
+		objects,
+		reset() {
+			objects.clear();
+		},
+		stop: () => new Promise((resolve) => server.close(() => resolve()))
+	};
+}

--- a/tests/fakes/smtp.test.ts
+++ b/tests/fakes/smtp.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import nodemailer from 'nodemailer';
+import { startSmtpSink, type SmtpSink } from './smtp';
+
+function sendMail(port: number, from: string, to: string, body: string): Promise<void> {
+	const transport = nodemailer.createTransport({
+		host: '127.0.0.1',
+		port,
+		secure: false,
+		tls: { rejectUnauthorized: false }
+	});
+	return transport
+		.sendMail({ from, to, subject: 'hello', text: body })
+		.then(() => transport.close());
+}
+
+describe('smtp sink', () => {
+	let sink: SmtpSink;
+	beforeAll(async () => {
+		sink = await startSmtpSink();
+	});
+	afterAll(async () => {
+		await sink.stop();
+	});
+
+	it('captures a delivered mail and resolves waitForMail', async () => {
+		const waiting = sink.waitForMail((m) => (m.text ?? '').includes('ping-1'), 5000);
+		await sendMail(sink.port, 'a@example.com', 'b@example.com', 'ping-1');
+		const mail = await waiting;
+		expect(mail.subject).toBe('hello');
+		expect(sink.messages.length).toBeGreaterThan(0);
+	});
+
+	it('reset clears messages and pending waiters', async () => {
+		// Clear state from previous test so the orphan waiter cannot fast-path
+		// against already-captured messages.
+		sink.reset();
+		const orphan = sink.waitForMail(() => true, 500);
+		sink.reset();
+		expect(sink.messages).toHaveLength(0);
+		// Orphaned waiter must reject on its own timeout, not resolve on later mail.
+		await sendMail(sink.port, 'a@example.com', 'b@example.com', 'ping-2');
+		await expect(orphan).rejects.toThrow(/timed out/);
+	});
+});

--- a/tests/fakes/smtp.ts
+++ b/tests/fakes/smtp.ts
@@ -64,6 +64,8 @@ export async function startSmtpSink(): Promise<SmtpSink> {
 		},
 		reset() {
 			messages.length = 0;
+			// Abandon pending waiters; their callers own the timeout rejection.
+			waiters.length = 0;
 		},
 		stop: () => new Promise((resolve) => server.close(() => resolve()))
 	};

--- a/tests/lib/fixtures.ts
+++ b/tests/lib/fixtures.ts
@@ -48,29 +48,34 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 			// change passwords for the cached roles (admin/member/caretaker) — the
 			// cookie in the state file would go stale for the rest of the worker.
 			// Destructive flows use SEED.resetUser or a dedicated seed identity.
-			const statePaths = new Map<Role, string>();
+			const statePromises = new Map<Role, Promise<string>>();
 			const app: AppWorker = {
 				server,
 				smtp,
 				dataDir,
-				async stateFor(role, browser) {
-					const cached = statePaths.get(role);
-					if (cached) return cached;
-					const user = SEED[role];
-					const context = await browser.newContext({ baseURL: server.baseURL });
-					const page = await context.newPage();
-					await page.goto('/auth/login');
-					await page.getByLabel('Username').fill(user.username);
-					await page.getByLabel('Password').fill(SEED.password);
-					await page.getByRole('button', { name: 'Sign in' }).click();
-					// Login failure here is also the harness's "server sees the seeded
-					// DB" assertion (guards resolveDbPath silent fallback).
-					await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
-					const statePath = path.join(dataDir, `state-${role}.json`);
-					await context.storageState({ path: statePath });
-					await context.close();
-					statePaths.set(role, statePath);
-					return statePath;
+				stateFor(role, browser) {
+					const inflight = statePromises.get(role);
+					if (inflight) return inflight;
+					const promise = (async () => {
+						const user = SEED[role];
+						const context = await browser.newContext({ baseURL: server.baseURL });
+						const page = await context.newPage();
+						await page.goto('/auth/login');
+						await page.getByLabel('Username').fill(user.username);
+						await page.getByLabel('Password').fill(SEED.password);
+						await page.getByRole('button', { name: 'Sign in' }).click();
+						// Login failure here is also the harness's "server sees the seeded
+						// DB" assertion (guards resolveDbPath silent fallback).
+						await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
+						const statePath = path.join(dataDir, `state-${role}.json`);
+						await context.storageState({ path: statePath });
+						await context.close();
+						return statePath;
+					})();
+					statePromises.set(role, promise);
+					// A failed login attempt must not poison the cache for retries.
+					promise.catch(() => statePromises.delete(role));
+					return promise;
 				}
 			};
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 		port: 5173
 	},
 	test: {
-		include: ['src/**/*.test.ts'],
+		include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
 		environment: 'node',
 		setupFiles: ['./src/vitest.setup.ts']
 	}


### PR DESCRIPTION
## Summary

Test internals build-out (part of #96, follows #103):

- **Unit suite 25 → 84 tests:** session bulk invalidation and expiry cleanup, reminder recurrence math (short-month clamping, Feb 29 anchors, no-drift advancement), undo-window env resolution, both permission modules, journal upsert/pagination, markdown XSS sanitization, OIDC state cookie HMAC round-trip/tamper/single-use.
- **Four service fakes** in `tests/fakes/`, each loopback-only with vitest self-tests: ntfy recorder, S3 path-style blob store (single-range 206 for video), Immich, Paperless. These unblock the feature e2e specs planned next.
- **Harness fixes:** smtp sink `reset()` drains pending waiters, worker fixture caches in-flight role logins (dedupes concurrent first logins, evicts on failure), vitest include widened to `tests/**/*.test.ts`.

No production code changes.

## Test plan

- [x] `npm run lint`, `npm run check` clean
- [x] `npm run test:unit` — 84 passed (17 files)
- [x] `PW_SKIP_BUILD=1 npm run test:e2e` — 16 passed, run twice, no flake
- [x] CI green on this PR