### PR TITLE
Exhaustive feature e2e coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ npm run test:e2e    # end-to-end tests (Playwright, builds the app first)
 npm test            # both
 ```
 
-Unit tests live next to the code they cover (`src/**/*.test.ts`) and each test file gets a fresh in-memory database. E2e specs live in `tests/e2e/` and drive a real browser against real server processes booted from the production build; shared fixtures, seed data, and fakes (SMTP sink, mock OIDC IdP) live in `tests/lib/` and `tests/fakes/`.
+Unit tests live next to the code they cover (`src/**/*.test.ts`) and each test file gets a fresh in-memory database. E2e specs live in `tests/e2e/` and drive a real browser against real server processes booted from the production build; shared fixtures and seed data live in `tests/lib/`; service fakes (SMTP sink, mock OIDC IdP, S3, Immich, Paperless, ntfy) live in `tests/fakes/` with their own unit self-tests.
 
 The e2e suite needs Chromium once: `npx playwright install chromium`, plus `sudo npx playwright install-deps chromium` on Debian/Ubuntu for its system libraries. During iteration, `PW_SKIP_BUILD=1 npm run test:e2e` skips the rebuild and reuses the existing `build/` output; rebuild after changing server code.
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ When you change `src/lib/server/db/schema.ts`, run `db:generate` then `db:migrat
 
 ### Testing
 
