### PR TITLE
Upgrade libcrypto3/libssl3 past CVE-2026-45447

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 # syntax=docker/dockerfile:1.7
 
-ARG NODE_IMAGE=node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+# The node base image is pinned by digest and repeated in every FROM line
+# (instead of a single ARG) so Dependabot's docker ecosystem can see and bump
+# it — it does not reliably update ARG-indirected references. Dependabot
+# updates all four lines together in one PR; keep them identical.
 
 # pkgmeta: zero out the version field so version-bump commits don't invalidate
 # the npm ci layer in deps; nothing in the install depends on the real version.
-FROM ${NODE_IMAGE} AS pkgmeta
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS pkgmeta
 
 WORKDIR /meta
 
@@ -19,7 +22,7 @@ RUN node -e "const fs = require('fs'); \
 
 
 # deps
-FROM ${NODE_IMAGE} AS deps
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS deps
 
 WORKDIR /build
 
@@ -33,7 +36,7 @@ RUN npm ci --ignore-scripts \
 
 
 # builder
-FROM ${NODE_IMAGE} AS builder
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
 
 WORKDIR /build
 
@@ -48,7 +51,7 @@ RUN npm prune --omit=dev
 
 
 # runner
-FROM ${NODE_IMAGE} AS runner
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS runner
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,11 @@ WORKDIR /app
 # libx264 for H.264 encode. Adds ~100-150MB to the image.
 RUN apk add --no-cache ffmpeg
 
+# Pull in OS security fixes published after the pinned base digest. Currently
+# covers CVE-2026-45447 (libcrypto3/libssl3 3.5.7-r0); no-ops once the node
+# base image catches up. Keep targeted so the layer stays deterministic-ish.
+RUN apk upgrade --no-cache libcrypto3 libssl3
+
 # Strip npm, npx, corepack, and the bundled yarn from the runtime image. The
 # app starts with `node build` and never invokes a package manager at runtime;
 # keeping them adds attack surface and CVE noise (npm's transitives, etc.).


### PR DESCRIPTION
## Summary

The Release workflow's Trivy gate fails on main: the pinned `node:24-alpine` digest ships `libcrypto3` 3.5.6-r0, vulnerable to CVE-2026-45447 (HIGH, OpenSSL PKCS#7/S/MIME). Alpine has the fix in 3.5.7-r0.

Adds a targeted `apk upgrade --no-cache libcrypto3 libssl3` to the runner stage. It becomes a no-op once the base image digest is bumped past the fix.

## Verification

Built the image locally and ran Trivy with the workflow's exact settings (`--severity CRITICAL,HIGH --ignore-unfixed --exit-code 1`): exit 0, and the image now carries `libcrypto3-3.5.7-r0` / `libssl3-3.5.7-r0`.

The Release workflow only runs on main pushes, so the real gate re-runs on merge.