-Unit tests cover server helpers against a fresh in-memory database per test file. End-to-end tests build the app for production and drive a real browser against real server processes, each with its own throwaway SQLite database under `.test-data/`. Email and OIDC flows run against local fakes, so no external services are needed.
+Unit tests cover server helpers against a fresh in-memory database per test file. End-to-end tests build the app for production and drive a real browser against real server processes, each with its own throwaway SQLite database under `.test-data/`. Integrations run against local fakes (SMTP, OIDC, S3, Immich, Paperless, ntfy), so no external services are needed.
 
 The e2e suite needs Chromium once:
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -116,9 +116,10 @@ const authContext: Handle = async ({ event, resolve }) => {
 
 const localeDetect: Handle = async ({ event, resolve }) => {
 	// Priority: user preference > cookie > Accept-Language > default
+	const cookieRaw = event.cookies.get('einvault_locale');
 	const locale =
 		event.locals.user?.locale ??
-		resolveLocale(event.cookies.get('einvault_locale')) ??
+		(cookieRaw ? resolveLocale(cookieRaw) : null) ??
 		parseAcceptLanguage(event.request.headers.get('accept-language'));
 
 	event.locals.locale = locale;

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -11,6 +11,7 @@ import { isAllowedVideoMime, looksLikeVideo, videoExtFromMime } from '$lib/serve
 import { demuxerForMime, transcodeAvailable } from '$lib/server/video/transcode';
 import { kickWorker } from '$lib/server/video/worker';
 import { canModifyPhoto } from '$lib/permissions';
+import { assertCanEditCompanion } from '$lib/server/permissions';
 import { isValidDate } from '$lib/server/validation';
 
 const MAX_IMAGE_SIZE = UPLOAD_MAX_MB * 1024 * 1024;
@@ -70,6 +71,9 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 
 	const { companionId, date } = params;
 	if (!isValidDate(date)) error(400, t(locals.locale, 'error.invalidDate'));
+
+	// Caretakers may only upload for assigned companions (mirrors the GET guard).
+	await assertCanEditCompanion(locals, companionId);
 
 	// Verify companion exists
 	const companion = await db.query.companions.findFirst({

--- a/tests/e2e/admin-users.spec.ts
+++ b/tests/e2e/admin-users.spec.ts
@@ -1,0 +1,254 @@
+import { test, expect } from '../lib/fixtures';
+
+// Helper: log in as a freshly-created user in an isolated context.
+// Returns the page (already past login) and a cleanup function.
+async function loginAs(
+	browser: import('@playwright/test').Browser,
+	baseURL: string,
+	username: string,
+	password: string
+): Promise<{ page: import('@playwright/test').Page; cleanup: () => Promise<void> }> {
+	const ctx = await browser.newContext({ baseURL });
+	const page = await ctx.newPage();
+	await page.goto('/auth/login');
+	await page.getByLabel('Username').fill(username);
+	await page.getByLabel('Password').fill(password);
+	await page.getByRole('button', { name: 'Sign in' }).click();
+	return {
+		page,
+		cleanup: () => ctx.close()
+	};
+}
+
+const INITIAL_PASSWORD = 'e2e-password-123';
+
+test.describe('admin-users', () => {
+	// -----------------------------------------------------------------------
+	// 1. Admin creates a new user and it appears in the list.
+	// -----------------------------------------------------------------------
+	test('create user', async ({ asAdmin }) => {
+		await asAdmin.goto('/admin/users');
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+		await asAdmin.getByRole('button', { name: /new user/i }).click();
+
+		const form = asAdmin.locator('form[action="?/create"]');
+		await expect(form).toBeVisible({ timeout: 4_000 });
+
+		await form.getByLabel(/display name/i).fill('E2E User 1');
+		await form.getByLabel(/username/i).fill('e2e-user-1');
+		await form.getByLabel(/password/i).fill(INITIAL_PASSWORD);
+		// Leave role as default (member).
+
+		await form.getByRole('button', { name: /create user/i }).click();
+
+		// Success alert
+		await expect(asAdmin.getByText(/user created successfully/i)).toBeVisible({ timeout: 10_000 });
+
+		// User row appears in the list.
+		const userRow = asAdmin.locator('div.px-6.py-4').filter({ hasText: 'e2e-user-1' });
+		await expect(userRow).toBeVisible({ timeout: 6_000 });
+		await expect(userRow.getByText('E2E User 1')).toBeVisible();
+	});
+
+	// -----------------------------------------------------------------------
+	// 2. Newly created user can log in.
+	// -----------------------------------------------------------------------
+	test('new user can log in', async ({ asAdmin, app, browser }) => {
+		// Create the user.
+		await asAdmin.goto('/admin/users');
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+		await asAdmin.getByRole('button', { name: /new user/i }).click();
+
+		const form = asAdmin.locator('form[action="?/create"]');
+		await expect(form).toBeVisible({ timeout: 4_000 });
+
+		await form.getByLabel(/display name/i).fill('E2E User 2');
+		await form.getByLabel(/username/i).fill('e2e-user-2');
+		await form.getByLabel(/password/i).fill(INITIAL_PASSWORD);
+
+		await form.getByRole('button', { name: /create user/i }).click();
+		await expect(asAdmin.getByText(/user created successfully/i)).toBeVisible({ timeout: 10_000 });
+
+		// Try logging in as the new user.
+		const { page, cleanup } = await loginAs(
+			browser,
+			app.server.baseURL,
+			'e2e-user-2',
+			INITIAL_PASSWORD
+		);
+		await expect(page).not.toHaveURL(/auth\/login/, { timeout: 10_000 });
+		await cleanup();
+	});
+
+	// -----------------------------------------------------------------------
+	// 3. Deactivate blocks login; reactivate restores it.
+	// -----------------------------------------------------------------------
+	test('deactivate blocks login, reactivate restores', async ({ asAdmin, app, browser }) => {
+		// Create e2e-user-3.
+		await asAdmin.goto('/admin/users');
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+		await asAdmin.getByRole('button', { name: /new user/i }).click();
+
+		const form = asAdmin.locator('form[action="?/create"]');
+		await expect(form).toBeVisible({ timeout: 4_000 });
+
+		await form.getByLabel(/display name/i).fill('E2E User 3');
+		await form.getByLabel(/username/i).fill('e2e-user-3');
+		await form.getByLabel(/password/i).fill(INITIAL_PASSWORD);
+
+		await form.getByRole('button', { name: /create user/i }).click();
+		await expect(asAdmin.getByText(/user created successfully/i)).toBeVisible({ timeout: 10_000 });
+
+		// Deactivate via More Actions menu.
+		const userRow = asAdmin.locator('div.px-6.py-4').filter({ hasText: 'e2e-user-3' });
+		await expect(userRow).toBeVisible({ timeout: 6_000 });
+
+		await userRow.getByRole('button', { name: /more actions/i }).click();
+		const deactivateItem = asAdmin.getByRole('menuitem', { name: /deactivate/i });
+		await expect(deactivateItem).toBeVisible({ timeout: 4_000 });
+		await deactivateItem.click();
+
+		// Wait for the inactive badge to appear.
+		await expect(userRow.getByText(/inactive/i)).toBeVisible({ timeout: 10_000 });
+
+		// Login with deactivated account should fail (stay on login page).
+		const ctx1 = await browser.newContext({ baseURL: app.server.baseURL });
+		const loginPage1 = await ctx1.newPage();
+		await loginPage1.goto('/auth/login');
+		await loginPage1.getByLabel('Username').fill('e2e-user-3');
+		await loginPage1.getByLabel('Password').fill(INITIAL_PASSWORD);
+		await loginPage1.getByRole('button', { name: /sign in/i }).click();
+		await expect(loginPage1).toHaveURL(/auth\/login/, { timeout: 10_000 });
+		// An error message should be visible.
+		await expect(loginPage1.locator('body')).not.toBeEmpty();
+		await ctx1.close();
+
+		// Reactivate via More Actions menu.
+		await userRow.getByRole('button', { name: /more actions/i }).click();
+		const activateItem = asAdmin.getByRole('menuitem', { name: /activate/i });
+		await expect(activateItem).toBeVisible({ timeout: 4_000 });
+		await activateItem.click();
+
+		// Inactive badge should disappear.
+		await expect(userRow.getByText(/inactive/i)).toHaveCount(0, { timeout: 10_000 });
+
+		// Login now succeeds.
+		const { page: page2, cleanup: cleanup2 } = await loginAs(
+			browser,
+			app.server.baseURL,
+			'e2e-user-3',
+			INITIAL_PASSWORD
+		);
+		await expect(page2).not.toHaveURL(/auth\/login/, { timeout: 10_000 });
+		await cleanup2();
+	});
+
+	// -----------------------------------------------------------------------
+	// 4. Edit displayName and confirm the list shows the updated name.
+	// -----------------------------------------------------------------------
+	test('edit displayName', async ({ asAdmin }) => {
+		await asAdmin.goto('/admin/users');
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+		// Create e2e-user-4.
+		await asAdmin.getByRole('button', { name: /new user/i }).click();
+
+		const form = asAdmin.locator('form[action="?/create"]');
+		await expect(form).toBeVisible({ timeout: 4_000 });
+
+		await form.getByLabel(/display name/i).fill('E2E User 4');
+		await form.getByLabel(/username/i).fill('e2e-user-4');
+		await form.getByLabel(/password/i).fill(INITIAL_PASSWORD);
+
+		await form.getByRole('button', { name: /create user/i }).click();
+		await expect(asAdmin.getByText(/user created successfully/i)).toBeVisible({ timeout: 10_000 });
+
+		// Click the inline Edit button on the user row.
+		const userRow = asAdmin.locator('div.px-6.py-4').filter({ hasText: 'e2e-user-4' });
+		await expect(userRow).toBeVisible({ timeout: 6_000 });
+
+		await userRow.getByRole('button', { name: /edit/i }).click();
+
+		// The inline edit form expands within the same row.
+		const editForm = userRow.locator('form[action="?/editUser"]');
+		await expect(editForm).toBeVisible({ timeout: 4_000 });
+
+		// Clear and re-fill the displayName field.
+		const displayNameInput = editForm.locator('input[name="displayName"]');
+		await displayNameInput.clear();
+		await displayNameInput.fill('E2E Renamed');
+
+		await editForm.getByRole('button', { name: /save/i }).click();
+
+		// Success feedback.
+		await expect(asAdmin.getByText(/user updated successfully/i)).toBeVisible({ timeout: 10_000 });
+
+		// The row should now show the new display name.
+		await expect(userRow.getByText('E2E Renamed')).toBeVisible({ timeout: 6_000 });
+	});
+
+	// -----------------------------------------------------------------------
+	// 5. Reset password: new credential logs in, old one does not.
+	// -----------------------------------------------------------------------
+	test('reset password', async ({ asAdmin, app, browser }) => {
+		// Create e2e-user-5.
+		await asAdmin.goto('/admin/users');
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+		await asAdmin.getByRole('button', { name: /new user/i }).click();
+
+		const form = asAdmin.locator('form[action="?/create"]');
+		await expect(form).toBeVisible({ timeout: 4_000 });
+
+		await form.getByLabel(/display name/i).fill('E2E User 5');
+		await form.getByLabel(/username/i).fill('e2e-user-5');
+		await form.getByLabel(/password/i).fill(INITIAL_PASSWORD);
+
+		await form.getByRole('button', { name: /create user/i }).click();
+		await expect(asAdmin.getByText(/user created successfully/i)).toBeVisible({ timeout: 10_000 });
+
+		const userRow = asAdmin.locator('div.px-6.py-4').filter({ hasText: 'e2e-user-5' });
+		await expect(userRow).toBeVisible({ timeout: 6_000 });
+
+		// Open More Actions → Reset Password.
+		await userRow.getByRole('button', { name: /more actions/i }).click();
+		const resetItem = asAdmin.getByRole('menuitem', { name: /reset password/i });
+		await expect(resetItem).toBeVisible({ timeout: 4_000 });
+		await resetItem.click();
+
+		// The reset-password inline panel appears (within the same row).
+		// Admin types the new password directly — there is no server-generated token.
+		const resetPanel = userRow.locator('form[action="?/resetPassword"]');
+		await expect(resetPanel).toBeVisible({ timeout: 4_000 });
+
+		const newPassword = 'e2e-new-password-456';
+		await resetPanel.locator('input[name="newPassword"]').fill(newPassword);
+		await resetPanel.getByRole('button', { name: /set password/i }).click();
+
+		// Panel disappears; no error shown.
+		await expect(resetPanel).toHaveCount(0, { timeout: 10_000 });
+
+		// Old password no longer works.
+		const ctx1 = await browser.newContext({ baseURL: app.server.baseURL });
+		const oldPassPage = await ctx1.newPage();
+		await oldPassPage.goto('/auth/login');
+		await oldPassPage.getByLabel('Username').fill('e2e-user-5');
+		await oldPassPage.getByLabel('Password').fill(INITIAL_PASSWORD);
+		await oldPassPage.getByRole('button', { name: /sign in/i }).click();
+		await expect(oldPassPage).toHaveURL(/auth\/login/, { timeout: 10_000 });
+		await ctx1.close();
+
+		// New password succeeds.
+		const { page: newPassPage, cleanup } = await loginAs(
+			browser,
+			app.server.baseURL,
+			'e2e-user-5',
+			newPassword
+		);
+		await expect(newPassPage).not.toHaveURL(/auth\/login/, { timeout: 10_000 });
+		await cleanup();
+	});
+});

--- a/tests/e2e/caretaker.spec.ts
+++ b/tests/e2e/caretaker.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '../lib/fixtures';
+
+const BISCUIT = 'seed-comp-biscuit';
+const WAFFLES = 'seed-comp-waffles';
+
+// The server runs with TZ=UTC; localDateISO() uses the process timezone (UTC),
+// so "today" from the server's perspective is the current UTC date.
+function todayUTC(): string {
+	const now = new Date();
+	const p = (n: number) => String(n).padStart(2, '0');
+	return `${now.getUTCFullYear()}-${p(now.getUTCMonth() + 1)}-${p(now.getUTCDate())}`;
+}
+
+test.describe('caretaker', () => {
+	test('dashboard redirect + on-shift indicator', async ({ asCaretaker }) => {
+		await asCaretaker.goto('/care');
+
+		// /care redirects to the first assigned companion: Biscuit
+		await expect(asCaretaker).toHaveURL(new RegExp(BISCUIT), { timeout: 10_000 });
+
+		// On-shift banner renders because the seeded shift is active (started 1h ago)
+		// The banner text starts with the i18n key 'layout.caretaker.onShift' = "On shift, ends"
+		await expect(asCaretaker.getByText(/On shift, ends/i)).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('unassigned companion blocked', async ({ asCaretaker }) => {
+		// The load() in both the companion overview and log pages calls:
+		//   if (!companions.find((c) => c.id === params.companionId)) error(403, ...)
+		// companions is the list from the parent layout (assigned companions only).
+		// Waffles is NOT assigned to seed-caretaker, so a 403 error page is returned.
+		await asCaretaker.goto(`/care/${WAFFLES}/log`);
+
+		// The load() guard calls error(403, ...) — SvelteKit renders an error page.
+		// The URL stays on the requested path (error rendered in-place, no redirect).
+		// Assert a 403-style indicator is visible (status code or the server message).
+		await expect(asCaretaker.getByText(/403|not assigned/i)).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('log activity', async ({ asCaretaker }) => {
+		await asCaretaker.goto(`/care/${BISCUIT}/log`);
+
+		// The log page renders the quick-log form when on shift.
+		// Activity type pills: 'Walk' is selected by default ($state('walk')).
+		// The label text rendered by TYPE_PILL_LABELS is "🦮 Walk" (icon + label).
+		// Locate the radio input for walk and assert it is already checked, or
+		// just click the pill label to be certain.
+		const walkPill = asCaretaker.locator('label').filter({ hasText: /Walk/i }).first();
+		await walkPill.click();
+
+		// Pick 30-minute quick button
+		await asCaretaker.getByRole('button', { name: '30m' }).click();
+
+		// Fill notes
+		const notesField = asCaretaker.locator('textarea[name="notes"]');
+		await notesField.fill('e2e-walk-note');
+
+		// Submit
+		await asCaretaker.getByRole('button', { name: /Log/i }).click();
+
+		// Success banner (page.log.activityLogged = "✓ Activity logged!")
+		await expect(asCaretaker.getByText('✓ Activity logged!')).toBeVisible({ timeout: 10_000 });
+
+		// The entry must appear in the "Today so far" list
+		await expect(
+			asCaretaker
+				.locator('text=e2e-walk-note')
+				.or(asCaretaker.locator('[class*="Badge"]').filter({ hasText: /walk/i }))
+		).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('member sees caretaker journal entry', async ({ asCaretaker, asMember }) => {
+		const today = todayUTC();
+
+		// Caretaker opens their care journal for Biscuit.
+		// The care journal page is at /care/{companionId}/journal and works on today's date.
+		await asCaretaker.goto(`/care/${BISCUIT}/journal`);
+
+		// The journal textarea has name="body"; the MarkdownTextarea renders a <textarea>
+		const bodyField = asCaretaker.locator('textarea[name="body"]');
+		await bodyField.fill('e2e-caretaker-journal');
+
+		// Wait for autosave ("✓ Saved" indicator — page.journal.caretaker.savedStatus)
+		await expect(asCaretaker.getByText('✓ Saved')).toBeVisible({ timeout: 10_000 });
+
+		// Member views the journal entry for the same companion + date via the app route.
+		// The app [date] journal page renders the body in a raw <textarea> (no name attr)
+		// in write mode. Locate by placeholder substring.
+		await asMember.goto(`/${BISCUIT}/journal/${today}`);
+		await expect(asMember.locator('textarea').first()).toHaveValue('e2e-caretaker-journal', {
+			timeout: 10_000
+		});
+	});
+
+	test('caretaker app-route bounce', async ({ asCaretaker }) => {
+		// The (app) layout load() checks role === 'caretaker' and redirects to /care.
+		await asCaretaker.goto(`/${BISCUIT}/health`);
+
+		// Must end up at /care (or a sub-path like /care/{companionId})
+		await expect(asCaretaker).toHaveURL(/\/care/, { timeout: 10_000 });
+
+		// Must NOT be on the requested app route
+		await expect(asCaretaker).not.toHaveURL(new RegExp(`/${BISCUIT}/health`));
+	});
+});

--- a/tests/e2e/companions.spec.ts
+++ b/tests/e2e/companions.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '../lib/fixtures';
+
+// Helper: create a companion via the /companions/new form and return its id
+// extracted from the redirect URL.
+async function createCompanion(
+	page: import('@playwright/test').Page,
+	name: string
+): Promise<string> {
+	await page.goto('/companions/new');
+	await page.locator('#name').fill(name);
+	await page.getByRole('button', { name: 'Add Companion' }).click();
+	// Server redirects to /{id} on success
+	await expect(page).not.toHaveURL(/\/companions\/new/, { timeout: 10_000 });
+	const url = page.url();
+	// URL is /{id} — extract the last path segment
+	const id = url.split('/').filter(Boolean).pop()!;
+	expect(id).toBeTruthy();
+	return id;
+}
+
+test.describe('companion crud', () => {
+	test('member creates a companion', async ({ asMember }) => {
+		const id = await createCompanion(asMember, 'e2e-comp-create');
+		// Should have landed on the companion dashboard page
+		await expect(asMember).toHaveURL(new RegExp(id));
+		// The companion name should be visible in the page heading (not a hidden dropdown option)
+		await expect(asMember.locator('h1').filter({ hasText: 'e2e-comp-create' })).toBeVisible();
+	});
+
+	test('edit persists breed', async ({ asMember }) => {
+		const id = await createCompanion(asMember, 'e2e-comp-edit');
+
+		await asMember.goto(`/companions/${id}/edit`);
+		await asMember.locator('#breed').fill('e2e-breed');
+		await asMember.getByRole('button', { name: 'Save Changes' }).click();
+
+		// After save the page stays on the edit page and shows a success alert
+		await expect(asMember.getByText('Changes saved.')).toBeVisible({ timeout: 8_000 });
+
+		// Reload and confirm the value is persisted
+		await asMember.goto(`/companions/${id}/edit`);
+		await expect(asMember.locator('#breed')).toHaveValue('e2e-breed');
+	});
+
+	test('empty name is rejected', async ({ asMember }) => {
+		await asMember.goto('/companions/new');
+
+		// The #name input has HTML `required`; clicking submit without filling it
+		// triggers browser validation and never navigates away.
+		await asMember.getByRole('button', { name: 'Add Companion' }).click();
+
+		// URL must still be on /companions/new — no redirect to a companion page
+		await expect(asMember).toHaveURL(/\/companions\/new/);
+
+		// The name input should be invalid per the browser constraint API
+		const nameInput = asMember.locator('#name');
+		const validity = await nameInput.evaluate((el) => (el as HTMLInputElement).validity.valid);
+		expect(validity).toBe(false);
+	});
+
+	test('admin can archive then restore a companion', async ({ asAdmin }) => {
+		// Archive action is admin-only (confirmed in +page.server.ts).
+		const id = await createCompanion(asAdmin, 'e2e-comp-archive');
+
+		// Navigate to the edit page. The archive card is outside the tab switcher, always visible.
+		await asAdmin.goto(`/companions/${id}/edit`);
+
+		// Click the trigger button to reveal the archive panel.
+		// Key from i18n: 'page.companion.edit.archiveButton' = 'Archive {name}'
+		const triggerBtn = asAdmin.getByRole('button', { name: /Archive e2e-comp-archive/i });
+		await triggerBtn.scrollIntoViewIfNeeded();
+		await triggerBtn.click();
+
+		// Wait for the archive form to appear in the DOM (it's inside {#if showArchivePanel}).
+		const archiveForm = asAdmin.locator('form[action="?/archive"]');
+		await expect(archiveForm).toBeVisible({ timeout: 5_000 });
+
+		// The date field is pre-filled; submit immediately.
+		await archiveForm.locator('button[type="submit"]').click();
+
+		// Server redirects to /settings after archive
+		await expect(asAdmin).toHaveURL(/\/settings/, { timeout: 10_000 });
+
+		// The "Past Companions" card title must be visible on the settings page.
+		await expect(asAdmin.getByText('Past Companions')).toBeVisible({ timeout: 8_000 });
+
+		// The archived companion entry has a restore form scoped to it.
+		// Use the restore form's hidden companionId input to uniquely identify the right form.
+		const restoreForm = asAdmin.locator(`form[action*="restore"]:has(input[value="${id}"])`);
+		await expect(restoreForm).toBeVisible();
+
+		// Click the restore submit button
+		await restoreForm.locator('button[type="submit"]').click();
+
+		// After restore the companion moves from Past Companions back to the active Companions
+		// list. The Past Companions card disappears once the list is empty (only one archived
+		// companion in this test). Wait for "Past Companions" to leave the page as confirmation
+		// that the server re-render completed, then verify the companion is active again.
+		await expect(asAdmin.getByText('Past Companions')).toBeHidden({ timeout: 8_000 });
+
+		// Companion should now appear in the active Companions list
+		await expect(
+			asAdmin.locator('li').filter({ hasText: 'e2e-comp-archive' }).first()
+		).toBeVisible();
+	});
+});

--- a/tests/e2e/documents.spec.ts
+++ b/tests/e2e/documents.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '../lib/fixtures';
+import { pdfUpload } from '../lib/files';
+
+const COMP = 'seed-comp-biscuit';
+
+test.describe('documents', () => {
+	test('upload PDF', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/documents`);
+
+		const fileInput = asMember.locator('input[type="file"]');
+		await fileInput.setInputFiles(pdfUpload('e2e-doc.pdf'));
+
+		// Title defaults to the filename
+		await expect(asMember.getByText('e2e-doc.pdf')).toBeVisible({ timeout: 15_000 });
+
+		// Persists after reload
+		await asMember.reload();
+		await expect(asMember.getByText('e2e-doc.pdf')).toBeVisible({ timeout: 10_000 });
+	});
+
+	test('edit metadata', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/documents`);
+
+		// Upload a dedicated doc for this test
+		const fileInput = asMember.locator('input[type="file"]');
+		await fileInput.setInputFiles(pdfUpload('e2e-doc-edit-src.pdf'));
+		await expect(asMember.getByText('e2e-doc-edit-src.pdf')).toBeVisible({ timeout: 15_000 });
+
+		// Click the edit (pencil) button for this doc
+		const listItem = asMember.locator('li').filter({ hasText: 'e2e-doc-edit-src.pdf' }).first();
+		await listItem.getByRole('button', { name: 'Edit document' }).click();
+
+		// After clicking, the inline edit form opens. The li re-renders so we use
+		// page-level locators for the form fields (there is only one edit form open).
+		const titleInput = asMember.locator('input[id^="doc-title-"]');
+		await titleInput.fill('e2e-doc-renamed');
+
+		// Set category to 'medical'
+		const categorySelect = asMember.locator('select[id^="doc-cat-"]');
+		await categorySelect.selectOption('medical');
+
+		// Save
+		await asMember.getByRole('button', { name: 'Save' }).first().click();
+
+		// Renamed title should appear, old name gone
+		await expect(asMember.getByText('e2e-doc-renamed')).toBeVisible({ timeout: 8_000 });
+		await expect(asMember.getByText('e2e-doc-edit-src.pdf', { exact: true })).toHaveCount(0);
+
+		// Reload and confirm persistence
+		await asMember.reload();
+		await expect(asMember.getByText('e2e-doc-renamed')).toBeVisible({ timeout: 10_000 });
+		// Medical badge should be visible in the document list item (scoped to avoid the select option)
+		const renamedItem = asMember.locator('li').filter({ hasText: 'e2e-doc-renamed' }).first();
+		await expect(renamedItem.locator('.rounded-full', { hasText: 'Medical' })).toBeVisible();
+	});
+
+	test('download', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/documents`);
+
+		const fileInput = asMember.locator('input[type="file"]');
+		await fileInput.setInputFiles(pdfUpload('e2e-doc-dl.pdf'));
+		await expect(asMember.getByText('e2e-doc-dl.pdf')).toBeVisible({ timeout: 15_000 });
+
+		// Find the download anchor for this doc
+		const listItem = asMember.locator('li').filter({ hasText: 'e2e-doc-dl.pdf' }).first();
+		const downloadLink = listItem.locator('a[aria-label="Download"]');
+		const href = await downloadLink.getAttribute('href');
+		expect(href).toBeTruthy();
+
+		// Fetch via the authenticated request context
+		const response = await asMember.request.get(href!);
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-type']).toContain('application/pdf');
+
+		const body = await response.body();
+		expect(body.subarray(0, 5).toString('ascii')).toBe('%PDF-');
+	});
+
+	test('delete', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/documents`);
+
+		const fileInput = asMember.locator('input[type="file"]');
+		await fileInput.setInputFiles(pdfUpload('e2e-doc-del.pdf'));
+		await expect(asMember.getByText('e2e-doc-del.pdf')).toBeVisible({ timeout: 15_000 });
+
+		// Click the delete button for this doc
+		const listItem = asMember.locator('li').filter({ hasText: 'e2e-doc-del.pdf' }).first();
+		await listItem.getByRole('button', { name: 'Delete' }).click();
+
+		// ConfirmDialog appears — confirm deletion
+		const confirmDialog = asMember.locator('[role="dialog"]');
+		await confirmDialog.getByRole('button', { name: 'Delete' }).click();
+
+		// Row should be gone
+		await expect(asMember.getByText('e2e-doc-del.pdf')).toHaveCount(0, { timeout: 8_000 });
+
+		// Reload and confirm still gone
+		await asMember.reload();
+		await expect(asMember.getByText('e2e-doc-del.pdf')).toHaveCount(0);
+	});
+
+	test('caretaker blocked', async ({ asCaretaker }) => {
+		const response = await asCaretaker.request.get(`/api/companions/${COMP}/documents`);
+		expect(response.status()).toBe(403);
+	});
+});

--- a/tests/e2e/health.spec.ts
+++ b/tests/e2e/health.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '../lib/fixtures';
+
+const COMP = 'seed-comp-biscuit';
+
+test.describe('health events and weight log', () => {
+	test('add health event', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/health`);
+
+		await asMember.getByRole('button', { name: 'Add Event' }).click();
+		await asMember.locator('#title').fill('e2e-health-vacc');
+		await asMember.locator('select[name="type"]').selectOption('vaccination');
+		await asMember.getByRole('button', { name: 'Save Event' }).click();
+
+		// Form closes on success; event should now appear in the Health Events list
+		await expect(asMember.getByText('e2e-health-vacc')).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('edit event', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/health`);
+
+		// Create the event this test owns
+		await asMember.getByRole('button', { name: 'Add Event' }).click();
+		await asMember.locator('#title').fill('e2e-health-vacc');
+		await asMember.locator('select[name="type"]').selectOption('vaccination');
+		await asMember.getByRole('button', { name: 'Save Event' }).click();
+		await expect(asMember.getByText('e2e-health-vacc')).toBeVisible({ timeout: 8_000 });
+
+		// Open detail modal by clicking the event row
+		await asMember.getByText('e2e-health-vacc').click();
+
+		// Click Edit in the modal
+		const dialog = asMember.locator('[role="dialog"]');
+		await dialog.getByRole('button', { name: 'Edit' }).click();
+
+		// The inline edit form should now be visible; update the title
+		const editTitleInput = asMember.locator('input[name="title"]').last();
+		await editTitleInput.fill('e2e-health-vacc-2');
+		await asMember.getByRole('button', { name: 'Save' }).first().click();
+
+		// Updated title visible, old title gone
+		await expect(asMember.getByText('e2e-health-vacc-2')).toBeVisible({ timeout: 8_000 });
+		await expect(asMember.getByText('e2e-health-vacc', { exact: true })).toHaveCount(0);
+	});
+
+	test('delete event', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/health`);
+
+		// Create a dedicated row for this test
+		await asMember.getByRole('button', { name: 'Add Event' }).click();
+		await asMember.locator('#title').fill('e2e-health-del');
+		await asMember.locator('select[name="type"]').selectOption('other');
+		await asMember.getByRole('button', { name: 'Save Event' }).click();
+		await expect(asMember.getByText('e2e-health-del')).toBeVisible({ timeout: 8_000 });
+
+		// Open detail modal
+		await asMember.getByText('e2e-health-del').click();
+
+		const dialog = asMember.locator('[role="dialog"]');
+		await dialog.getByRole('button', { name: 'Delete' }).click();
+
+		// ConfirmDialog appears — confirm deletion
+		const confirmDialog = asMember.locator('[role="dialog"]');
+		await confirmDialog.getByRole('button', { name: 'Delete' }).click();
+
+		// Confirm the row is gone after reload
+		await asMember.reload();
+		await expect(asMember.getByText('e2e-health-del')).toHaveCount(0);
+	});
+
+	test('log weight', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/health`);
+
+		await asMember.getByRole('button', { name: 'Log Weight' }).click();
+		await asMember.locator('#weight').fill('12.5');
+		await asMember.getByRole('button', { name: 'Log Weight' }).last().click();
+
+		// Weight history card should now show the recorded value
+		await expect(asMember.getByText(/12\.5/)).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('title required', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/health`);
+
+		await asMember.getByRole('button', { name: 'Add Event' }).click();
+		// Leave title empty, submit immediately
+		await asMember.getByRole('button', { name: 'Save Event' }).click();
+
+		// Browser HTML `required` constraint prevents navigation; form stays open
+		const titleInput = asMember.locator('#title');
+		const valid = await titleInput.evaluate((el) => (el as HTMLInputElement).validity.valid);
+		expect(valid).toBe(false);
+
+		// Form should still be visible — no redirect/close occurred
+		await expect(asMember.getByRole('button', { name: 'Save Event' })).toBeVisible();
+	});
+});

--- a/tests/e2e/health.spec.ts
+++ b/tests/e2e/health.spec.ts
@@ -20,13 +20,13 @@ test.describe('health events and weight log', () => {
 
 		// Create the event this test owns
 		await asMember.getByRole('button', { name: 'Add Event' }).click();
-		await asMember.locator('#title').fill('e2e-health-vacc');
+		await asMember.locator('#title').fill('e2e-health-edit-src');
 		await asMember.locator('select[name="type"]').selectOption('vaccination');
 		await asMember.getByRole('button', { name: 'Save Event' }).click();
-		await expect(asMember.getByText('e2e-health-vacc')).toBeVisible({ timeout: 8_000 });
+		await expect(asMember.getByText('e2e-health-edit-src')).toBeVisible({ timeout: 8_000 });
 
 		// Open detail modal by clicking the event row
-		await asMember.getByText('e2e-health-vacc').click();
+		await asMember.getByText('e2e-health-edit-src').click();
 
 		// Click Edit in the modal
 		const dialog = asMember.locator('[role="dialog"]');
@@ -34,12 +34,12 @@ test.describe('health events and weight log', () => {
 
 		// The inline edit form should now be visible; update the title
 		const editTitleInput = asMember.locator('input[name="title"]').last();
-		await editTitleInput.fill('e2e-health-vacc-2');
+		await editTitleInput.fill('e2e-health-edit-dst');
 		await asMember.getByRole('button', { name: 'Save' }).first().click();
 
 		// Updated title visible, old title gone
-		await expect(asMember.getByText('e2e-health-vacc-2')).toBeVisible({ timeout: 8_000 });
-		await expect(asMember.getByText('e2e-health-vacc', { exact: true })).toHaveCount(0);
+		await expect(asMember.getByText('e2e-health-edit-dst')).toBeVisible({ timeout: 8_000 });
+		await expect(asMember.getByText('e2e-health-edit-src', { exact: true })).toHaveCount(0);
 	});
 
 	test('delete event', async ({ asMember }) => {
@@ -71,11 +71,11 @@ test.describe('health events and weight log', () => {
 		await asMember.goto(`/${COMP}/health`);
 
 		await asMember.getByRole('button', { name: 'Log Weight' }).click();
-		await asMember.locator('#weight').fill('12.5');
+		await asMember.locator('#weight').fill('13.7');
 		await asMember.getByRole('button', { name: 'Log Weight' }).last().click();
 
 		// Weight history card should now show the recorded value
-		await expect(asMember.getByText(/12\.5/)).toBeVisible({ timeout: 8_000 });
+		await expect(asMember.getByText(/13\.7/)).toBeVisible({ timeout: 8_000 });
 	});
 
 	test('title required', async ({ asMember }) => {

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '../lib/fixtures';
+
+test.describe('i18n', () => {
+	test('user pref persists across reload and can be restored', async ({ asMember, app }) => {
+		await asMember.goto(app.server.baseURL + '/settings');
+
+		// Switch to German
+		await asMember.locator('select[name="locale"]').selectOption('de');
+		// The enhance callback calls window.location.reload() after submit
+		await asMember.waitForLoadState('networkidle');
+
+		// German settings page visible
+		await expect(asMember.locator('html')).toHaveAttribute('lang', 'de');
+		// 'Sprache' is page.settings.languageCard in de.ts
+		await expect(asMember.getByRole('heading', { name: 'Sprache' })).toBeVisible();
+
+		// Preference persists after reload
+		await asMember.reload();
+		await expect(asMember.locator('html')).toHaveAttribute('lang', 'de');
+		await expect(asMember.getByRole('heading', { name: 'Sprache' })).toBeVisible();
+
+		// Restore to English — the option label is always 'English' in every locale
+		await asMember.locator('select[name="locale"]').selectOption('en');
+		await asMember.waitForLoadState('networkidle');
+		await expect(asMember.locator('html')).toHaveAttribute('lang', 'en');
+	});
+
+	test('einvault_locale cookie drives language on anonymous pages', async ({ app, browser }) => {
+		const ctx = await browser.newContext({ baseURL: app.server.baseURL });
+		await ctx.addCookies([{ name: 'einvault_locale', value: 'de', url: app.server.baseURL }]);
+		const page = await ctx.newPage();
+		await page.goto('/auth/login');
+
+		// 'Anmelden' is page.login.signIn in de.ts (the submit button)
+		await expect(page.getByRole('button', { name: 'Anmelden' })).toBeVisible();
+		await expect(page.locator('html')).toHaveAttribute('lang', 'de');
+
+		await ctx.close();
+	});
+
+	test('Accept-Language header falls back to matching locale', async ({ app, browser }) => {
+		// Playwright's locale option sets the browser Accept-Language header.
+		// extraHTTPHeaders cannot override browser-generated headers in Chromium.
+		const ctx = await browser.newContext({
+			baseURL: app.server.baseURL,
+			locale: 'fr-FR'
+		});
+		const page = await ctx.newPage();
+		await page.goto('/auth/login');
+
+		// 'Se connecter' is page.login.signIn in fr.ts (the submit button)
+		await expect(page.getByRole('button', { name: 'Se connecter' })).toBeVisible();
+		await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
+
+		await ctx.close();
+	});
+});

--- a/tests/e2e/immich.spec.ts
+++ b/tests/e2e/immich.spec.ts
@@ -1,0 +1,143 @@
+import { test as base, expect, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createSeededDb, SEED } from '../lib/seed';
+import { startAppServer, type AppServer } from '../lib/app-server';
+import { startImmichFake, makeImmichAsset, type ImmichFake } from '../fakes/immich';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+
+interface ImmichWorld {
+	server: AppServer;
+	fake: ImmichFake;
+}
+
+const test = base.extend<{ world: ImmichWorld }>({
+	// eslint-disable-next-line no-empty-pattern
+	world: async ({}, use, testInfo) => {
+		const dir = path.join(
+			REPO_ROOT,
+			'.test-data',
+			`immich-${testInfo.workerIndex}-${testInfo.testId}`
+		);
+		const fake = await startImmichFake();
+		const dbPath = createSeededDb(dir);
+		let server: AppServer;
+		try {
+			server = await startAppServer({
+				dbPath,
+				env: {
+					IMMICH_URL: fake.url,
+					IMMICH_API_KEY: fake.apiKey
+					// No IMMICH_ALBUM_ID → recent-assets (search/metadata) path
+				}
+			});
+		} catch (err) {
+			await fake.stop();
+			fs.rmSync(dir, { recursive: true, force: true });
+			throw err;
+		}
+		await use({ server, fake });
+		await server.stop();
+		await fake.stop();
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+async function login(page: Page, baseURL: string, username: string) {
+	await page.goto(baseURL + '/auth/login');
+	await page.getByLabel('Username').fill(username);
+	await page.getByLabel('Password').fill(SEED.password);
+	await page.getByRole('button', { name: 'Sign in' }).click();
+	await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
+}
+
+// Asset IDs must be valid UUIDs — the server validates with IMMICH_ASSET_ID_RE.
+const ASSET_ID_1 = '00000000-0000-0000-0000-000000000001';
+const ASSET_ID_2 = '00000000-0000-0000-0000-000000000002';
+const ASSET_ID_3 = '00000000-0000-0000-0000-000000000003';
+
+const ASSETS = [
+	makeImmichAsset(ASSET_ID_1),
+	makeImmichAsset(ASSET_ID_2),
+	makeImmichAsset(ASSET_ID_3)
+];
+
+const BISCUIT_ID = SEED.companions.biscuit.id;
+
+test('avatar from Immich', async ({ world, page }) => {
+	world.fake.setAssets(ASSETS);
+
+	await login(page, world.server.baseURL, SEED.member.username);
+	await page.goto(world.server.baseURL + `/${BISCUIT_ID}`);
+
+	// The Immich avatar button has aria-label="Pick from Immich" and sits
+	// next to the file-upload button in the editable avatar group.
+	await page
+		.getByRole('button', { name: /pick from immich/i })
+		.first()
+		.click();
+
+	// Picker opens (dialog role) and thumbnails load via /api/immich/thumbnail/
+	const dialog = page.getByRole('dialog');
+	await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+	// Wait for at least one thumbnail image inside the picker
+	const thumbnail = dialog.locator(`img[src*="/api/immich/thumbnail/${ASSET_ID_1}"]`);
+	await expect(thumbnail).toBeVisible({ timeout: 10_000 });
+
+	// Pick asset 1 — buttons have title={asset.originalFileName} which is "<id>.png"
+	await dialog.locator(`button[title="${ASSET_ID_1}.png"]`).click();
+
+	// Picker should close after a successful pick
+	await expect(dialog).toHaveCount(0, { timeout: 10_000 });
+
+	// Avatar endpoint must now return an image
+	const avatarRes = await page.request.get(world.server.baseURL + `/api/avatars/${BISCUIT_ID}`);
+	expect(avatarRes.status()).toBe(200);
+	const ct = avatarRes.headers()['content-type'] ?? '';
+	expect(ct).toMatch(/^image\//);
+});
+
+test('journal photo from Immich', async ({ world, page }) => {
+	world.fake.setAssets(ASSETS);
+
+	await login(page, world.server.baseURL, SEED.member.username);
+	await page.goto(world.server.baseURL + `/${BISCUIT_ID}/journal/2026-06-01`);
+
+	// The "Pick from Immich" button is in the Photos section header
+	await page.getByRole('button', { name: /pick from immich/i }).click();
+
+	const dialog = page.getByRole('dialog');
+	await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+	// Wait for asset 2 thumbnail
+	const thumbnail = dialog.locator(`img[src*="/api/immich/thumbnail/${ASSET_ID_2}"]`);
+	await expect(thumbnail).toBeVisible({ timeout: 10_000 });
+
+	// Pick asset 2
+	await dialog.locator(`button[title="${ASSET_ID_2}.png"]`).click();
+
+	// Picker closes
+	await expect(dialog).toHaveCount(0, { timeout: 10_000 });
+
+	// A photo thumbnail served via /api/photos/ should appear in the entry
+	const photoImg = page.locator('img[src*="/api/photos/journal/"]');
+	await expect(photoImg).toBeVisible({ timeout: 10_000 });
+
+	// Reload and verify persistence
+	await page.reload();
+	const photoImgAfterReload = page.locator('img[src*="/api/photos/journal/"]');
+	await expect(photoImgAfterReload).toBeVisible({ timeout: 10_000 });
+});
+
+test('caretaker is blocked from the Immich assets API', async ({ world, browser }) => {
+	const ctx = await browser.newContext({ baseURL: world.server.baseURL });
+	const page = await ctx.newPage();
+	await login(page, world.server.baseURL, SEED.caretaker.username);
+
+	const res = await page.request.get(world.server.baseURL + '/api/immich/assets');
+	expect(res.status()).toBe(403);
+
+	await ctx.close();
+});

--- a/tests/e2e/journal.spec.ts
+++ b/tests/e2e/journal.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from '../lib/fixtures';
+import { pngUpload } from '../lib/files';
+
+const COMP = 'seed-comp-biscuit';
+
+test.describe('journal day editor', () => {
+	test('write entry with autosave', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/journal/2026-05-01`);
+
+		const textarea = asMember.locator('textarea');
+		await textarea.fill('e2e journal body');
+
+		// Select the Good mood (aria-pressed button with title 'Good')
+		const goodBtn = asMember.locator('button[title="Good"]');
+		await goodBtn.click();
+
+		// Trigger blur by clicking the page heading
+		await asMember.locator('h1').first().click();
+
+		// Wait for the saved-status indicator
+		await expect(asMember.getByText('✓ Saved')).toBeVisible({ timeout: 5_000 });
+
+		// Reload and confirm persistence
+		await asMember.reload();
+
+		await expect(asMember.locator('textarea')).toHaveValue('e2e journal body');
+		// Good mood pill should still be pressed
+		await expect(asMember.locator('button[title="Good"][aria-pressed="true"]')).toBeVisible();
+	});
+
+	test('photo upload', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/journal/2026-05-02`);
+
+		// Write a short body so an entry row exists (upload needs entry id in some impls)
+		const textarea = asMember.locator('textarea');
+		await textarea.fill('e2e photo test');
+		await asMember.locator('h1').first().click();
+		await expect(asMember.getByText('✓ Saved')).toBeVisible({ timeout: 5_000 });
+
+		// The file input is visually hidden inside the label; setInputFiles works on hidden inputs
+		const fileInput = asMember.locator('input[type="file"][name="photos"]').first();
+		await fileInput.setInputFiles(pngUpload());
+
+		// Wait for a photo thumbnail to appear
+		await expect(asMember.locator('img[src*="/api/photos/journal/"]').first()).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Reload and confirm the photo is still there
+		await asMember.reload();
+		await expect(asMember.locator('img[src*="/api/photos/journal/"]').first()).toBeVisible({
+			timeout: 10_000
+		});
+	});
+
+	test('caption edit and photo delete', async ({ asMember }) => {
+		// Start from the 2026-05-02 page where the photo was uploaded in the prior test.
+		// Each test gets its own worker-scoped seeded DB — the photo was uploaded in the
+		// same worker above, so it persists. But because Playwright can run tests in any
+		// order within a describe, we ensure the photo exists first.
+		await asMember.goto(`/${COMP}/journal/2026-05-02`);
+
+		// Make sure a photo is present; if not, upload one.
+		const photoImg = asMember.locator('img[src*="/api/photos/journal/"]').first();
+		const count = await photoImg.count();
+		if (count === 0) {
+			const textarea = asMember.locator('textarea');
+			await textarea.fill('e2e caption test');
+			await asMember.locator('h1').first().click();
+			await expect(asMember.getByText('✓ Saved')).toBeVisible({ timeout: 5_000 });
+
+			const fileInput = asMember.locator('input[type="file"][name="photos"]').first();
+			await fileInput.setInputFiles(pngUpload());
+			await expect(photoImg).toBeVisible({ timeout: 15_000 });
+		}
+
+		// Click "Edit Caption"
+		const editCaptionBtn = asMember.getByRole('button', { name: 'Edit Caption' }).first();
+		await editCaptionBtn.click();
+
+		// Fill in the caption textarea
+		const captionInput = asMember.locator('textarea[name="photo-notes"]').first();
+		await captionInput.fill('e2e-caption');
+
+		// Save
+		await asMember.getByRole('button', { name: 'Save' }).first().click();
+
+		// Caption text should now appear
+		await expect(asMember.getByText('e2e-caption')).toBeVisible({ timeout: 5_000 });
+
+		// Reload and confirm caption persisted
+		await asMember.reload();
+		await expect(asMember.getByText('e2e-caption')).toBeVisible({ timeout: 5_000 });
+
+		// Delete the photo
+		// Hover the photo thumbnail to reveal the delete button
+		const photoContainer = asMember
+			.locator('div.group')
+			.filter({ has: asMember.locator('img[src*="/api/photos/journal/"]') })
+			.first();
+		await photoContainer.hover();
+
+		const deleteBtn = photoContainer.locator('button[aria-label]');
+		await deleteBtn.click();
+
+		// Confirm in the dialog (scope to the confirm dialog to avoid the aria-labeled trash button)
+		const confirmDialog = asMember.locator('[role="dialog"]');
+		await confirmDialog.getByRole('button', { name: 'Delete' }).click();
+
+		// Photo should be gone
+		await expect(asMember.locator('img[src*="/api/photos/journal/"]')).toHaveCount(0, {
+			timeout: 5_000
+		});
+
+		// Reload and confirm still gone
+		await asMember.reload();
+		await expect(asMember.locator('img[src*="/api/photos/journal/"]')).toHaveCount(0, {
+			timeout: 5_000
+		});
+	});
+
+	test('journal list shows entries', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/journal`);
+
+		// The seed entry body is rendered as markdown HTML; the raw text will appear
+		// inside the prose container
+		await expect(asMember.getByText('Seed journal entry')).toBeVisible({ timeout: 8_000 });
+	});
+
+	test.fixme('edit shows the editor, not the original author, as attribution', async () => {
+		// #24: editing another user's entry overwrites nothing visibly — the entry
+		// still shows the original loggedBy with no updatedBy. Flip to a real test
+		// when #24 lands updatedBy.
+	});
+});

--- a/tests/e2e/limits.spec.ts
+++ b/tests/e2e/limits.spec.ts
@@ -1,0 +1,111 @@
+import { test as base, expect, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createSeededDb, SEED } from '../lib/seed';
+import { startAppServer, type AppServer } from '../lib/app-server';
+import { PNG_BYTES } from '../lib/files';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+const COMP = SEED.companions.biscuit.id;
+
+interface LimitsWorld {
+	server: AppServer;
+}
+
+const test = base.extend<{ world: LimitsWorld }>({
+	// eslint-disable-next-line no-empty-pattern
+	world: async ({}, use, testInfo) => {
+		const dir = path.join(
+			REPO_ROOT,
+			'.test-data',
+			`limits-${testInfo.workerIndex}-${testInfo.testId}`
+		);
+		const dbPath = createSeededDb(dir);
+		let server: AppServer;
+		try {
+			server = await startAppServer({
+				dbPath,
+				env: {
+					UPLOAD_MAX_MB: '1',
+					MAX_DAILY_MEDIA: '2'
+				}
+			});
+		} catch (err) {
+			fs.rmSync(dir, { recursive: true, force: true });
+			throw err;
+		}
+		await use({ server });
+		await server.stop();
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+async function login(page: Page, baseURL: string, username: string) {
+	await page.goto(baseURL + '/auth/login');
+	await page.getByLabel('Username').fill(username);
+	await page.getByLabel('Password').fill(SEED.password);
+	await page.getByRole('button', { name: 'Sign in' }).click();
+	await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
+}
+
+async function apiUploadPhoto(
+	page: Page,
+	baseURL: string,
+	comp: string,
+	date: string,
+	photoBuffer: Buffer,
+	name = 'photo.png'
+) {
+	return page.request.post(`${baseURL}/api/companions/${comp}/journal/${date}/photos`, {
+		headers: { Origin: baseURL },
+		multipart: {
+			photo: {
+				name,
+				mimeType: 'image/png',
+				buffer: photoBuffer
+			}
+		}
+	});
+}
+
+test('oversized upload is rejected with fileTooLarge', async ({ world, page }) => {
+	await login(page, world.server.baseURL, SEED.member.username);
+
+	// Build a buffer just over 1 MB that starts with valid PNG magic bytes.
+	// The handler checks file.size > MAX_IMAGE_SIZE (1 * 1024 * 1024) before
+	// calling sharp, so this returns 400 with the fileTooLarge message.
+	const oversized = Buffer.concat([PNG_BYTES, Buffer.alloc(1_300_000)]);
+
+	const res = await apiUploadPhoto(page, world.server.baseURL, COMP, '2026-06-10', oversized);
+	expect(res.status()).toBe(400);
+	const body = await res.text();
+	expect(body).toContain('File too large');
+});
+
+test('daily media cap rejects the third upload', async ({ world, page }) => {
+	await login(page, world.server.baseURL, SEED.member.username);
+
+	const date = '2026-06-11';
+	const photoData = PNG_BYTES;
+
+	// First two uploads must succeed
+	const first = await apiUploadPhoto(page, world.server.baseURL, COMP, date, photoData);
+	expect(first.status()).toBe(200);
+
+	const second = await apiUploadPhoto(page, world.server.baseURL, COMP, date, photoData);
+	expect(second.status()).toBe(200);
+
+	// Third upload must be rejected
+	const third = await apiUploadPhoto(page, world.server.baseURL, COMP, date, photoData);
+	expect(third.status()).toBe(400);
+	const body = await third.text();
+	expect(body).toContain('Maximum 2 photos or videos per day');
+
+	// Verify the entry still shows exactly 2 photos
+	const listRes = await page.request.get(
+		`${world.server.baseURL}/api/companions/${COMP}/journal/${date}/photos`
+	);
+	expect(listRes.status()).toBe(200);
+	const data = await listRes.json();
+	expect(data.photos).toHaveLength(2);
+});

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -1,0 +1,283 @@
+import { test as base, expect, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createSeededDb, SEED } from '../lib/seed';
+import { startAppServer, type AppServer } from '../lib/app-server';
+import { startSmtpSink, type SmtpSink } from '../fakes/smtp';
+import { startNtfyFake, type NtfyFake } from '../fakes/ntfy';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+
+// ---------------------------------------------------------------------------
+// World fixture — one per test (full isolation)
+// ---------------------------------------------------------------------------
+
+interface NotifyWorld {
+	server: AppServer;
+	smtp: SmtpSink;
+	ntfy: NtfyFake;
+}
+
+const test = base.extend<{ world: NotifyWorld }>({
+	// eslint-disable-next-line no-empty-pattern
+	world: async ({}, use, testInfo) => {
+		const dir = path.join(
+			REPO_ROOT,
+			'.test-data',
+			`notifications-${testInfo.workerIndex}-${testInfo.testId}`
+		);
+		const smtp = await startSmtpSink();
+		const ntfy = await startNtfyFake();
+		const dbPath = createSeededDb(dir);
+		let server: AppServer;
+		try {
+			server = await startAppServer({
+				dbPath,
+				env: {
+					NOTIFY_SCAN_INTERVAL_MS: '250',
+					SMTP_HOST: '127.0.0.1',
+					SMTP_PORT: String(smtp.port),
+					SMTP_SECURE: 'false',
+					SMTP_FROM: 'einvault-test@example.com',
+					NTFY_URL: ntfy.url
+				}
+			});
+		} catch (err) {
+			await server!?.stop();
+			await smtp.stop();
+			await ntfy.stop();
+			fs.rmSync(dir, { recursive: true, force: true });
+			throw err;
+		}
+		await use({ server, smtp, ntfy });
+		// Teardown: server first, then fakes, then data dir.
+		await server.stop();
+		await smtp.stop();
+		await ntfy.stop();
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Inline login helper
+// ---------------------------------------------------------------------------
+
+async function login(page: Page, baseURL: string, username: string): Promise<void> {
+	await page.goto(baseURL + '/auth/login');
+	await page.getByLabel('Username').fill(username);
+	await page.getByLabel('Password').fill(SEED.password);
+	await page.getByRole('button', { name: 'Sign in' }).click();
+	await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
+}
+
+// ---------------------------------------------------------------------------
+// Date helpers
+// ---------------------------------------------------------------------------
+
+/** One minute ago as datetime-local string — reminder is immediately overdue. */
+function justPast(): string {
+	const d = new Date(Date.now() - 60_000);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * A datetime-local string for a time ~9 hours from now. The seed DB has an
+ * active shift from -1h to +8h; the new test shift must start after +8h to
+ * avoid an overlap conflict while still being within the 24h lead window.
+ */
+function inNineHours(): string {
+	const d = new Date(Date.now() + 9 * 60 * 60 * 1000);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/** Ten hours from now — end of a shift that starts in nine hours. */
+function inTenHours(): string {
+	const d = new Date(Date.now() + 10 * 60 * 60 * 1000);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * Save notification settings via a fetch to the SvelteKit action. Playwright's
+ * `page.evaluate` runs inside the browser context so the session cookie is
+ * automatically included — no CSRF workaround needed.
+ */
+async function saveNotificationSettings(
+	page: Page,
+	baseURL: string,
+	opts: { reminderEmail?: boolean; shiftEmail?: boolean; ntfyTopic?: string }
+): Promise<void> {
+	const fd = new URLSearchParams();
+	if (opts.reminderEmail) fd.append('notifyReminderEmail', 'on');
+	if (opts.shiftEmail) fd.append('notifyShiftEmail', 'on');
+	if (opts.ntfyTopic) fd.append('ntfyTopic', opts.ntfyTopic);
+
+	const status = await page.evaluate(
+		async ([url, body]) => {
+			const r = await fetch(url, {
+				method: 'POST',
+				headers: { 'content-type': 'application/x-www-form-urlencoded' },
+				body,
+				credentials: 'include'
+			});
+			return r.status;
+		},
+		[baseURL + '/settings?/notifications', fd.toString()] as [string, string]
+	);
+	if (status !== 200) throw new Error(`saveNotificationSettings: HTTP ${status}`);
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 + 2: reminder due fires email AND ntfy push; dedup stays at 1
+// ---------------------------------------------------------------------------
+
+test('reminder due fires email and ntfy push', async ({ world, page }) => {
+	await login(page, world.server.baseURL, SEED.member.username);
+
+	// Navigate to settings so the page is on the right origin before calling
+	// saveNotificationSettings (which uses page.evaluate to post via fetch).
+	await page.goto(world.server.baseURL + '/settings');
+	await expect(page).toHaveURL(/\/settings/, { timeout: 10_000 });
+
+	// Enable reminder email and set ntfy topic via the settings action.
+	// The component uses an auto-submit onchange pattern; we call the action
+	// directly to avoid Svelte 5 reactivity timing quirks in Playwright.
+	await saveNotificationSettings(page, world.server.baseURL, {
+		reminderEmail: true,
+		ntfyTopic: 'e2e-topic-1'
+	});
+
+	// Create a reminder due right now on Biscuit's reminders page.
+	const biscuitRemindersUrl = world.server.baseURL + `/${SEED.companions.biscuit.id}/reminders`;
+	await page.goto(biscuitRemindersUrl);
+	await page.getByRole('button', { name: 'Add Reminder' }).click();
+	await page.locator('#title').fill('e2e-notify-rem');
+	await page.locator('#dueAt').fill(justPast());
+	await page.getByRole('button', { name: 'Save Reminder' }).click();
+	await expect(page.getByRole('button', { name: 'Save Reminder' })).toHaveCount(0, {
+		timeout: 8_000
+	});
+
+	// Wait for the scheduler to fire (NOTIFY_SCAN_INTERVAL_MS=250; allow 20s).
+	// mailparser exposes .to as an AddressObject; use .text to get the address string.
+	const mail = await world.smtp.waitForMail(
+		(m) =>
+			(m.to?.text ?? '').includes('seed-member@example.com') &&
+			(m.subject ?? '').includes('e2e-notify-rem'),
+		20_000
+	);
+
+	// Subject: "Reminder: e2e-notify-rem"
+	expect(mail.subject).toMatch(/Reminder: e2e-notify-rem/);
+	// Body: "{companion} has a reminder due: {title}" → contains companion name
+	const bodyText = mail.text ?? '';
+	expect(bodyText).toMatch(/Biscuit/);
+	expect(bodyText).toMatch(/e2e-notify-rem/);
+	// Recipient
+	expect(mail.to?.text).toContain('seed-member@example.com');
+
+	// ntfy push
+	const publish = await world.ntfy.waitForPublish(
+		(p) => p.topic === 'e2e-topic-1' && (p.title ?? '').includes('e2e-notify-rem'),
+		20_000
+	);
+	expect(publish.topic).toBe('e2e-topic-1');
+	// ntfy title is built with email.reminder.subject key: "Reminder: {title}"
+	expect(publish.title).toMatch(/Reminder: e2e-notify-rem/);
+
+	// ------------------------------------------------------------------
+	// Dedup: after ~4 scan cycles (1s) the count must not have grown
+	// ------------------------------------------------------------------
+	const reminderMailMatcher = (m: import('mailparser').ParsedMail) =>
+		(m.to?.text ?? '').includes('seed-member@example.com') &&
+		(m.subject ?? '').includes('e2e-notify-rem');
+
+	await expect
+		.poll(() => world.smtp.messages.filter(reminderMailMatcher).length, {
+			timeout: 1_500,
+			intervals: [200]
+		})
+		.toBe(1);
+
+	const reminderPublishMatcher = (p: import('../fakes/ntfy').NtfyPublish) =>
+		p.topic === 'e2e-topic-1' && (p.title ?? '').includes('e2e-notify-rem');
+
+	expect(world.ntfy.publishes.filter(reminderPublishMatcher)).toHaveLength(1);
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: shift start email reaches seed-caretaker
+// ---------------------------------------------------------------------------
+
+test('shift start email fires for caretaker', async ({ world, browser }) => {
+	// Log in as seed-caretaker and enable shift-email via the settings action.
+	const caretakerCtx = await browser.newContext({ baseURL: world.server.baseURL });
+	const caretakerPage = await caretakerCtx.newPage();
+	await login(caretakerPage, world.server.baseURL, SEED.caretaker.username);
+
+	// Call the caretaker settings notifications action directly.
+	const fd = new URLSearchParams();
+	fd.append('notifyShiftEmail', 'on');
+	const status = await caretakerPage.evaluate(
+		async ([url, body]) => {
+			const r = await fetch(url, {
+				method: 'POST',
+				headers: { 'content-type': 'application/x-www-form-urlencoded' },
+				body,
+				credentials: 'include'
+			});
+			return r.status;
+		},
+		[world.server.baseURL + '/care/settings?/notifications', fd.toString()] as [string, string]
+	);
+	if (status !== 200) throw new Error(`caretaker notifications save: HTTP ${status}`);
+	await caretakerCtx.close();
+
+	// Log in as admin to add a shift for seed-caretaker starting in ~1h (inside
+	// the 24h lead window).
+	const adminCtx = await browser.newContext({ baseURL: world.server.baseURL });
+	const adminPage = await adminCtx.newPage();
+	await login(adminPage, world.server.baseURL, SEED.admin.username);
+
+	await adminPage.goto(world.server.baseURL + '/admin/users');
+	await expect(adminPage).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+	const caretakerRow = adminPage
+		.locator('div.px-6.py-4')
+		.filter({ hasText: SEED.caretaker.displayName });
+	await expect(caretakerRow).toBeVisible({ timeout: 8_000 });
+
+	await caretakerRow.getByRole('button', { name: /more actions/i }).click();
+	await adminPage.getByRole('menuitem', { name: /shifts/i }).click();
+
+	const panel = caretakerRow.locator('div.rounded-lg.border.border-border.bg-muted\\/30');
+	await expect(panel).toBeVisible({ timeout: 4_000 });
+
+	await panel.locator('input[name="startAt"]').fill(inNineHours());
+	await panel.locator('input[name="endAt"]').fill(inTenHours());
+	await panel.locator('input[name="notes"]').fill('e2e-notify-shift');
+	await panel.getByRole('button', { name: /add shift/i }).click();
+
+	// After submission the panel re-renders with the new shift row.
+	await expect(panel.getByText('e2e-notify-shift')).toBeVisible({ timeout: 10_000 });
+	await adminCtx.close();
+
+	// Wait for the scheduler to emit the shift-start email.
+	// Subject: "Shift starting soon: {caretaker}" → "Shift starting soon: Seed Caretaker"
+	// mailparser exposes .to as an AddressObject; use .text for the address string.
+	const mail = await world.smtp.waitForMail(
+		(m) =>
+			(m.to?.text ?? '').includes('seed-caretaker@example.com') &&
+			(m.subject ?? '').toLowerCase().includes('shift starting soon'),
+		20_000
+	);
+
+	expect(mail.subject).toMatch(/Shift starting soon: Seed Caretaker/i);
+	expect(mail.to?.text).toContain('seed-caretaker@example.com');
+	// Body: "{caretaker} begins a care shift on {start}."
+	const bodyText = mail.text ?? '';
+	expect(bodyText).toMatch(/Seed Caretaker/);
+	expect(bodyText).toMatch(/begins a care shift/);
+});

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -5,8 +5,17 @@ import { createSeededDb, SEED } from '../lib/seed';
 import { startAppServer, type AppServer } from '../lib/app-server';
 import { startSmtpSink, type SmtpSink } from '../fakes/smtp';
 import { startNtfyFake, type NtfyFake } from '../fakes/ntfy';
+import type { ParsedMail } from 'mailparser';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+
+// mailparser types .to as AddressObject | AddressObject[]; flatten either shape.
+function toText(to: ParsedMail['to']): string {
+	return [to ?? []]
+		.flat()
+		.map((a) => a.text)
+		.join(', ');
+}
 
 // ---------------------------------------------------------------------------
 // World fixture — one per test (full isolation)
@@ -164,7 +173,7 @@ test('reminder due fires email and ntfy push', async ({ world, page }) => {
 	// mailparser exposes .to as an AddressObject; use .text to get the address string.
 	const mail = await world.smtp.waitForMail(
 		(m) =>
-			(m.to?.text ?? '').includes('seed-member@example.com') &&
+			toText(m.to).includes('seed-member@example.com') &&
 			(m.subject ?? '').includes('e2e-notify-rem'),
 		20_000
 	);
@@ -176,7 +185,7 @@ test('reminder due fires email and ntfy push', async ({ world, page }) => {
 	expect(bodyText).toMatch(/Biscuit/);
 	expect(bodyText).toMatch(/e2e-notify-rem/);
 	// Recipient
-	expect(mail.to?.text).toContain('seed-member@example.com');
+	expect(toText(mail.to)).toContain('seed-member@example.com');
 
 	// ntfy push
 	const publish = await world.ntfy.waitForPublish(
@@ -191,7 +200,7 @@ test('reminder due fires email and ntfy push', async ({ world, page }) => {
 	// Dedup: after ~4 scan cycles (1s) the count must not have grown
 	// ------------------------------------------------------------------
 	const reminderMailMatcher = (m: import('mailparser').ParsedMail) =>
-		(m.to?.text ?? '').includes('seed-member@example.com') &&
+		toText(m.to).includes('seed-member@example.com') &&
 		(m.subject ?? '').includes('e2e-notify-rem');
 
 	await expect
@@ -269,13 +278,13 @@ test('shift start email fires for caretaker', async ({ world, browser }) => {
 	// mailparser exposes .to as an AddressObject; use .text for the address string.
 	const mail = await world.smtp.waitForMail(
 		(m) =>
-			(m.to?.text ?? '').includes('seed-caretaker@example.com') &&
+			toText(m.to).includes('seed-caretaker@example.com') &&
 			(m.subject ?? '').toLowerCase().includes('shift starting soon'),
 		20_000
 	);
 
 	expect(mail.subject).toMatch(/Shift starting soon: Seed Caretaker/i);
-	expect(mail.to?.text).toContain('seed-caretaker@example.com');
+	expect(toText(mail.to)).toContain('seed-caretaker@example.com');
 	// Body: "{caretaker} begins a care shift on {start}."
 	const bodyText = mail.text ?? '';
 	expect(bodyText).toMatch(/Seed Caretaker/);

--- a/tests/e2e/oidc-variants.spec.ts
+++ b/tests/e2e/oidc-variants.spec.ts
@@ -1,0 +1,251 @@
+import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createSeededDb } from '../lib/seed';
+import { startAppServer, type AppServer } from '../lib/app-server';
+import { getFreePort } from '../lib/ports';
+import { startOidcFake, type OidcFake } from '../fakes/oidc';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+
+interface OidcWorld {
+	server: AppServer;
+	oidc: OidcFake;
+	dir: string;
+}
+
+/**
+ * Boot an app server with the OIDC fake and a seeded DB.
+ * `extraEnv` is merged on top of the base OIDC env; pass an empty object (or
+ * override OIDC_ISSUER_URL to undefined) when OIDC should be disabled.
+ */
+async function bootOidcWorld(
+	label: string,
+	extraEnv: Record<string, string>,
+	withOidc = true
+): Promise<OidcWorld> {
+	const dir = path.join(
+		REPO_ROOT,
+		'.test-data',
+		`oidc-variants-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+	);
+	const dbPath = createSeededDb(dir);
+
+	let oidc: OidcFake | null = null;
+	if (withOidc) {
+		oidc = await startOidcFake();
+	}
+
+	const appPort = await getFreePort();
+
+	const baseOidcEnv: Record<string, string> = withOidc
+		? {
+				OIDC_ISSUER_URL: oidc!.issuerUrl,
+				OIDC_CLIENT_ID: 'einvault-test',
+				OIDC_CLIENT_SECRET: 'einvault-test-secret',
+				OIDC_REDIRECT_URI: `http://localhost:${appPort}/auth/oidc/callback`,
+				OIDC_STATE_SECRET: 'e2e-oidc-state-secret-not-for-production',
+				OIDC_ALLOW_INSECURE_HTTP: 'true',
+				OIDC_PROVIDER_NAME: 'MockIdP'
+			}
+		: {};
+
+	let server: AppServer;
+	try {
+		server = await startAppServer({
+			dbPath,
+			env: {
+				PORT: String(appPort),
+				...baseOidcEnv,
+				...extraEnv
+			}
+		});
+	} catch (err) {
+		if (oidc) await oidc.stop();
+		fs.rmSync(dir, { recursive: true, force: true });
+		throw err;
+	}
+
+	// Return a stub OidcFake when OIDC is disabled so callers don't have to
+	// branch; the stub's stop() is a no-op.
+	const noopOidc: OidcFake = {
+		url: '',
+		issuerUrl: '',
+		setClaims() {},
+		reset() {},
+		stop: async () => {}
+	};
+
+	return { server, oidc: oidc ?? noopOidc, dir };
+}
+
+async function teardown(world: OidcWorld) {
+	await world.server.stop();
+	await world.oidc.stop();
+	fs.rmSync(world.dir, { recursive: true, force: true });
+}
+
+// ─── Test 1: signup denied ─────────────────────────────────────────────────
+
+test('oidc-variants: signup denied when OIDC_ALLOW_SIGNUP=false', async ({ page }) => {
+	const world = await bootOidcWorld('signup-denied', { OIDC_ALLOW_SIGNUP: 'false' });
+	try {
+		world.oidc.setClaims({
+			sub: 'variant-sub-1',
+			email: 'variant1@example.com',
+			preferred_username: 'variantuser1',
+			name: 'Variant User 1'
+		});
+
+		await page.goto(world.server.baseURL + '/auth/login');
+		await page.getByRole('link', { name: /sign in with mockidp/i }).click();
+
+		// Callback redirects back to /auth/login?error=oidc_not_provisioned — must
+		// land on an /auth/* page, NOT create a session.
+		await expect(page).toHaveURL(/\/auth\//, { timeout: 15_000 });
+
+		// The error query param is present in the URL.
+		await expect(page).toHaveURL(/error=oidc_not_provisioned/);
+
+		// Navigating to the app root must still redirect to login (no session).
+		await page.goto(world.server.baseURL + '/');
+		await expect(page).toHaveURL(/\/auth\/login/, { timeout: 10_000 });
+	} finally {
+		await teardown(world);
+	}
+});
+
+// ─── Test 2: default role = caretaker ─────────────────────────────────────
+
+test('oidc-variants: new user gets caretaker role when OIDC_DEFAULT_ROLE=caretaker', async ({
+	page
+}) => {
+	const world = await bootOidcWorld('default-caretaker', {
+		OIDC_ALLOW_SIGNUP: 'true',
+		OIDC_DEFAULT_ROLE: 'caretaker'
+	});
+	try {
+		world.oidc.setClaims({
+			sub: 'variant-sub-2',
+			email: 'variant2@example.com',
+			preferred_username: 'variantuser2',
+			name: 'Variant User 2'
+		});
+
+		await page.goto(world.server.baseURL + '/auth/login');
+		await page.getByRole('link', { name: /sign in with mockidp/i }).click();
+
+		// Caretakers are redirected to /care after login.
+		await expect(page).toHaveURL(/\/care/, { timeout: 15_000 });
+
+		// The caretaker layout badge confirms the role in the UI.
+		await expect(page.getByText(/caretaker/i).first()).toBeVisible({ timeout: 5_000 });
+	} finally {
+		await teardown(world);
+	}
+});
+
+// ─── Test 3: admin group grants admin role ─────────────────────────────────
+
+test('oidc-variants: admin group membership grants admin role', async ({ page }) => {
+	const world = await bootOidcWorld('admin-group-grants', {
+		OIDC_ALLOW_SIGNUP: 'true',
+		OIDC_ADMIN_GROUPS: 'einvault-admins'
+	});
+	try {
+		world.oidc.setClaims({
+			sub: 'variant-sub-3',
+			email: 'variant3@example.com',
+			preferred_username: 'variantuser3',
+			name: 'Variant User 3',
+			groups: ['einvault-admins']
+		});
+
+		await page.goto(world.server.baseURL + '/auth/login');
+		await page.getByRole('link', { name: /sign in with mockidp/i }).click();
+
+		// Must clear /auth/* before navigating further.
+		await expect(page).not.toHaveURL(/\/auth\//, { timeout: 15_000 });
+
+		// Admin page must render (not 403).
+		await page.goto(world.server.baseURL + '/admin/users');
+		// The admin users page has an h1 with the localised "Users" title and a
+		// "New User" button — either confirms the page rendered for an admin.
+		await expect(page.getByRole('heading', { name: /users/i })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByRole('button', { name: /new user/i })).toBeVisible();
+	} finally {
+		await teardown(world);
+	}
+});
+
+// ─── Test 4: group absence demotes to member ───────────────────────────────
+
+test('oidc-variants: group absence demotes admin to member', async ({ page }) => {
+	const world = await bootOidcWorld('admin-group-demote', {
+		OIDC_ALLOW_SIGNUP: 'true',
+		OIDC_ADMIN_GROUPS: 'einvault-admins'
+	});
+	try {
+		const sub = 'variant-sub-4';
+
+		// ── First login: WITH the admin group ──────────────────────────────
+		world.oidc.setClaims({
+			sub,
+			email: 'variant4@example.com',
+			preferred_username: 'variantuser4',
+			name: 'Variant User 4',
+			groups: ['einvault-admins']
+		});
+
+		await page.goto(world.server.baseURL + '/auth/login');
+		await page.getByRole('link', { name: /sign in with mockidp/i }).click();
+		await expect(page).not.toHaveURL(/\/auth\//, { timeout: 15_000 });
+
+		// Verify admin access granted.
+		await page.goto(world.server.baseURL + '/admin/users');
+		await expect(page.getByRole('heading', { name: /users/i })).toBeVisible({ timeout: 10_000 });
+
+		// Sign out.
+		await page.goto(world.server.baseURL + '/settings');
+		await expect(page).toHaveURL(/settings/, { timeout: 10_000 });
+		await page.getByRole('button', { name: /sign out/i }).click();
+		await expect(page).toHaveURL(/auth\/login/, { timeout: 10_000 });
+
+		// ── Second login: WITHOUT the group → role demoted to member ───────
+		world.oidc.setClaims({
+			sub,
+			email: 'variant4@example.com',
+			preferred_username: 'variantuser4',
+			name: 'Variant User 4'
+			// no groups claim
+		});
+
+		await page.getByRole('link', { name: /sign in with mockidp/i }).click();
+		await expect(page).not.toHaveURL(/\/auth\//, { timeout: 15_000 });
+
+		// /admin/users must now return 403.
+		await page.goto(world.server.baseURL + '/admin/users');
+		await expect(page).toHaveURL(/admin\/users/, { timeout: 10_000 });
+		// SvelteKit error pages carry the HTTP status as visible text.
+		await expect(page.getByText(/403/)).toBeVisible({ timeout: 5_000 });
+	} finally {
+		await teardown(world);
+	}
+});
+
+// ─── Test 5: OIDC disabled — no "Sign in with" button ─────────────────────
+
+test('oidc-variants: no SSO button when OIDC is not configured', async ({ page }) => {
+	// Boot without OIDC: pass withOidc=false so no fake is started and no OIDC
+	// env vars are injected.
+	const world = await bootOidcWorld('oidc-disabled', {}, false);
+	try {
+		await page.goto(world.server.baseURL + '/auth/login');
+
+		// The OIDC link only renders when oidcEnabled is true on the page data.
+		// With no OIDC env vars, the link must not appear at all.
+		await expect(page.getByRole('link', { name: /sign in with/i })).toHaveCount(0);
+	} finally {
+		await teardown(world);
+	}
+});

--- a/tests/e2e/paperless.spec.ts
+++ b/tests/e2e/paperless.spec.ts
@@ -1,0 +1,132 @@
+import { test as base, expect, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createSeededDb, SEED } from '../lib/seed';
+import { startAppServer, type AppServer } from '../lib/app-server';
+import { startPaperlessFake, makePaperlessDoc, type PaperlessFake } from '../fakes/paperless';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+
+interface PaperlessWorld {
+	server: AppServer;
+	fake: PaperlessFake;
+}
+
+const test = base.extend<{ world: PaperlessWorld }>({
+	// eslint-disable-next-line no-empty-pattern
+	world: async ({}, use, testInfo) => {
+		const dir = path.join(
+			REPO_ROOT,
+			'.test-data',
+			`paperless-${testInfo.workerIndex}-${testInfo.testId}`
+		);
+		const fake = await startPaperlessFake();
+		const dbPath = createSeededDb(dir);
+		let server: AppServer;
+		try {
+			server = await startAppServer({
+				dbPath,
+				env: {
+					PAPERLESS_URL: fake.url,
+					PAPERLESS_API_TOKEN: fake.token,
+					PAPERLESS_TAG_ID: '7'
+				}
+			});
+		} catch (err) {
+			await fake.stop();
+			fs.rmSync(dir, { recursive: true, force: true });
+			throw err;
+		}
+		await use({ server, fake });
+		await server.stop();
+		await fake.stop();
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+async function login(page: Page, baseURL: string, username: string) {
+	await page.goto(baseURL + '/auth/login');
+	await page.getByLabel('Username').fill(username);
+	await page.getByLabel('Password').fill(SEED.password);
+	await page.getByRole('button', { name: 'Sign in' }).click();
+	await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
+}
+
+const DOCS = [
+	makePaperlessDoc(1, { title: 'Vaccination record', tags: [7] }),
+	makePaperlessDoc(2, { title: 'Insurance policy', tags: [7] }),
+	makePaperlessDoc(3, { title: 'Tax receipt', tags: [9] })
+];
+
+const BISCUIT_DOCS_URL = `/${SEED.companions.biscuit.id}/documents`;
+
+test('picker lists tagged docs and imports one', async ({ world, page }) => {
+	world.fake.setDocuments(DOCS);
+
+	await login(page, world.server.baseURL, SEED.member.username);
+	await page.goto(world.server.baseURL + BISCUIT_DOCS_URL);
+
+	// Open the picker
+	await page.getByRole('button', { name: /add from paperless/i }).click();
+
+	// Tag-scoped docs visible
+	await expect(page.getByRole('button', { name: /vaccination record/i })).toBeVisible({
+		timeout: 10_000
+	});
+	await expect(page.getByRole('button', { name: /insurance policy/i })).toBeVisible();
+
+	// Doc with tag 9 must not appear
+	await expect(page.getByRole('button', { name: /tax receipt/i })).toHaveCount(0);
+
+	// Import Vaccination record
+	await page.getByRole('button', { name: /vaccination record/i }).click();
+
+	// Picker should close and the doc should appear in the list
+	await expect(page.getByRole('dialog')).toHaveCount(0, { timeout: 10_000 });
+	await expect(page.getByText('Vaccination record')).toBeVisible({ timeout: 10_000 });
+
+	// Verify the document is retrievable via the proxy (bytes start with %PDF)
+	const docLink = page.locator('a[href*="/api/documents/"]').first();
+	const href = await docLink.getAttribute('href');
+	expect(href).toBeTruthy();
+	const res = await page.request.get(world.server.baseURL + href!);
+	expect(res.status()).toBe(200);
+	const body = await res.body();
+	expect(body.subarray(0, 4).toString()).toBe('%PDF');
+});
+
+test('search filters documents in the picker', async ({ world, page }) => {
+	world.fake.setDocuments(DOCS);
+
+	await login(page, world.server.baseURL, SEED.member.username);
+	await page.goto(world.server.baseURL + BISCUIT_DOCS_URL);
+
+	await page.getByRole('button', { name: /add from paperless/i }).click();
+
+	// Wait for initial load
+	await expect(page.getByRole('button', { name: /vaccination record/i })).toBeVisible({
+		timeout: 10_000
+	});
+
+	// Type in the search input
+	const searchInput = page.getByPlaceholder(/search documents/i);
+	await expect(searchInput).toBeVisible();
+	await searchInput.fill('insurance');
+
+	// Debounce is 300 ms; wait for the filtered result
+	await expect(page.getByRole('button', { name: /insurance policy/i })).toBeVisible({
+		timeout: 5_000
+	});
+	await expect(page.getByRole('button', { name: /vaccination record/i })).toHaveCount(0);
+});
+
+test('caretaker is blocked from the paperless documents API', async ({ world, browser }) => {
+	const ctx = await browser.newContext({ baseURL: world.server.baseURL });
+	const page = await ctx.newPage();
+	await login(page, world.server.baseURL, SEED.caretaker.username);
+
+	const res = await page.request.get(world.server.baseURL + '/api/paperless/documents');
+	expect(res.status()).toBe(403);
+
+	await ctx.close();
+});

--- a/tests/e2e/reminders.spec.ts
+++ b/tests/e2e/reminders.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect } from '../lib/fixtures';
+
+const COMP = 'seed-comp-biscuit';
+const BASE = `/${COMP}/reminders`;
+
+/**
+ * Fill and submit the "Add Reminder" form.
+ * `dueAt` must be a valid datetime-local string, e.g. "2099-01-15T10:00".
+ * `recurring` is optional; when provided the recurring checkbox is checked and
+ * the interval/unit fields are set.
+ */
+async function addReminder(
+	page: import('@playwright/test').Page,
+	opts: {
+		title: string;
+		type?: string;
+		dueAt: string;
+		recurring?: { interval: number; unit: 'day' | 'week' | 'month' | 'year' };
+	}
+) {
+	await page.getByRole('button', { name: 'Add Reminder' }).click();
+	await page.locator('#title').fill(opts.title);
+	if (opts.type) {
+		await page.locator('select[name="type"]').selectOption(opts.type);
+	}
+	// The datetime-local input is rendered by SvelteKit's use:localDatetimes action
+	// which converts a UTC ISO to local on load. For a fresh (empty) input we can
+	// type directly.
+	await page.locator('#dueAt').fill(opts.dueAt);
+
+	if (opts.recurring) {
+		const { interval, unit } = opts.recurring;
+		// The checkbox uses id="{idPrefix}-isRecurring" where idPrefix="add"
+		await page.locator('#add-isRecurring').check();
+		await page.locator('#add-recurrenceInterval').fill(String(interval));
+		await page.locator('select[name="recurrenceUnit"]').selectOption(unit);
+	}
+
+	await page.getByRole('button', { name: 'Save Reminder' }).click();
+	// Form closes on success — wait for the button to disappear
+	await expect(page.getByRole('button', { name: 'Save Reminder' })).toHaveCount(0, {
+		timeout: 8_000
+	});
+}
+
+/** Tomorrow in "YYYY-MM-DDT10:00" (local) — safe for "future" due dates. */
+function tomorrow(): string {
+	const d = new Date();
+	d.setDate(d.getDate() + 1);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T10:00`;
+}
+
+/** One minute ago in "YYYY-MM-DDT..." — ensures the reminder is already overdue/actionable. */
+function justPast(): string {
+	const d = new Date(Date.now() - 60_000);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// Locate the active-reminders section (cards listed before the completed
+// <details> element). We use the container div that holds the active cards.
+// The Svelte template renders either an empty-state Card or a `div.space-y-3`
+// with one Card per active reminder. We scope lookups to the whole page and
+// rely on the title text being unique per test (enforced by UNIQUE names).
+function activeSection(page: import('@playwright/test').Page) {
+	// The active section is the sibling space-y-3 div before the <details> element.
+	// Simplest robust locator: a div that does NOT sit inside <details>.
+	// In practice we just use the page and narrow by the card's position above
+	// the completed summary line.
+	return page.locator('div.space-y-3').first();
+}
+
+function completedSection(page: import('@playwright/test').Page) {
+	// The completed reminders are inside a <details> element.
+	return page.locator('details');
+}
+
+test.describe('reminders', () => {
+	test('create one-time reminder appears in active section', async ({ asMember }) => {
+		await asMember.goto(BASE);
+
+		await addReminder(asMember, {
+			title: 'e2e-rem-once',
+			type: 'other',
+			dueAt: tomorrow()
+		});
+
+		// The new reminder should appear in the active list
+		await expect(activeSection(asMember).getByText('e2e-rem-once')).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('complete with undo restores reminder to active list', async ({ asMember }) => {
+		await asMember.goto(BASE);
+
+		await addReminder(asMember, {
+			title: 'e2e-rem-undo',
+			type: 'other',
+			dueAt: tomorrow()
+		});
+
+		await expect(activeSection(asMember).getByText('e2e-rem-undo')).toBeVisible({
+			timeout: 8_000
+		});
+
+		// Click the Done button for this specific reminder card
+		const reminderCard = activeSection(asMember)
+			.locator('div')
+			.filter({ hasText: 'e2e-rem-undo' })
+			.first();
+		await reminderCard.getByRole('button', { name: 'Done' }).click();
+
+		// Toast with Undo button should appear
+		const toast = asMember.locator('[role="status"]');
+		await expect(toast).toBeVisible({ timeout: 5_000 });
+		await expect(toast.getByRole('button', { name: 'Undo' })).toBeVisible();
+
+		// Click Undo
+		await toast.getByRole('button', { name: 'Undo' }).click();
+
+		// Toast should disappear and the reminder should be back in the active list
+		await expect(toast).toHaveCount(0, { timeout: 5_000 });
+		await expect(activeSection(asMember).getByText('e2e-rem-undo')).toBeVisible({ timeout: 5_000 });
+
+		// Should not have moved to the completed section
+		await expect(completedSection(asMember)).toHaveCount(0);
+	});
+
+	test('complete without undo commits to completed section', async ({ asMember }) => {
+		await asMember.goto(BASE);
+
+		await addReminder(asMember, {
+			title: 'e2e-rem-commit',
+			type: 'other',
+			dueAt: tomorrow()
+		});
+
+		await expect(activeSection(asMember).getByText('e2e-rem-commit')).toBeVisible({
+			timeout: 8_000
+		});
+
+		// Click Done
+		const reminderCard = activeSection(asMember)
+			.locator('div')
+			.filter({ hasText: 'e2e-rem-commit' })
+			.first();
+		await reminderCard.getByRole('button', { name: 'Done' }).click();
+
+		// Wait for it to appear in the completed section — timeout must outlast the 7s undo window
+		const completed = completedSection(asMember);
+		await expect(completed).toBeVisible({ timeout: 15_000 });
+
+		// Open the <details> summary to see the completed list
+		await completed.locator('summary').click();
+
+		// Reminder should be listed as completed (line-through text)
+		await expect(completed.getByText('e2e-rem-commit')).toBeVisible({ timeout: 5_000 });
+
+		// Must be gone from the active section
+		await expect(activeSection(asMember).getByText('e2e-rem-commit')).toHaveCount(0);
+	});
+
+	test('completing recurring reminder spawns next instance', async ({ asMember }) => {
+		await asMember.goto(BASE);
+
+		// Due in the past (1 minute ago) so it is actionable immediately
+		await addReminder(asMember, {
+			title: 'e2e-rem-rec',
+			type: 'other',
+			dueAt: justPast(),
+			recurring: { interval: 1, unit: 'day' }
+		});
+
+		await expect(activeSection(asMember).getByText('e2e-rem-rec')).toBeVisible({
+			timeout: 8_000
+		});
+
+		// Click Done on the recurring reminder
+		const reminderCard = activeSection(asMember)
+			.locator('div')
+			.filter({ hasText: 'e2e-rem-rec' })
+			.first();
+		await reminderCard.getByRole('button', { name: 'Done' }).click();
+
+		// Wait past the undo window for the completed instance to appear
+		const completed = completedSection(asMember);
+		await expect(completed).toBeVisible({ timeout: 15_000 });
+
+		// Open the completed <details>
+		await completed.locator('summary').click();
+
+		// One completed instance
+		await expect(completed.getByText('e2e-rem-rec')).toBeVisible({ timeout: 5_000 });
+
+		// One new active instance (the next occurrence, due tomorrow)
+		const activeInstances = activeSection(asMember).getByText('e2e-rem-rec');
+		await expect(activeInstances).toHaveCount(1, { timeout: 5_000 });
+	});
+
+	test('title required — save blocked when empty', async ({ asMember }) => {
+		await asMember.goto(BASE);
+
+		await asMember.getByRole('button', { name: 'Add Reminder' }).click();
+
+		// Leave title empty; fill a valid due date so only the title is missing
+		await asMember.locator('#dueAt').fill(tomorrow());
+
+		await asMember.getByRole('button', { name: 'Save Reminder' }).click();
+
+		// Browser HTML `required` constraint prevents submission; form stays open
+		const titleInput = asMember.locator('#title');
+		const valid = await titleInput.evaluate((el) => (el as HTMLInputElement).validity.valid);
+		expect(valid).toBe(false);
+
+		// Save button still visible — no redirect/close
+		await expect(asMember.getByRole('button', { name: 'Save Reminder' })).toBeVisible();
+	});
+});

--- a/tests/e2e/s3.spec.ts
+++ b/tests/e2e/s3.spec.ts
@@ -1,0 +1,115 @@
+import { test as base, expect, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createSeededDb, SEED } from '../lib/seed';
+import { startAppServer, type AppServer } from '../lib/app-server';
+import { startS3Fake, type S3Fake } from '../fakes/s3';
+import { pngUpload } from '../lib/files';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+const COMP = SEED.companions.biscuit.id;
+
+interface S3World {
+	server: AppServer;
+	s3: S3Fake;
+}
+
+const test = base.extend<{ world: S3World }>({
+	// eslint-disable-next-line no-empty-pattern
+	world: async ({}, use, testInfo) => {
+		const dir = path.join(REPO_ROOT, '.test-data', `s3-${testInfo.workerIndex}-${testInfo.testId}`);
+		const fake = await startS3Fake();
+		const dbPath = createSeededDb(dir);
+		let server: AppServer;
+		try {
+			server = await startAppServer({
+				dbPath,
+				env: {
+					STORAGE_BACKEND: 's3',
+					S3_ENDPOINT: fake.url,
+					S3_BUCKET: 'einvault-test',
+					S3_REGION: 'auto',
+					S3_ACCESS_KEY_ID: 'test',
+					S3_SECRET_ACCESS_KEY: 'test',
+					S3_FORCE_PATH_STYLE: 'true',
+					S3_PRESIGN_TTL_SECONDS: '300'
+				}
+			});
+		} catch (err) {
+			await fake.stop();
+			fs.rmSync(dir, { recursive: true, force: true });
+			throw err;
+		}
+		await use({ server, s3: fake });
+		await server.stop();
+		await fake.stop();
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+async function login(page: Page, baseURL: string, username: string) {
+	await page.goto(baseURL + '/auth/login');
+	await page.getByLabel('Username').fill(username);
+	await page.getByLabel('Password').fill(SEED.password);
+	await page.getByRole('button', { name: 'Sign in' }).click();
+	await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
+}
+
+async function uploadPhoto(page: Page, baseURL: string) {
+	await login(page, baseURL, SEED.member.username);
+	await page.goto(baseURL + `/${COMP}/journal/2026-06-02`);
+	const fileInput = page.locator('input[type="file"][name="photos"]').first();
+	await fileInput.setInputFiles(pngUpload());
+	await expect(page.locator('img[src*="/api/photos/journal/"]').first()).toBeVisible({
+		timeout: 15_000
+	});
+}
+
+test('upload lands in the bucket', async ({ world, page }) => {
+	await uploadPhoto(page, world.server.baseURL);
+	expect(world.s3.objects.size).toBeGreaterThan(0);
+});
+
+test('photo GET 302s to a presigned fake URL', async ({ world, page }) => {
+	await uploadPhoto(page, world.server.baseURL);
+
+	const src = await page.locator('img[src*="/api/photos/journal/"]').first().getAttribute('src');
+	expect(src).toBeTruthy();
+
+	// Request the /api/photos/... URL without following redirects
+	const res = await page.request.get(world.server.baseURL + src!, { maxRedirects: 0 });
+	expect(res.status()).toBe(302);
+
+	const location = res.headers()['location'] ?? '';
+	expect(location).toContain(world.s3.url);
+	expect(location).toContain('X-Amz-');
+});
+
+test('delete removes from bucket', async ({ world, page }) => {
+	await uploadPhoto(page, world.server.baseURL);
+
+	const sizeBefore = world.s3.objects.size;
+	expect(sizeBefore).toBeGreaterThan(0);
+
+	// Hover the photo container to reveal the delete button
+	const photoContainer = page
+		.locator('div.group')
+		.filter({ has: page.locator('img[src*="/api/photos/journal/"]') })
+		.first();
+	await photoContainer.hover();
+
+	const deleteBtn = photoContainer.locator('button[aria-label]');
+	await deleteBtn.click();
+
+	// Confirm in the dialog
+	const confirmDialog = page.locator('[role="dialog"]');
+	await confirmDialog.getByRole('button', { name: 'Delete' }).click();
+
+	// Photo removed from UI
+	await expect(page.locator('img[src*="/api/photos/journal/"]')).toHaveCount(0, {
+		timeout: 5_000
+	});
+
+	// Bucket objects should decrease
+	await expect.poll(() => world.s3.objects.size, { timeout: 5_000 }).toBeLessThan(sizeBefore);
+});

--- a/tests/e2e/s3.spec.ts
+++ b/tests/e2e/s3.spec.ts
@@ -60,9 +60,13 @@ async function uploadPhoto(page: Page, baseURL: string) {
 	await page.goto(baseURL + `/${COMP}/journal/2026-06-02`);
 	const fileInput = page.locator('input[type="file"][name="photos"]').first();
 	await fileInput.setInputFiles(pngUpload());
-	await expect(page.locator('img[src*="/api/photos/journal/"]').first()).toBeVisible({
-		timeout: 15_000
-	});
+	const img = page.locator('img[src*="/api/photos/journal/"]').first();
+	await expect(img).toBeVisible({ timeout: 15_000 });
+	// A broken 302 still leaves a visible-but-empty <img>; naturalWidth > 0
+	// proves the browser followed the presign redirect and decoded real bytes.
+	await expect
+		.poll(() => img.evaluate((el: HTMLImageElement) => el.naturalWidth), { timeout: 15_000 })
+		.toBeGreaterThan(0);
 }
 
 test('upload lands in the bucket', async ({ world, page }) => {

--- a/tests/e2e/security.spec.ts
+++ b/tests/e2e/security.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../lib/fixtures';
+import { SEED } from '../lib/seed';
+import { pngUpload } from '../lib/files';
+
+const BISCUIT = SEED.companions.biscuit.id;
+const WAFFLES = SEED.companions.waffles.id;
+
+test.describe('security headers', () => {
+	test('page response carries required security headers', async ({ app, browser }) => {
+		const ctx = await browser.newContext({ baseURL: app.server.baseURL });
+		const res = await ctx.request.get('/auth/login');
+		expect(res.status()).toBe(200);
+
+		const headers = res.headers();
+		expect(headers['x-frame-options']).toBe('DENY');
+		expect(headers['x-content-type-options']).toBe('nosniff');
+		expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+		expect(headers['permissions-policy']).toContain('camera=()');
+		expect(headers['content-security-policy'] ?? '').toBeTruthy();
+		// Test server runs NODE_ENV=production so HSTS must be present
+		expect(headers['strict-transport-security'] ?? '').toContain('max-age=');
+
+		await ctx.close();
+	});
+});
+
+test.describe('api authz', () => {
+	test('health endpoint is public', async ({ app, browser }) => {
+		const ctx = await browser.newContext({ baseURL: app.server.baseURL });
+		const res = await ctx.request.get('/api/health');
+		expect(res.status()).toBe(200);
+		await ctx.close();
+	});
+
+	test('caretaker cannot access immich assets (role check before config)', async ({
+		asCaretaker
+	}) => {
+		// Handler checks role === 'caretaker' → 403 before checking IMMICH_CONFIG
+		const res = await asCaretaker.request.get('/api/immich/assets');
+		expect(res.status()).toBe(403);
+	});
+
+	test('caretaker cannot access paperless documents (role check before config)', async ({
+		asCaretaker
+	}) => {
+		// Handler checks role === 'caretaker' → 403 before checking PAPERLESS_CONFIG
+		const res = await asCaretaker.request.get('/api/paperless/documents');
+		expect(res.status()).toBe(403);
+	});
+
+	test('caretaker cannot access companion documents', async ({ asCaretaker }) => {
+		const res = await asCaretaker.request.get(`/api/companions/${BISCUIT}/documents`);
+		expect(res.status()).toBe(403);
+	});
+
+	test('caretaker cannot read a photo for an unassigned companion', async ({
+		asMember,
+		asCaretaker
+	}) => {
+		// Upload a photo to Waffles (caretaker is only assigned to Biscuit)
+		await asMember.goto(`/${WAFFLES}/journal/2026-06-03`);
+		const fileInput = asMember.locator('input[type="file"][name="photos"]').first();
+		await fileInput.setInputFiles(pngUpload());
+
+		const photoImg = asMember.locator('img[src*="/api/photos/journal/"]').first();
+		await expect(photoImg).toBeVisible({ timeout: 15_000 });
+
+		const src = await photoImg.getAttribute('src');
+		expect(src).toBeTruthy();
+
+		// asCaretaker is not assigned to Waffles → 403
+		const res = await asCaretaker.request.get(src!);
+		expect(res.status()).toBe(403);
+	});
+
+	test('anonymous request to avatar endpoint returns 401', async ({ app, browser }) => {
+		const ctx = await browser.newContext({ baseURL: app.server.baseURL });
+		const res = await ctx.request.get(`/api/avatars/${BISCUIT}`);
+		// Handler: if (!locals.user) error(401, ...)
+		expect(res.status()).toBe(401);
+		await ctx.close();
+	});
+
+	test('member cannot access caretaker shift calendar export', async ({ asMember }) => {
+		// Handler: if (locals.user.role !== 'caretaker') error(403, ...)
+		const res = await asMember.request.get('/api/shifts/export.ics');
+		expect(res.status()).toBe(403);
+	});
+});

--- a/tests/e2e/security.spec.ts
+++ b/tests/e2e/security.spec.ts
@@ -73,6 +73,34 @@ test.describe('api authz', () => {
 		expect(res.status()).toBe(403);
 	});
 
+	test('caretaker cannot upload a photo for an unassigned companion', async ({
+		app,
+		asCaretaker
+	}) => {
+		// Regression: POST used to skip the assignment check the GET enforces,
+		// letting any caretaker write into any companion's journal.
+		const res = await asCaretaker.request.post(
+			`/api/companions/${WAFFLES}/journal/2026-06-04/photos`,
+			{
+				headers: { Origin: app.server.baseURL }, // SvelteKit CSRF check
+				multipart: { photo: pngUpload() }
+			}
+		);
+		expect(res.status()).toBe(403);
+	});
+
+	test('assigned caretaker can still upload a journal photo', async ({ app, asCaretaker }) => {
+		// Guard must not over-tighten: caretaker IS assigned to Biscuit.
+		const res = await asCaretaker.request.post(
+			`/api/companions/${BISCUIT}/journal/2026-06-04/photos`,
+			{
+				headers: { Origin: app.server.baseURL },
+				multipart: { photo: pngUpload() }
+			}
+		);
+		expect(res.status()).toBe(200);
+	});
+
 	test('anonymous request to avatar endpoint returns 401', async ({ app, browser }) => {
 		const ctx = await browser.newContext({ baseURL: app.server.baseURL });
 		const res = await ctx.request.get(`/api/avatars/${BISCUIT}`);

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,0 +1,265 @@
+import { test, expect } from '../lib/fixtures';
+
+// Helper: log in as a freshly-created user in an isolated context.
+// Returns the page (already past login) and a cleanup function.
+async function loginAs(
+	browser: import('@playwright/test').Browser,
+	baseURL: string,
+	username: string,
+	password: string
+): Promise<{ page: import('@playwright/test').Page; cleanup: () => Promise<void> }> {
+	const ctx = await browser.newContext({ baseURL });
+	const page = await ctx.newPage();
+	await page.goto('/auth/login');
+	await page.getByLabel('Username').fill(username);
+	await page.getByLabel('Password').fill(password);
+	await page.getByRole('button', { name: 'Sign in' }).click();
+	return {
+		page,
+		cleanup: () => ctx.close()
+	};
+}
+
+const INITIAL_PASSWORD = 'e2e-password-123';
+
+// Helper: create a user via the admin UI.
+async function createUser(
+	asAdmin: import('@playwright/test').Page,
+	{ displayName, username }: { displayName: string; username: string }
+): Promise<void> {
+	await asAdmin.goto('/admin/users');
+	await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+	await asAdmin.getByRole('button', { name: /new user/i }).click();
+
+	const form = asAdmin.locator('form[action="?/create"]');
+	await expect(form).toBeVisible({ timeout: 4_000 });
+
+	await form.getByLabel(/display name/i).fill(displayName);
+	await form.getByLabel(/username/i).fill(username);
+	await form.getByLabel(/password/i).fill(INITIAL_PASSWORD);
+
+	await form.getByRole('button', { name: /create user/i }).click();
+	await expect(asAdmin.getByText(/user created successfully/i)).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('settings', () => {
+	// -------------------------------------------------------------------------
+	// 1. Account fields persist across reload.
+	// -------------------------------------------------------------------------
+	test('account fields persist', async ({ asMember }) => {
+		await asMember.goto('/settings');
+		await expect(asMember).toHaveURL(/\/settings/, { timeout: 10_000 });
+
+		// Fill in the phone field only (do not touch username).
+		const phoneInput = asMember.locator('input[name="phone"]');
+		await phoneInput.clear();
+		await phoneInput.fill('555-0100');
+
+		// Save.
+		await asMember
+			.locator('form[action="?/account"]')
+			.getByRole('button', { name: /save changes/i })
+			.click();
+		await expect(asMember.getByText(/account updated/i)).toBeVisible({ timeout: 8_000 });
+
+		// Reload and check the value persisted.
+		await asMember.reload();
+		await expect(asMember.locator('input[name="phone"]')).toHaveValue('555-0100', {
+			timeout: 6_000
+		});
+
+		// Clean up: clear the phone field so it doesn't bleed into other tests
+		// that share the same member session.
+		await asMember.locator('input[name="phone"]').clear();
+		await asMember
+			.locator('form[action="?/account"]')
+			.getByRole('button', { name: /save changes/i })
+			.click();
+		await expect(asMember.getByText(/account updated/i)).toBeVisible({ timeout: 8_000 });
+	});
+
+	// -------------------------------------------------------------------------
+	// 2. Theme switch persists.
+	// Theme mechanism: applyTheme() adds/removes the 'dark' class on <html>.
+	// The toggle is in the app layout header (aria-pressed buttons), not on
+	// the settings page. Selecting "Dark" posts ?/theme and sets a cookie +
+	// DB value; on reload the layout re-applies the class via the $effect.
+	// -------------------------------------------------------------------------
+	test('theme switch persists', async ({ asMember }) => {
+		await asMember.goto('/settings');
+		await expect(asMember).toHaveURL(/\/settings/, { timeout: 10_000 });
+
+		// Click the "Dark mode" button in the header theme toggle.
+		await asMember.getByRole('button', { name: /dark mode/i }).click();
+
+		// applyTheme runs synchronously in the browser; html.dark should be set.
+		await expect(asMember.locator('html')).toHaveClass(/dark/, { timeout: 6_000 });
+
+		// Reload: the layout $effect should re-apply dark based on the saved theme.
+		await asMember.reload();
+		await expect(asMember.locator('html')).toHaveClass(/dark/, { timeout: 6_000 });
+
+		// Reset to system so the shared session is not left in dark mode.
+		await asMember.getByRole('button', { name: /system mode/i }).click();
+	});
+
+	// -------------------------------------------------------------------------
+	// 3. Password change: new password works, old one fails.
+	// Creates a dedicated user so the shared member session is untouched.
+	// -------------------------------------------------------------------------
+	test('password change works', async ({ asAdmin, app, browser }) => {
+		await createUser(asAdmin, {
+			displayName: 'E2E Settings PW',
+			username: 'e2e-settings-pw'
+		});
+
+		// Log in as the new user in an isolated context.
+		const { page, cleanup } = await loginAs(
+			browser,
+			app.server.baseURL,
+			'e2e-settings-pw',
+			INITIAL_PASSWORD
+		);
+
+		try {
+			await expect(page).not.toHaveURL(/auth\/login/, { timeout: 10_000 });
+
+			await page.goto('/settings');
+			await expect(page).toHaveURL(/\/settings/, { timeout: 6_000 });
+
+			// Open password change fields.
+			await page.getByRole('button', { name: /change password/i }).click();
+
+			await page.locator('input[name="currentPassword"]').fill(INITIAL_PASSWORD);
+			await page.locator('input[name="newPassword"]').fill('e2e-password-456');
+			await page.locator('input[name="confirmPassword"]').fill('e2e-password-456');
+
+			await page
+				.locator('form[action="?/account"]')
+				.getByRole('button', { name: /save changes/i })
+				.click();
+			await expect(page.getByText(/account updated/i)).toBeVisible({ timeout: 8_000 });
+		} finally {
+			await cleanup();
+		}
+
+		// Old password must fail.
+		const ctx1 = await browser.newContext({ baseURL: app.server.baseURL });
+		const oldPassPage = await ctx1.newPage();
+		await oldPassPage.goto('/auth/login');
+		await oldPassPage.getByLabel('Username').fill('e2e-settings-pw');
+		await oldPassPage.getByLabel('Password').fill(INITIAL_PASSWORD);
+		await oldPassPage.getByRole('button', { name: /sign in/i }).click();
+		await expect(oldPassPage).toHaveURL(/auth\/login/, { timeout: 10_000 });
+		await ctx1.close();
+
+		// New password must succeed.
+		const { page: newPassPage, cleanup: cleanup2 } = await loginAs(
+			browser,
+			app.server.baseURL,
+			'e2e-settings-pw',
+			'e2e-password-456'
+		);
+		await expect(newPassPage).not.toHaveURL(/auth\/login/, { timeout: 10_000 });
+		await cleanup2();
+	});
+
+	// -------------------------------------------------------------------------
+	// 4. Wrong current password is rejected.
+	// Creates a dedicated user to avoid state dependency on test 3.
+	// -------------------------------------------------------------------------
+	test('wrong current password rejected', async ({ asAdmin, app, browser }) => {
+		await createUser(asAdmin, {
+			displayName: 'E2E Settings PW2',
+			username: 'e2e-settings-pw2'
+		});
+
+		const { page, cleanup } = await loginAs(
+			browser,
+			app.server.baseURL,
+			'e2e-settings-pw2',
+			INITIAL_PASSWORD
+		);
+
+		try {
+			await expect(page).not.toHaveURL(/auth\/login/, { timeout: 10_000 });
+
+			await page.goto('/settings');
+			await expect(page).toHaveURL(/\/settings/, { timeout: 6_000 });
+
+			// Open password change fields.
+			await page.getByRole('button', { name: /change password/i }).click();
+
+			// Deliberately use wrong current password.
+			await page.locator('input[name="currentPassword"]').fill('wrong-password-xyz');
+			await page.locator('input[name="newPassword"]').fill('e2e-password-456');
+			await page.locator('input[name="confirmPassword"]').fill('e2e-password-456');
+
+			await page
+				.locator('form[action="?/account"]')
+				.getByRole('button', { name: /save changes/i })
+				.click();
+
+			// Error should be visible.
+			await expect(page.getByText(/current password is incorrect/i)).toBeVisible({
+				timeout: 8_000
+			});
+		} finally {
+			await cleanup();
+		}
+
+		// The password was NOT changed; the new password must not work.
+		const ctx = await browser.newContext({ baseURL: app.server.baseURL });
+		const tryPage = await ctx.newPage();
+		await tryPage.goto('/auth/login');
+		await tryPage.getByLabel('Username').fill('e2e-settings-pw2');
+		await tryPage.getByLabel('Password').fill('e2e-password-456');
+		await tryPage.getByRole('button', { name: /sign in/i }).click();
+		await expect(tryPage).toHaveURL(/auth\/login/, { timeout: 10_000 });
+		await ctx.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// 5. Notification checkbox persists.
+	// The seed member has an email address. Mail is enabled in the worker env.
+	// The reminder-email checkbox is auto-submitted via onchange → formEl.requestSubmit().
+	// -------------------------------------------------------------------------
+	test('notification checkbox persists', async ({ asMember }) => {
+		await asMember.goto('/settings');
+		await expect(asMember).toHaveURL(/\/settings/, { timeout: 10_000 });
+
+		const reminderCheckbox = asMember.locator('input[name="notifyReminderEmail"]');
+		await expect(reminderCheckbox).toBeVisible({ timeout: 6_000 });
+
+		// Record starting state and ensure we start from unchecked.
+		const wasChecked = await reminderCheckbox.isChecked();
+		if (wasChecked) {
+			// Uncheck first to establish a clean baseline.
+			await reminderCheckbox.click();
+			// Wait for the auto-submit to settle.
+			await expect(asMember.getByText(/notification settings updated/i)).toBeVisible({
+				timeout: 8_000
+			});
+			await asMember.reload();
+		}
+
+		// Now check the box (should trigger auto-submit).
+		await asMember.locator('input[name="notifyReminderEmail"]').click();
+		await expect(asMember.getByText(/notification settings updated/i)).toBeVisible({
+			timeout: 8_000
+		});
+
+		// Reload and verify still checked.
+		await asMember.reload();
+		await expect(asMember.locator('input[name="notifyReminderEmail"]')).toBeChecked({
+			timeout: 6_000
+		});
+
+		// Clean up: uncheck to restore original state.
+		await asMember.locator('input[name="notifyReminderEmail"]').click();
+		await expect(asMember.getByText(/notification settings updated/i)).toBeVisible({
+			timeout: 8_000
+		});
+	});
+});

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -100,8 +100,12 @@ test.describe('settings', () => {
 		await asMember.reload();
 		await expect(asMember.locator('html')).toHaveClass(/dark/, { timeout: 6_000 });
 
-		// Reset to system so the shared session is not left in dark mode.
+		// Reset to system so the shared session is not left in dark mode. The
+		// reload forces the reset POST to complete before the test ends —
+		// otherwise context teardown can abort it and leak dark mode to later tests.
 		await asMember.getByRole('button', { name: /system mode/i }).click();
+		await asMember.reload();
+		await expect(asMember.locator('html')).not.toHaveClass(/dark/, { timeout: 6_000 });
 	});
 
 	// -------------------------------------------------------------------------

--- a/tests/e2e/shifts.spec.ts
+++ b/tests/e2e/shifts.spec.ts
@@ -122,23 +122,26 @@ test.describe('shifts', () => {
 		const countText = await countBadge.textContent({ timeout: 8_000 });
 		expect(parseInt(countText ?? '0', 10)).toBeGreaterThanOrEqual(2);
 
-		// The card groups shifts. "This week" or "next week" depending on the day.
-		// Find the shift row for tomorrow by looking for the year string (unambiguous).
-		const [year, , day] = tomorrowUTC().split('-');
-		const dayNum = String(parseInt(day, 10)); // strip leading zero
+		// Shift rows are <button> elements inside the card (accordion: expanding one
+		// collapses the other, and notes render only while expanded). Picking the row
+		// by rendered date numbers is timezone-dependent — the seed shift crosses UTC
+		// midnight on evening runs and then also displays tomorrow's day number. So
+		// expand each candidate row in turn until the note shows up.
+		const [year] = tomorrowUTC().split('-');
+		const candidates = shiftsCard.getByRole('button').filter({ hasText: new RegExp(year) });
+		const count = await candidates.count();
+		expect(count).toBeGreaterThan(0);
 
-		// Shift rows are <button> elements inside the card. Filter to the one whose
-		// text includes tomorrow's year AND day number to distinguish it from the
-		// active seed shift (which runs today).
-		const tomorrowShiftRow = shiftsCard
-			.getByRole('button')
-			.filter({ hasText: new RegExp(year) })
-			.filter({ hasText: new RegExp(`\\b${dayNum}\\b`) })
-			.first();
-
-		// Click to expand and reveal notes.
-		await tomorrowShiftRow.click();
-		await expect(shiftsCard.getByText('e2e-shift-note')).toBeVisible({ timeout: 6_000 });
+		let revealed = false;
+		for (let i = 0; i < count && !revealed; i++) {
+			await candidates.nth(i).click();
+			revealed = await shiftsCard
+				.getByText('e2e-shift-note')
+				.waitFor({ state: 'visible', timeout: 2_000 })
+				.then(() => true)
+				.catch(() => false);
+		}
+		expect(revealed).toBe(true);
 	});
 
 	test('ICS export returns valid calendar with the new shift', async ({ asAdmin, asCaretaker }) => {

--- a/tests/e2e/shifts.spec.ts
+++ b/tests/e2e/shifts.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect } from '../lib/fixtures';
+import { request as pwRequest } from '@playwright/test';
+import { SEED } from '../lib/seed';
+
+// The server runs in UTC; build tomorrow's date string relative to UTC midnight.
+function tomorrowDatetimeLocal(hour: number): string {
+	const now = new Date();
+	const tomorrow = new Date(
+		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, hour, 0, 0)
+	);
+	const p = (n: number) => String(n).padStart(2, '0');
+	return `${tomorrow.getUTCFullYear()}-${p(tomorrow.getUTCMonth() + 1)}-${p(tomorrow.getUTCDate())}T${p(tomorrow.getUTCHours())}:${p(tomorrow.getUTCMinutes())}`;
+}
+
+// YYYY-MM-DD for tomorrow in UTC (used to distinguish tomorrow's shift from today's).
+function tomorrowUTC(): string {
+	const now = new Date();
+	const tomorrow = new Date(
+		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1)
+	);
+	const p = (n: number) => String(n).padStart(2, '0');
+	return `${tomorrow.getUTCFullYear()}-${p(tomorrow.getUTCMonth() + 1)}-${p(tomorrow.getUTCDate())}`;
+}
+
+test.describe('shifts', () => {
+	test('admin adds a shift for seed-caretaker', async ({ asAdmin }) => {
+		await asAdmin.goto('/admin/users');
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+		// Find the seed-caretaker row and open the overflow menu.
+		// The row contains both the displayName and the username badge.
+		const caretakerRow = asAdmin
+			.locator('div.px-6.py-4')
+			.filter({ hasText: SEED.caretaker.displayName });
+		await expect(caretakerRow).toBeVisible({ timeout: 8_000 });
+
+		const menuButton = caretakerRow.getByRole('button', { name: /more actions/i });
+		await menuButton.click();
+
+		// Overflow menu is now open; click "Shifts".
+		const shiftsMenuItem = asAdmin.getByRole('menuitem', { name: /shifts/i });
+		await expect(shiftsMenuItem).toBeVisible({ timeout: 4_000 });
+		await shiftsMenuItem.click();
+
+		// The shifts management panel should now be visible for this user.
+		// "Add shift" form is rendered inside the panel.
+		// The startAt / endAt inputs have ids like shift-start-{userId}.
+		// Use name attributes which are unique within the visible panel.
+		const panel = caretakerRow.locator('div.rounded-lg.border.border-border.bg-muted\\/30');
+		await expect(panel).toBeVisible({ timeout: 4_000 });
+
+		const startInput = panel.locator('input[name="startAt"]');
+		const endInput = panel.locator('input[name="endAt"]');
+		const notesInput = panel.locator('input[name="notes"]');
+
+		// Fill tomorrow 09:00–17:00. The form uses use:localDatetimes which converts
+		// datetime-local values to ISO on formdata event (triggered by enhance).
+		// Playwright fills the <input type="datetime-local"> directly; the action
+		// fires when the form submits via enhance.
+		await startInput.fill(tomorrowDatetimeLocal(9));
+		await endInput.fill(tomorrowDatetimeLocal(17));
+		await notesInput.fill('e2e-shift-note');
+
+		await panel.getByRole('button', { name: /add shift/i }).click();
+
+		// After submission the page re-loads (SvelteKit enhance invalidates loader).
+		// The new shift should appear in the shifts list for the caretaker.
+		// The panel re-opens because managingShiftsUserId stays set until "Close".
+		// The shift is rendered as a row inside the same panel showing LocalTime dates.
+		// We assert the note is visible (rendered as a muted text span next to the times).
+		await expect(panel.getByText('e2e-shift-note')).toBeVisible({ timeout: 10_000 });
+	});
+
+	test('caretaker sees the upcoming shift on the settings page', async ({
+		asAdmin,
+		asCaretaker
+	}) => {
+		// First, ensure the shift exists — add it as admin.
+		await asAdmin.goto('/admin/users');
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+		const caretakerRow = asAdmin
+			.locator('div.px-6.py-4')
+			.filter({ hasText: SEED.caretaker.displayName });
+		await expect(caretakerRow).toBeVisible({ timeout: 8_000 });
+
+		await caretakerRow.getByRole('button', { name: /more actions/i }).click();
+		await asAdmin.getByRole('menuitem', { name: /shifts/i }).click();
+
+		const panel = caretakerRow.locator('div.rounded-lg.border.border-border.bg-muted\\/30');
+		await expect(panel).toBeVisible({ timeout: 4_000 });
+
+		// Only add if the note isn't already there (idempotent guard).
+		const alreadyPresent = await panel.getByText('e2e-shift-note').isVisible();
+		if (!alreadyPresent) {
+			await panel.locator('input[name="startAt"]').fill(tomorrowDatetimeLocal(9));
+			await panel.locator('input[name="endAt"]').fill(tomorrowDatetimeLocal(17));
+			await panel.locator('input[name="notes"]').fill('e2e-shift-note');
+			await panel.getByRole('button', { name: /add shift/i }).click();
+			await expect(panel.getByText('e2e-shift-note')).toBeVisible({ timeout: 10_000 });
+		}
+
+		// Now check the caretaker's settings "My Shifts" card.
+		// Route: /care/settings → card id="shifts"
+		await asCaretaker.goto('/care/settings');
+		await expect(asCaretaker).toHaveURL(/\/care\/settings/, { timeout: 10_000 });
+
+		// The shifts card lists upcoming shifts. Tomorrow's shift should appear.
+		// The seed active shift ends today; the new shift is tomorrow — both upcoming.
+		const shiftsCard = asCaretaker.locator('#shifts');
+		await expect(shiftsCard).toBeVisible({ timeout: 8_000 });
+
+		// Assert the card is not in the "no upcoming shifts" empty state.
+		await expect(shiftsCard.getByText(/no upcoming shifts/i)).toHaveCount(0);
+
+		// The card header badge shows the total count of upcoming shifts (≥ 2).
+		// Badge renders as a <div> with CVA classes containing "rounded-full".
+		// The badge is `<Badge variant="secondary" class="ml-auto">{count}</Badge>`.
+		// Locate by the rounded-full class which is unique to Badge components.
+		// The seed active shift + new shift = 2 total upcoming.
+		const countBadge = shiftsCard.locator('div[class*="rounded-full"]').first();
+		const countText = await countBadge.textContent({ timeout: 8_000 });
+		expect(parseInt(countText ?? '0', 10)).toBeGreaterThanOrEqual(2);
+
+		// The card groups shifts. "This week" or "next week" depending on the day.
+		// Find the shift row for tomorrow by looking for the year string (unambiguous).
+		const [year, , day] = tomorrowUTC().split('-');
+		const dayNum = String(parseInt(day, 10)); // strip leading zero
+
+		// Shift rows are <button> elements inside the card. Filter to the one whose
+		// text includes tomorrow's year AND day number to distinguish it from the
+		// active seed shift (which runs today).
+		const tomorrowShiftRow = shiftsCard
+			.getByRole('button')
+			.filter({ hasText: new RegExp(year) })
+			.filter({ hasText: new RegExp(`\\b${dayNum}\\b`) })
+			.first();
+
+		// Click to expand and reveal notes.
+		await tomorrowShiftRow.click();
+		await expect(shiftsCard.getByText('e2e-shift-note')).toBeVisible({ timeout: 6_000 });
+	});
+
+	test('ICS export returns valid calendar with the new shift', async ({ asAdmin, asCaretaker }) => {
+		// Ensure the shift exists (same pattern as test 2 — add if missing).
+		await asAdmin.goto('/admin/users');
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+
+		const caretakerRow = asAdmin
+			.locator('div.px-6.py-4')
+			.filter({ hasText: SEED.caretaker.displayName });
+		await expect(caretakerRow).toBeVisible({ timeout: 8_000 });
+
+		await caretakerRow.getByRole('button', { name: /more actions/i }).click();
+		await asAdmin.getByRole('menuitem', { name: /shifts/i }).click();
+
+		const panel = caretakerRow.locator('div.rounded-lg.border.border-border.bg-muted\\/30');
+		await expect(panel).toBeVisible({ timeout: 4_000 });
+
+		const alreadyPresent = await panel.getByText('e2e-shift-note').isVisible();
+		if (!alreadyPresent) {
+			await panel.locator('input[name="startAt"]').fill(tomorrowDatetimeLocal(9));
+			await panel.locator('input[name="endAt"]').fill(tomorrowDatetimeLocal(17));
+			await panel.locator('input[name="notes"]').fill('e2e-shift-note');
+			await panel.getByRole('button', { name: /add shift/i }).click();
+			await expect(panel.getByText('e2e-shift-note')).toBeVisible({ timeout: 10_000 });
+		}
+
+		// Caretaker fetches the ICS export.
+		const res = await asCaretaker.request.get('/api/shifts/export.ics');
+		expect(res.status()).toBe(200);
+
+		const contentType = res.headers()['content-type'] ?? '';
+		expect(contentType).toContain('text/calendar');
+
+		const body = await res.text();
+		expect(body).toContain('BEGIN:VCALENDAR');
+		expect(body).toContain('BEGIN:VEVENT');
+
+		// DTSTART line must match the iCal basic format (DTSTART:YYYYMMDDTHHmmssZ)
+		expect(body).toMatch(/DTSTART[^\n]*\d{8}T\d{6}/);
+
+		// The new shift's notes are exported in DESCRIPTION.
+		// src/routes/api/shifts/export.ics/+server.ts: `if (shift.notes) lines.push(\`DESCRIPTION:...\`)`
+		expect(body).toContain('e2e-shift-note');
+	});
+
+	test('ICS export: member gets 403', async ({ asMember }) => {
+		const res = await asMember.request.get('/api/shifts/export.ics');
+		expect(res.status()).toBe(403);
+	});
+
+	test('ICS export: anonymous gets redirected to login', async ({ app }) => {
+		// The handler calls `redirect(302, '/auth/login')` when there is no user.
+		// Create a fresh, unauthenticated request context.
+		const ctx = await pwRequest.newContext({ baseURL: app.server.baseURL });
+		const res = await ctx.get('/api/shifts/export.ics', { maxRedirects: 0 });
+		// The server emits a 302 redirect to /auth/login for unauthenticated requests.
+		expect(res.status()).toBe(302);
+		const location = res.headers()['location'] ?? '';
+		expect(location).toMatch(/\/auth\/login/);
+		await ctx.dispose();
+	});
+});

--- a/tests/lib/files.ts
+++ b/tests/lib/files.ts
@@ -1,0 +1,32 @@
+// Tiny valid files for upload tests. Kept as buffers so specs can use
+// page.setInputFiles(selector, { name, mimeType, buffer }) without disk I/O.
+
+/** 1x1 transparent PNG. */
+export const PNG_BYTES = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+	'base64'
+);
+
+/** Minimal single-page PDF. */
+export const PDF_BYTES = Buffer.from(
+	`%PDF-1.4
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] >> endobj
+xref
+0 4
+0000000000 65535 f
+trailer << /Size 4 /Root 1 0 R >>
+startxref
+0
+%%EOF
+`
+);
+
+export function pngUpload(name = 'photo.png') {
+	return { name, mimeType: 'image/png', buffer: PNG_BYTES };
+}
+
+export function pdfUpload(name = 'doc.pdf') {
+	return { name, mimeType: 'application/pdf', buffer: PDF_BYTES };
+}


### PR DESCRIPTION
## Summary

Completes #96. E2e suite grows 16 → 89 tests across 16 new spec files:

- **Core flows (worker fixture):** companions CRUD/archive, journal entries + media (with a `test.fixme` placeholder for #24), health events + weight, reminders (undo window, recurrence series), caretaker dashboard/log/gating, shifts + ICS export content, admin user management, settings, locale switching, documents.
- **Integration flows (per-test servers against the fakes from #104):** Paperless picker/import, Immich avatar + journal import, S3 storage (presign redirect verified to the decoded-bytes level), notification scheduler at 250ms (reminder email + ntfy push, outbox dedup, shift-start mail), OIDC variant matrix (signup deny, default role, admin-group grant/demotion, disabled), security headers, upload limits, API authz matrix.

The suite caught two production bugs, fixed here in dedicated commits:

- `a17d4e6` **Accept-Language detection never worked.** `resolveLocale()` always returns a locale, so the fallback to `parseAcceptLanguage` was unreachable. Browser-language detection now functions for anonymous visitors.
- `a025f91` **Caretaker upload authz gap.** The journal-photos POST handler skipped the assignment check its GET enforces, letting any caretaker upload media into any companion's journal. Now guarded by `assertCanEditCompanion`, with regression tests in both directions.

## Test plan

- [x] `npm run lint`, `npm run check` clean
- [x] `npm run test:unit` — 84 passed
- [x] `PW_SKIP_BUILD=1 npm run test:e2e` — 89 passed + 1 skipped (fixme), run 3x from clean rebuild, no flake
- [x] CI green on this PR