### PR TITLE
Rename internal photo identifiers to media-neutral names

### DIFF
--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -1,23 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { canModifyPhoto } from './permissions';
+import { canModifyMedia } from './permissions';
 
 const admin = { id: 'a1', role: 'admin' } as const;
 const member = { id: 'm1', role: 'member' } as const;
 
-describe('canModifyPhoto', () => {
+describe('canModifyMedia', () => {
 	it('rejects missing user', () => {
-		expect(canModifyPhoto(null, { loggedBy: 'm1' })).toBe(false);
-		expect(canModifyPhoto(undefined, { loggedBy: 'm1' })).toBe(false);
+		expect(canModifyMedia(null, { loggedBy: 'm1' })).toBe(false);
+		expect(canModifyMedia(undefined, { loggedBy: 'm1' })).toBe(false);
 	});
 
-	it('admin can modify any photo, including legacy null-loggedBy rows', () => {
-		expect(canModifyPhoto(admin, { loggedBy: 'someone-else' })).toBe(true);
-		expect(canModifyPhoto(admin, { loggedBy: null })).toBe(true);
+	it('admin can modify any media item, including legacy null-loggedBy rows', () => {
+		expect(canModifyMedia(admin, { loggedBy: 'someone-else' })).toBe(true);
+		expect(canModifyMedia(admin, { loggedBy: null })).toBe(true);
 	});
 
-	it('non-admin can modify only own photos', () => {
-		expect(canModifyPhoto(member, { loggedBy: 'm1' })).toBe(true);
-		expect(canModifyPhoto(member, { loggedBy: 'other' })).toBe(false);
-		expect(canModifyPhoto(member, { loggedBy: null })).toBe(false);
+	it('non-admin can modify only own media items', () => {
+		expect(canModifyMedia(member, { loggedBy: 'm1' })).toBe(true);
+		expect(canModifyMedia(member, { loggedBy: 'other' })).toBe(false);
+		expect(canModifyMedia(member, { loggedBy: null })).toBe(false);
 	});
 });

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -6,11 +6,11 @@
 type AuthUser = { id: string; role: 'admin' | 'member' | 'caretaker' } | null | undefined;
 
 /**
- * Admins can modify (edit caption, delete) any journal photo. Other users
- * can modify only photos they uploaded. Photos with a null `loggedBy`
+ * Admins can modify (edit caption, delete) any journal media item. Other users
+ * can modify only items they uploaded. Items with a null `loggedBy`
  * (pre-migration legacy rows) are modifiable only by admins.
  */
-export function canModifyPhoto(user: AuthUser, photo: { loggedBy: string | null }): boolean {
+export function canModifyMedia(user: AuthUser, item: { loggedBy: string | null }): boolean {
 	if (!user) return false;
-	return user.role === 'admin' || photo.loggedBy === user.id;
+	return user.role === 'admin' || item.loggedBy === user.id;
 }

--- a/src/lib/server/journal.ts
+++ b/src/lib/server/journal.ts
@@ -33,10 +33,10 @@ export async function getEnrichedJournalEntries(
 	type EventWithUserRef = typeof schema.dailyEvents.$inferSelect & {
 		logger: UserRef;
 	};
-	type PhotoWithUserRef = typeof schema.journalPhotos.$inferSelect & {
+	type MediaWithUserRef = typeof schema.journalPhotos.$inferSelect & {
 		logger: UserRef;
 	};
-	let photosByEntry = new Map<string, PhotoWithUserRef[]>();
+	let mediaByEntry = new Map<string, MediaWithUserRef[]>();
 	let eventsByDate = new Map<string, EventWithUserRef[]>();
 
 	if (pageEntries.length > 0) {
@@ -48,7 +48,7 @@ export async function getEnrichedJournalEntries(
 		const rangeStart = new Date(oy, om - 1, od); // local midnight (respects TZ)
 		const rangeEnd = new Date(ny, nm - 1, nd + 1); // next local midnight after newest
 
-		const [allPhotos, allEvents] = await Promise.all([
+		const [allMedia, allEvents] = await Promise.all([
 			db.query.journalPhotos.findMany({
 				where: inArray(schema.journalPhotos.entryId, entryIds),
 				orderBy: (p, { asc }) => [asc(p.createdAt)],
@@ -65,9 +65,9 @@ export async function getEnrichedJournalEntries(
 			})
 		]);
 
-		for (const photo of allPhotos) {
-			if (!photosByEntry.has(photo.entryId)) photosByEntry.set(photo.entryId, []);
-			photosByEntry.get(photo.entryId)!.push(photo);
+		for (const item of allMedia) {
+			if (!mediaByEntry.has(item.entryId)) mediaByEntry.set(item.entryId, []);
+			mediaByEntry.get(item.entryId)!.push(item);
 		}
 		for (const event of allEvents) {
 			const date = localDateISO(new Date(event.loggedAt));
@@ -78,7 +78,7 @@ export async function getEnrichedJournalEntries(
 
 	const enrichedEntries = pageEntries.map((entry) => ({
 		...entry,
-		photos: photosByEntry.get(entry.id) ?? [],
+		photos: mediaByEntry.get(entry.id) ?? [],
 		events: eventsByDate.get(entry.date) ?? []
 	}));
 

--- a/src/lib/server/video/worker.ts
+++ b/src/lib/server/video/worker.ts
@@ -1,10 +1,10 @@
 // Background video transcode worker (issue #86). A single in-process loop that
-// drains queued transcode jobs (journal_photos rows with status='processing'),
+// drains queued transcode jobs (journal media rows (journal_photos table) with status='processing'),
 // converts the source to a web-playable MP4 + poster via the hardened ffmpeg
 // wrapper, and updates the row. No external job queue — this fits the app's
 // single-process adapter-node + SQLite model.
 //
-// State machine (journal_photos.status):
+// State machine (journal media rows (journal_photos table).status):
 //   processing -> claimed -> ready          (success)
 //   processing -> claimed -> failed         (error, or attempts exhausted)
 //

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -89,23 +89,23 @@
 	}
 
 	// Lightbox
-	let lightboxPhotos = $state<Entry['photos']>([]);
+	let lightboxMedia = $state<Entry['photos']>([]);
 	let lightboxDate = $state('');
 	let lightboxIndex = $state(0);
-	let lightboxPhoto = $derived(lightboxPhotos.length > 0 ? lightboxPhotos[lightboxIndex] : null);
+	let lightboxItem = $derived(lightboxMedia.length > 0 ? lightboxMedia[lightboxIndex] : null);
 	let lightboxEl = $state<HTMLElement | null>(null);
 	let lightboxTrigger = $state<HTMLElement | null>(null);
 
 	async function openLightbox(photos: Entry['photos'], date: string, index: number) {
 		lightboxTrigger = document.activeElement as HTMLElement | null;
-		lightboxPhotos = photos;
+		lightboxMedia = photos;
 		lightboxDate = date;
 		lightboxIndex = index;
 		await tick();
 		lightboxEl?.focus();
 	}
 	function closeLightbox() {
-		lightboxPhotos = [];
+		lightboxMedia = [];
 		lightboxDate = '';
 		lightboxIndex = 0;
 		tick().then(() => lightboxTrigger?.focus());
@@ -114,12 +114,12 @@
 		if (lightboxIndex > 0) lightboxIndex--;
 	}
 	function lightboxNext() {
-		if (lightboxIndex < lightboxPhotos.length - 1) lightboxIndex++;
+		if (lightboxIndex < lightboxMedia.length - 1) lightboxIndex++;
 	}
 
 	function handleLightboxKey(e: KeyboardEvent) {
 		if (e.key === 'Escape') {
-			if (lightboxPhoto) {
+			if (lightboxItem) {
 				closeLightbox();
 				return;
 			}
@@ -128,7 +128,7 @@
 				return;
 			}
 		}
-		if (!lightboxPhoto) return;
+		if (!lightboxItem) return;
 		if (e.key === 'ArrowLeft') lightboxPrev();
 		else if (e.key === 'ArrowRight') lightboxNext();
 	}
@@ -204,7 +204,7 @@
 <svelte:window onkeydown={handleLightboxKey} />
 
 <!-- Lightbox -->
-{#if lightboxPhoto}
+{#if lightboxItem}
 	<div
 		bind:this={lightboxEl}
 		role="dialog"
@@ -225,15 +225,15 @@
 			class="relative max-w-4xl w-full"
 		>
 			<div class="flex items-center justify-between mb-2">
-				{#if lightboxPhotos.length > 1}
-					<span class="text-sm text-white/60">{lightboxIndex + 1} / {lightboxPhotos.length}</span>
+				{#if lightboxMedia.length > 1}
+					<span class="text-sm text-white/60">{lightboxIndex + 1} / {lightboxMedia.length}</span>
 				{:else}
 					<span></span>
 				{/if}
 				<div class="flex items-center gap-1">
 					<a
-						href={mediaUrl(lightboxPhoto, lightboxDate)}
-						download={lightboxPhoto.originalName ?? lightboxPhoto.filename}
+						href={mediaUrl(lightboxItem, lightboxDate)}
+						download={lightboxItem.originalName ?? lightboxItem.filename}
 						class="text-white/70 hover:text-white p-1 rounded"
 						aria-label={t(locale, 'aria.downloadMedia')}
 					>
@@ -251,24 +251,24 @@
 			</div>
 
 			<div class="relative">
-				{#if lightboxPhoto.mediaType === 'video'}
+				{#if lightboxItem.mediaType === 'video'}
 					<JournalVideo
-						src={mediaUrl(lightboxPhoto, lightboxDate)}
-						poster={posterUrl(lightboxPhoto, lightboxDate)}
-						status={lightboxPhoto.status}
-						downloadName={lightboxPhoto.originalName}
-						label={lightboxPhoto.originalName ?? undefined}
+						src={mediaUrl(lightboxItem, lightboxDate)}
+						poster={posterUrl(lightboxItem, lightboxDate)}
+						status={lightboxItem.status}
+						downloadName={lightboxItem.originalName}
+						label={lightboxItem.originalName ?? undefined}
 						autoplay
 						class="max-h-[78vh] w-full object-contain rounded-lg bg-black"
 					/>
 				{:else}
 					<img
-						src={mediaUrl(lightboxPhoto, lightboxDate)}
-						alt={lightboxPhoto.originalName ?? ''}
+						src={mediaUrl(lightboxItem, lightboxDate)}
+						alt={lightboxItem.originalName ?? ''}
 						class="max-h-[78vh] w-full object-contain rounded-lg"
 					/>
 				{/if}
-				{#if lightboxPhotos.length > 1}
+				{#if lightboxMedia.length > 1}
 					<button
 						type="button"
 						onclick={lightboxPrev}
@@ -284,9 +284,9 @@
 					<button
 						type="button"
 						onclick={lightboxNext}
-						disabled={lightboxIndex === lightboxPhotos.length - 1}
+						disabled={lightboxIndex === lightboxMedia.length - 1}
 						class="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center text-white transition-opacity bg-black/40 {lightboxIndex ===
-						lightboxPhotos.length - 1
+						lightboxMedia.length - 1
 							? 'opacity-20 cursor-default'
 							: 'opacity-70 hover:opacity-100'}"
 						aria-label={t(locale, 'aria.nextMedia')}
@@ -296,14 +296,14 @@
 				{/if}
 			</div>
 
-			{#if lightboxPhoto.notes}
+			{#if lightboxItem.notes}
 				<div class="prose prose-sm prose-invert max-w-none mt-3 text-center text-sm">
-					{@html renderMarkdown(lightboxPhoto.notes)}
+					{@html renderMarkdown(lightboxItem.notes)}
 				</div>
 			{/if}
-			{#if lightboxPhoto.logger}
+			{#if lightboxItem.logger}
 				<div class="mt-2 flex justify-center">
-					<ByLine user={lightboxPhoto.logger} variant="inline" class="!text-white/60 !ml-0" />
+					<ByLine user={lightboxItem.logger} variant="inline" class="!text-white/60 !ml-0" />
 				</div>
 			{/if}
 		</div>

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -76,12 +76,12 @@
 		});
 	}
 
-	function photoUrl(photo: Entry['photos'][0], date: string) {
+	function mediaUrl(photo: Entry['photos'][0], date: string) {
 		return `/api/photos/journal/${companion.id}/${date}/${photo.filename}`;
 	}
 
 	function posterUrl(photo: Entry['photos'][0], date: string) {
-		return photo.posterKey ? `${photoUrl(photo, date)}?poster` : null;
+		return photo.posterKey ? `${mediaUrl(photo, date)}?poster` : null;
 	}
 
 	function monthKey(date: string) {
@@ -232,7 +232,7 @@
 				{/if}
 				<div class="flex items-center gap-1">
 					<a
-						href={photoUrl(lightboxPhoto, lightboxDate)}
+						href={mediaUrl(lightboxPhoto, lightboxDate)}
 						download={lightboxPhoto.originalName ?? lightboxPhoto.filename}
 						class="text-white/70 hover:text-white p-1 rounded"
 						aria-label={t(locale, 'aria.downloadMedia')}
@@ -253,7 +253,7 @@
 			<div class="relative">
 				{#if lightboxPhoto.mediaType === 'video'}
 					<JournalVideo
-						src={photoUrl(lightboxPhoto, lightboxDate)}
+						src={mediaUrl(lightboxPhoto, lightboxDate)}
 						poster={posterUrl(lightboxPhoto, lightboxDate)}
 						status={lightboxPhoto.status}
 						downloadName={lightboxPhoto.originalName}
@@ -263,7 +263,7 @@
 					/>
 				{:else}
 					<img
-						src={photoUrl(lightboxPhoto, lightboxDate)}
+						src={mediaUrl(lightboxPhoto, lightboxDate)}
 						alt={lightboxPhoto.originalName ?? ''}
 						class="max-h-[78vh] w-full object-contain rounded-lg"
 					/>
@@ -529,7 +529,7 @@
 											/>
 										{:else}
 											<video
-												src={photoUrl(photo, entry.date)}
+												src={mediaUrl(photo, entry.date)}
 												preload="metadata"
 												muted
 												playsinline
@@ -546,7 +546,7 @@
 										</span>
 									{:else}
 										<img
-											src={photoUrl(photo, entry.date)}
+											src={mediaUrl(photo, entry.date)}
 											alt={photo.originalName ?? ''}
 											class="w-full h-full object-cover"
 											loading="lazy"

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -76,12 +76,12 @@
 		});
 	}
 
-	function mediaUrl(photo: Entry['photos'][0], date: string) {
-		return `/api/photos/journal/${companion.id}/${date}/${photo.filename}`;
+	function mediaUrl(item: Entry['photos'][0], date: string) {
+		return `/api/photos/journal/${companion.id}/${date}/${item.filename}`;
 	}
 
-	function posterUrl(photo: Entry['photos'][0], date: string) {
-		return photo.posterKey ? `${mediaUrl(photo, date)}?poster` : null;
+	function posterUrl(item: Entry['photos'][0], date: string) {
+		return item.posterKey ? `${mediaUrl(item, date)}?poster` : null;
 	}
 
 	function monthKey(date: string) {
@@ -96,9 +96,9 @@
 	let lightboxEl = $state<HTMLElement | null>(null);
 	let lightboxTrigger = $state<HTMLElement | null>(null);
 
-	async function openLightbox(photos: Entry['photos'], date: string, index: number) {
+	async function openLightbox(items: Entry['photos'], date: string, index: number) {
 		lightboxTrigger = document.activeElement as HTMLElement | null;
-		lightboxMedia = photos;
+		lightboxMedia = items;
 		lightboxDate = date;
 		lightboxIndex = index;
 		await tick();
@@ -495,7 +495,7 @@
 						</div>
 					</CardHeader>
 
-					<!-- Photos -->
+					<!-- Media -->
 					{#if entry.photos.length > 0}
 						<div
 							class="grid gap-0.5 {entry.photos.length === 1
@@ -504,32 +504,30 @@
 									? 'grid-cols-2'
 									: 'grid-cols-3'}"
 						>
-							{#each entry.photos as photo, i (photo.id)}
+							{#each entry.photos as item, i (item.id)}
 								<button
 									type="button"
 									onclick={() => openLightbox(entry.photos, entry.date, i)}
 									class="relative block overflow-hidden {entry.photos.length === 1
 										? 'aspect-video'
 										: 'aspect-square'} hover:opacity-95 transition-opacity"
-									title={photo.originalName ??
+									title={item.originalName ??
 										t(
 											locale,
-											photo.mediaType === 'video'
-												? 'page.journal.videoAlt'
-												: 'page.journal.photoAlt'
+											item.mediaType === 'video' ? 'page.journal.videoAlt' : 'page.journal.photoAlt'
 										)}
 								>
-									{#if photo.mediaType === 'video'}
-										{#if photo.posterKey}
+									{#if item.mediaType === 'video'}
+										{#if item.posterKey}
 											<img
-												src={posterUrl(photo, entry.date)}
-												alt={photo.originalName ?? ''}
+												src={posterUrl(item, entry.date)}
+												alt={item.originalName ?? ''}
 												class="w-full h-full object-cover pointer-events-none"
 												loading="lazy"
 											/>
 										{:else}
 											<video
-												src={mediaUrl(photo, entry.date)}
+												src={mediaUrl(item, entry.date)}
 												preload="metadata"
 												muted
 												playsinline
@@ -546,8 +544,8 @@
 										</span>
 									{:else}
 										<img
-											src={mediaUrl(photo, entry.date)}
-											alt={photo.originalName ?? ''}
+											src={mediaUrl(item, entry.date)}
+											alt={item.originalName ?? ''}
 											class="w-full h-full object-cover"
 											loading="lazy"
 										/>

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.server.ts
@@ -28,8 +28,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		}
 	});
 
-	// Load photos for this date
-	const photos = entry
+	// Load media for this date
+	const media = entry
 		? await db.query.journalPhotos.findMany({
 				where: eq(schema.journalPhotos.entryId, entry.id),
 				orderBy: (p, { asc }) => [asc(p.createdAt)],
@@ -63,7 +63,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	return {
 		companion,
 		entry: entry ?? null,
-		photos,
+		photos: media,
 		recentEntries,
 		dailyEvents,
 		date,

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -715,7 +715,7 @@
 		{/if}
 	</div>
 
-	<!-- Photos -->
+	<!-- Media -->
 	<div class="rounded-lg border border-border bg-card overflow-hidden">
 		<div class="flex items-center justify-between px-5 py-3 border-b border-border">
 			<h2 class="font-semibold flex items-center gap-2 text-foreground">
@@ -794,35 +794,35 @@
 				</label>
 			{:else}
 				<div class="space-y-3">
-					{#each media as photo (photo.id)}
+					{#each media as item (item.id)}
 						<div class="flex gap-3 items-start">
 							<div
-								class="group relative shrink-0 {photo.mediaType === 'video'
+								class="group relative shrink-0 {item.mediaType === 'video'
 									? 'w-40'
 									: 'w-24'} h-24 rounded-lg overflow-hidden bg-stone-100 dark:bg-stone-800"
 							>
-								{#if photo.mediaType === 'video'}
+								{#if item.mediaType === 'video'}
 									<JournalVideo
-										src={mediaUrl(photo)}
-										poster={posterUrl(photo)}
-										status={photo.status}
-										downloadName={photo.originalName}
-										label={photo.originalName ?? undefined}
+										src={mediaUrl(item)}
+										poster={posterUrl(item)}
+										status={item.status}
+										downloadName={item.originalName}
+										label={item.originalName ?? undefined}
 										class="w-full h-full object-cover"
 										compact
 									/>
 								{:else}
 									<img
-										src={mediaUrl(photo)}
-										alt={photo.originalName ?? t(locale, 'page.journal.photoAlt')}
+										src={mediaUrl(item)}
+										alt={item.originalName ?? t(locale, 'page.journal.photoAlt')}
 										class="w-full h-full object-cover"
 										loading="lazy"
 									/>
 								{/if}
-								{#if canModifyMedia(data.user, photo)}
+								{#if canModifyMedia(data.user, item)}
 									<button
 										type="button"
-										onclick={() => openConfirm(() => deleteMedia(photo.id))}
+										onclick={() => openConfirm(() => deleteMedia(item.id))}
 										class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
 										flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
 										hover:bg-red-600 transition-all"
@@ -833,7 +833,7 @@
 								{/if}
 							</div>
 							<div class="flex-1 min-w-0">
-								{#if editingMediaId === photo.id}
+								{#if editingMediaId === item.id}
 									<MarkdownTextarea
 										value={editingMediaNotes}
 										oninput={(e) => (editingMediaNotes = (e.target as HTMLTextAreaElement).value)}
@@ -844,7 +844,7 @@
 									<div class="flex gap-2 mt-2">
 										<button
 											type="button"
-											onclick={() => saveMediaNotes(photo.id)}
+											onclick={() => saveMediaNotes(item.id)}
 											class="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground px-2 py-1 text-xs font-medium shadow hover:bg-primary/90 transition-colors"
 											>{t(locale, 'common.save')}</button
 										>
@@ -856,9 +856,9 @@
 										>
 									</div>
 								{:else}
-									{#if photo.notes}
+									{#if item.notes}
 										<p class="text-sm text-muted-foreground">
-											{stripMarkdown(photo.notes)}
+											{stripMarkdown(item.notes)}
 										</p>
 									{:else}
 										<p class="text-sm italic text-muted-foreground">
@@ -866,15 +866,15 @@
 										</p>
 									{/if}
 									<div class="flex items-center gap-2 mt-1">
-										{#if canModifyMedia(data.user, photo)}
+										{#if canModifyMedia(data.user, item)}
 											<button
 												type="button"
-												onclick={() => startEditMediaNotes(photo)}
+												onclick={() => startEditMediaNotes(item)}
 												class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 												>{t(locale, 'page.journal.day.editCaption')}</button
 											>
 										{/if}
-										<ByLine user={photo.logger} variant="inline" />
+										<ByLine user={item.logger} variant="inline" />
 									</div>
 								{/if}
 							</div>

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -5,7 +5,7 @@
 	import { goto } from '$app/navigation';
 	import { enhance } from '$app/forms';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
-	import { canModifyPhoto } from '$lib/permissions';
+	import { canModifyMedia } from '$lib/permissions';
 	import { isVideoMime, MEDIA_ACCEPT } from '$lib/media';
 	import JournalVideo from '$lib/components/JournalVideo.svelte';
 	import { localDateISO } from '$lib/date';
@@ -48,7 +48,7 @@
 		posterKey: string | null;
 	};
 
-	let photos = $state<typeof data.photos>([]);
+	let media = $state<typeof data.photos>([]);
 	let companion = $derived(data.companion);
 
 	let body = $state('');
@@ -76,7 +76,7 @@
 	$effect(() => {
 		body = data.entry?.body ?? '';
 		mood = data.entry?.mood ?? '';
-		photos = [...(data.photos ?? [])];
+		media = [...(data.photos ?? [])];
 		saveStatus = 'idle';
 	});
 
@@ -125,8 +125,8 @@
 		saveTimer = setTimeout(saveNow, 800);
 	}
 
-	async function uploadPhoto(file: File) {
-		if (photos.length >= data.maxDailyMedia) {
+	async function uploadMedia(file: File) {
+		if (media.length >= data.maxDailyMedia) {
 			setUploadError(t(locale, 'error.maxMediaExceeded', { max: data.maxDailyMedia }));
 			return;
 		}
@@ -147,8 +147,8 @@
 			}
 			const { id, filename, provider, storageKey, status, posterKey, mimeType, loggedBy, logger } =
 				await res.json();
-			photos = [
-				...photos,
+			media = [
+				...media,
 				{
 					id,
 					filename,
@@ -176,36 +176,36 @@
 		}
 	}
 
-	async function deletePhoto(photoId: string) {
+	async function deleteMedia(photoId: string) {
 		const res = await fetch(
 			`/api/companions/${data.companion.id}/journal/${data.date}/photos?photoId=${photoId}`,
 			{ method: 'DELETE' }
 		);
-		if (res.ok) photos = photos.filter((p) => p.id !== photoId);
+		if (res.ok) media = media.filter((p) => p.id !== photoId);
 	}
 
-	let editingPhotoId = $state<string | null>(null);
-	let editingPhotoNotes = $state('');
+	let editingMediaId = $state<string | null>(null);
+	let editingMediaNotes = $state('');
 
-	function startEditPhotoNotes(photo: (typeof photos)[0]) {
-		editingPhotoId = photo.id;
-		editingPhotoNotes = photo.notes ?? '';
+	function startEditMediaNotes(item: (typeof media)[0]) {
+		editingMediaId = item.id;
+		editingMediaNotes = item.notes ?? '';
 	}
 
-	async function savePhotoNotes(photoId: string) {
+	async function saveMediaNotes(photoId: string) {
 		const res = await fetch(
 			`/api/companions/${data.companion.id}/journal/${data.date}/photos?photoId=${photoId}`,
 			{
 				method: 'PATCH',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ notes: editingPhotoNotes })
+				body: JSON.stringify({ notes: editingMediaNotes })
 			}
 		);
 		if (res.ok) {
-			photos = photos.map((p) =>
-				p.id === photoId ? { ...p, notes: editingPhotoNotes.trim() || null } : p
+			media = media.map((p) =>
+				p.id === photoId ? { ...p, notes: editingMediaNotes.trim() || null } : p
 			);
-			editingPhotoId = null;
+			editingMediaId = null;
 		}
 	}
 
@@ -213,7 +213,7 @@
 		const files = (e.target as HTMLInputElement).files;
 		if (!files?.length) return;
 		for (const file of Array.from(files)) {
-			if (photos.length < data.maxDailyMedia) uploadPhoto(file);
+			if (media.length < data.maxDailyMedia) uploadMedia(file);
 		}
 		if (fileInputEl) fileInputEl.value = '';
 	}
@@ -237,27 +237,27 @@
 				setUploadError(err.message ?? t(locale, 'immich.picker.pickFailed'));
 				return;
 			}
-			const photo = await res.json();
-			photos = [...photos, photo];
+			const item = await res.json();
+			media = [...media, item];
 			immichPickerOpen = false;
 		} catch {
 			setUploadError(t(locale, 'immich.picker.pickFailed'));
 		}
 	}
 
-	function photoUrl(photo: (typeof photos)[0]) {
-		return `/api/photos/journal/${companion.id}/${data.date}/${photo.filename}`;
+	function mediaUrl(item: (typeof media)[0]) {
+		return `/api/photos/journal/${companion.id}/${data.date}/${item.filename}`;
 	}
 
-	function posterUrl(photo: (typeof photos)[0]) {
-		return photo.posterKey ? `${photoUrl(photo)}?poster` : null;
+	function posterUrl(item: (typeof media)[0]) {
+		return item.posterKey ? `${mediaUrl(item)}?poster` : null;
 	}
 
 	// True while any video is still transcoding. Derived so the poll effect starts
 	// once when work appears and stops once when it finishes — not on every edit to
-	// the photos array.
+	// the media array.
 	const hasPendingTranscode = $derived(
-		photos.some((p) => p.status === 'processing' || p.status === 'claimed')
+		media.some((p) => p.status === 'processing' || p.status === 'claimed')
 	);
 
 	// Poll the transcode status and swap in the MP4 (filename/mimeType/poster
@@ -275,7 +275,7 @@
 				const { photos: statuses }: { photos: VideoStatus[] } = await res.json();
 				const byId = new Map(statuses.map((s) => [s.id, s]));
 				let changed = false;
-				const next = photos.map((p) => {
+				const next = media.map((p) => {
 					const s = byId.get(p.id);
 					if (!s || s.status === p.status) return p;
 					changed = true;
@@ -287,7 +287,7 @@
 						posterKey: s.posterKey
 					};
 				});
-				if (changed) photos = next;
+				if (changed) media = next;
 			} catch {
 				// transient; next tick retries
 			} finally {
@@ -722,10 +722,10 @@
 				<Camera class="h-4 w-4" />
 				{t(locale, 'page.journal.day.mediaTitle')}
 				<span class="text-xs font-normal text-muted-foreground"
-					>{photos.length}/{data.maxDailyMedia}</span
+					>{media.length}/{data.maxDailyMedia}</span
 				>
 			</h2>
-			{#if photos.length < data.maxDailyMedia}
+			{#if media.length < data.maxDailyMedia}
 				<div class="flex items-center gap-2">
 					{#if data.immichEnabled}
 						<button
@@ -769,7 +769,7 @@
 		{/if}
 
 		<div class="p-4">
-			{#if photos.length === 0}
+			{#if media.length === 0}
 				<label
 					class="flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg py-8 cursor-pointer transition-colors hover:opacity-80"
 				>
@@ -794,7 +794,7 @@
 				</label>
 			{:else}
 				<div class="space-y-3">
-					{#each photos as photo (photo.id)}
+					{#each media as photo (photo.id)}
 						<div class="flex gap-3 items-start">
 							<div
 								class="group relative shrink-0 {photo.mediaType === 'video'
@@ -803,7 +803,7 @@
 							>
 								{#if photo.mediaType === 'video'}
 									<JournalVideo
-										src={photoUrl(photo)}
+										src={mediaUrl(photo)}
 										poster={posterUrl(photo)}
 										status={photo.status}
 										downloadName={photo.originalName}
@@ -813,16 +813,16 @@
 									/>
 								{:else}
 									<img
-										src={photoUrl(photo)}
+										src={mediaUrl(photo)}
 										alt={photo.originalName ?? t(locale, 'page.journal.photoAlt')}
 										class="w-full h-full object-cover"
 										loading="lazy"
 									/>
 								{/if}
-								{#if canModifyPhoto(data.user, photo)}
+								{#if canModifyMedia(data.user, photo)}
 									<button
 										type="button"
-										onclick={() => openConfirm(() => deletePhoto(photo.id))}
+										onclick={() => openConfirm(() => deleteMedia(photo.id))}
 										class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
 										flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
 										hover:bg-red-600 transition-all"
@@ -833,10 +833,10 @@
 								{/if}
 							</div>
 							<div class="flex-1 min-w-0">
-								{#if editingPhotoId === photo.id}
+								{#if editingMediaId === photo.id}
 									<MarkdownTextarea
-										value={editingPhotoNotes}
-										oninput={(e) => (editingPhotoNotes = (e.target as HTMLTextAreaElement).value)}
+										value={editingMediaNotes}
+										oninput={(e) => (editingMediaNotes = (e.target as HTMLTextAreaElement).value)}
 										placeholder={t(locale, 'page.journal.day.addCaption')}
 										rows={3}
 										name="photo-notes"
@@ -844,13 +844,13 @@
 									<div class="flex gap-2 mt-2">
 										<button
 											type="button"
-											onclick={() => savePhotoNotes(photo.id)}
+											onclick={() => saveMediaNotes(photo.id)}
 											class="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground px-2 py-1 text-xs font-medium shadow hover:bg-primary/90 transition-colors"
 											>{t(locale, 'common.save')}</button
 										>
 										<button
 											type="button"
-											onclick={() => (editingPhotoId = null)}
+											onclick={() => (editingMediaId = null)}
 											class="inline-flex items-center justify-center rounded-md border border-input bg-background px-2 py-1 text-xs font-medium shadow-sm hover:bg-accent transition-colors"
 											>{t(locale, 'common.cancel')}</button
 										>
@@ -866,10 +866,10 @@
 										</p>
 									{/if}
 									<div class="flex items-center gap-2 mt-1">
-										{#if canModifyPhoto(data.user, photo)}
+										{#if canModifyMedia(data.user, photo)}
 											<button
 												type="button"
-												onclick={() => startEditPhotoNotes(photo)}
+												onclick={() => startEditMediaNotes(photo)}
 												class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 												>{t(locale, 'page.journal.day.editCaption')}</button
 											>

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.server.ts
@@ -37,7 +37,7 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 		}
 	});
 
-	const photos = todayEntry
+	const media = todayEntry
 		? await db.query.journalPhotos.findMany({
 				where: eq(schema.journalPhotos.entryId, todayEntry.id),
 				orderBy: (p, { asc }) => [asc(p.createdAt)],
@@ -48,7 +48,7 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	return {
 		companion,
 		todayEntry: todayEntry ?? null,
-		photos,
+		photos: media,
 		today,
 		maxDailyMedia: MAX_DAILY_MEDIA
 	};

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -336,7 +336,7 @@
 			</div>
 		</Card>
 
-		<!-- Photos -->
+		<!-- Media -->
 		<Card class="overflow-hidden">
 			<CardHeader class="pb-3 flex flex-row items-center justify-between">
 				<h2 class="font-semibold flex items-center gap-2">
@@ -393,34 +393,34 @@
 					</label>
 				{:else}
 					<div class="space-y-3">
-						{#each media as photo (photo.id)}
+						{#each media as item (item.id)}
 							<div class="flex gap-3 items-start">
 								<div
-									class="group relative shrink-0 {photo.mediaType === 'video'
+									class="group relative shrink-0 {item.mediaType === 'video'
 										? 'w-40'
 										: 'w-24'} h-24 rounded-lg overflow-hidden bg-stone-100 dark:bg-stone-800"
 								>
-									{#if photo.mediaType === 'video'}
+									{#if item.mediaType === 'video'}
 										<JournalVideo
-											src={mediaUrl(photo)}
-											poster={posterUrl(photo)}
-											status={photo.status}
-											downloadName={photo.originalName}
-											label={photo.originalName ?? undefined}
+											src={mediaUrl(item)}
+											poster={posterUrl(item)}
+											status={item.status}
+											downloadName={item.originalName}
+											label={item.originalName ?? undefined}
 											class="w-full h-full object-cover"
 											compact
 										/>
 									{:else}
 										<img
-											src={mediaUrl(photo)}
-											alt={photo.originalName ?? t(locale, 'page.journal.photoAlt')}
+											src={mediaUrl(item)}
+											alt={item.originalName ?? t(locale, 'page.journal.photoAlt')}
 											class="w-full h-full object-cover"
 											loading="lazy"
 										/>
 									{/if}
-									{#if canModifyMedia(data.user, photo)}
+									{#if canModifyMedia(data.user, item)}
 										<button
-											onclick={() => deleteMedia(photo.id)}
+											onclick={() => deleteMedia(item.id)}
 											aria-label={t(locale, 'aria.deleteMedia')}
 											class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
 											flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
@@ -431,7 +431,7 @@
 									{/if}
 								</div>
 								<div class="flex-1 min-w-0">
-									{#if editingMediaId === photo.id}
+									{#if editingMediaId === item.id}
 										<MarkdownTextarea
 											value={editingMediaNotes}
 											oninput={(e) => (editingMediaNotes = (e.target as HTMLTextAreaElement).value)}
@@ -442,7 +442,7 @@
 										<div class="flex gap-2 mt-2">
 											<button
 												type="button"
-												onclick={() => saveMediaNotes(photo.id)}
+												onclick={() => saveMediaNotes(item.id)}
 												class="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground px-2 py-1 text-xs font-medium shadow hover:bg-primary/90 transition-colors"
 											>
 												{t(locale, 'common.save')}
@@ -456,9 +456,9 @@
 											</button>
 										</div>
 									{:else}
-										{#if photo.notes}
+										{#if item.notes}
 											<p class="text-sm text-muted-foreground">
-												{stripMarkdown(photo.notes)}
+												{stripMarkdown(item.notes)}
 											</p>
 										{:else}
 											<p class="text-sm italic text-muted-foreground">
@@ -466,16 +466,16 @@
 											</p>
 										{/if}
 										<div class="flex items-center gap-2 mt-1">
-											{#if canModifyMedia(data.user, photo)}
+											{#if canModifyMedia(data.user, item)}
 												<button
 													type="button"
-													onclick={() => startEditMediaNotes(photo)}
+													onclick={() => startEditMediaNotes(item)}
 													class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 												>
 													{t(locale, 'page.journal.caretaker.editCaption')}
 												</button>
 											{/if}
-											<ByLine user={photo.logger} variant="inline" />
+											<ByLine user={item.logger} variant="inline" />
 										</div>
 									{/if}
 								</div>

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData } from './$types';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
 	import { stripMarkdown } from '$lib/markdown';
-	import { canModifyPhoto } from '$lib/permissions';
+	import { canModifyMedia } from '$lib/permissions';
 	import { isVideoMime, MEDIA_ACCEPT } from '$lib/media';
 	import JournalVideo from '$lib/components/JournalVideo.svelte';
 	import { Trash2 } from '@lucide/svelte';
@@ -30,8 +30,8 @@
 	let saveStatus = $state<'idle' | 'saving' | 'saved' | 'error'>('idle');
 	let saveTimer: ReturnType<typeof setTimeout>;
 
-	// Photos
-	let photos = $state(untrack(() => data.photos ?? []));
+	// Media
+	let media = $state(untrack(() => data.photos ?? []));
 	let uploading = $state(false);
 	let uploadError = $state('');
 	let uploadErrorTimer: ReturnType<typeof setTimeout>;
@@ -43,14 +43,14 @@
 		uploadErrorTimer = setTimeout(() => (uploadError = ''), 5000);
 	}
 
-	// Photo caption editing
-	let editingPhotoId = $state<string | null>(null);
-	let editingPhotoNotes = $state('');
+	// Media caption editing
+	let editingMediaId = $state<string | null>(null);
+	let editingMediaNotes = $state('');
 
 	$effect(() => {
 		body = data.todayEntry?.body ?? '';
 		mood = data.todayEntry?.mood ?? '';
-		photos = data.photos ?? [];
+		media = data.photos ?? [];
 	});
 
 	const MOODS = moodOptions(locale);
@@ -76,8 +76,8 @@
 		}, 800);
 	}
 
-	async function uploadPhoto(file: File) {
-		if (photos.length >= data.maxDailyMedia) {
+	async function uploadMedia(file: File) {
+		if (media.length >= data.maxDailyMedia) {
 			setUploadError(t(locale, 'error.maxMediaExceeded', { max: data.maxDailyMedia }));
 			return;
 		}
@@ -98,8 +98,8 @@
 			}
 			const { id, filename, provider, storageKey, status, posterKey, mimeType, loggedBy, logger } =
 				await res.json();
-			photos = [
-				...photos,
+			media = [
+				...media,
 				{
 					id,
 					filename,
@@ -127,33 +127,33 @@
 		}
 	}
 
-	async function deletePhoto(photoId: string) {
+	async function deleteMedia(photoId: string) {
 		const res = await fetch(
 			`/api/companions/${data.companion.id}/journal/${data.today}/photos?photoId=${photoId}`,
 			{ method: 'DELETE' }
 		);
-		if (res.ok) photos = photos.filter((p) => p.id !== photoId);
+		if (res.ok) media = media.filter((p) => p.id !== photoId);
 	}
 
-	function startEditPhotoNotes(photo: (typeof photos)[0]) {
-		editingPhotoId = photo.id;
-		editingPhotoNotes = photo.notes ?? '';
+	function startEditMediaNotes(item: (typeof media)[0]) {
+		editingMediaId = item.id;
+		editingMediaNotes = item.notes ?? '';
 	}
 
-	async function savePhotoNotes(photoId: string) {
+	async function saveMediaNotes(photoId: string) {
 		const res = await fetch(
 			`/api/companions/${data.companion.id}/journal/${data.today}/photos?photoId=${photoId}`,
 			{
 				method: 'PATCH',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ notes: editingPhotoNotes })
+				body: JSON.stringify({ notes: editingMediaNotes })
 			}
 		);
 		if (res.ok) {
-			photos = photos.map((p) =>
-				p.id === photoId ? { ...p, notes: editingPhotoNotes.trim() || null } : p
+			media = media.map((p) =>
+				p.id === photoId ? { ...p, notes: editingMediaNotes.trim() || null } : p
 			);
-			editingPhotoId = null;
+			editingMediaId = null;
 		}
 	}
 
@@ -161,23 +161,23 @@
 		const files = (e.target as HTMLInputElement).files;
 		if (!files?.length) return;
 		for (const file of Array.from(files)) {
-			if (photos.length < data.maxDailyMedia) uploadPhoto(file);
+			if (media.length < data.maxDailyMedia) uploadMedia(file);
 		}
 		if (fileInputEl) fileInputEl.value = '';
 	}
 
-	function photoUrl(photo: (typeof photos)[0]) {
-		return `/api/photos/journal/${data.companion.id}/${data.today}/${photo.filename}`;
+	function mediaUrl(item: (typeof media)[0]) {
+		return `/api/photos/journal/${data.companion.id}/${data.today}/${item.filename}`;
 	}
 
-	function posterUrl(photo: (typeof photos)[0]) {
-		return photo.posterKey ? `${photoUrl(photo)}?poster` : null;
+	function posterUrl(item: (typeof media)[0]) {
+		return item.posterKey ? `${mediaUrl(item)}?poster` : null;
 	}
 
 	// True while any video is still transcoding. Derived so the poll effect starts
 	// once when work appears and stops once when it finishes.
 	const hasPendingTranscode = $derived(
-		photos.some((p) => p.status === 'processing' || p.status === 'claimed')
+		media.some((p) => p.status === 'processing' || p.status === 'claimed')
 	);
 
 	// Poll transcoding videos and swap in the MP4 once ready, without a full
@@ -197,7 +197,7 @@
 				const { photos: statuses }: { photos: VideoStatus[] } = await res.json();
 				const byId = new Map(statuses.map((s) => [s.id, s]));
 				let changed = false;
-				const next = photos.map((p) => {
+				const next = media.map((p) => {
 					const s = byId.get(p.id);
 					if (!s || s.status === p.status) return p;
 					changed = true;
@@ -209,7 +209,7 @@
 						posterKey: s.posterKey
 					};
 				});
-				if (changed) photos = next;
+				if (changed) media = next;
 			} catch {
 				// transient; next tick retries
 			} finally {
@@ -343,10 +343,10 @@
 					<span>📷</span>
 					{t(locale, 'page.journal.caretaker.media')}
 					<span class="text-xs font-normal text-muted-foreground"
-						>{photos.length}/{data.maxDailyMedia}</span
+						>{media.length}/{data.maxDailyMedia}</span
 					>
 				</h2>
-				{#if photos.length < data.maxDailyMedia}
+				{#if media.length < data.maxDailyMedia}
 					<label
 						class="inline-flex items-center justify-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium hover:bg-accent hover:text-accent-foreground cursor-pointer transition-colors"
 					>
@@ -373,7 +373,7 @@
 				</div>
 			{/if}
 			<CardContent>
-				{#if photos.length === 0}
+				{#if media.length === 0}
 					<label
 						class="flex flex-col items-center justify-center border-2 border-dashed rounded-lg py-8
 					cursor-pointer hover:opacity-80 transition-colors"
@@ -393,7 +393,7 @@
 					</label>
 				{:else}
 					<div class="space-y-3">
-						{#each photos as photo (photo.id)}
+						{#each media as photo (photo.id)}
 							<div class="flex gap-3 items-start">
 								<div
 									class="group relative shrink-0 {photo.mediaType === 'video'
@@ -402,7 +402,7 @@
 								>
 									{#if photo.mediaType === 'video'}
 										<JournalVideo
-											src={photoUrl(photo)}
+											src={mediaUrl(photo)}
 											poster={posterUrl(photo)}
 											status={photo.status}
 											downloadName={photo.originalName}
@@ -412,15 +412,15 @@
 										/>
 									{:else}
 										<img
-											src={photoUrl(photo)}
+											src={mediaUrl(photo)}
 											alt={photo.originalName ?? t(locale, 'page.journal.photoAlt')}
 											class="w-full h-full object-cover"
 											loading="lazy"
 										/>
 									{/if}
-									{#if canModifyPhoto(data.user, photo)}
+									{#if canModifyMedia(data.user, photo)}
 										<button
-											onclick={() => deletePhoto(photo.id)}
+											onclick={() => deleteMedia(photo.id)}
 											aria-label={t(locale, 'aria.deleteMedia')}
 											class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
 											flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
@@ -431,10 +431,10 @@
 									{/if}
 								</div>
 								<div class="flex-1 min-w-0">
-									{#if editingPhotoId === photo.id}
+									{#if editingMediaId === photo.id}
 										<MarkdownTextarea
-											value={editingPhotoNotes}
-											oninput={(e) => (editingPhotoNotes = (e.target as HTMLTextAreaElement).value)}
+											value={editingMediaNotes}
+											oninput={(e) => (editingMediaNotes = (e.target as HTMLTextAreaElement).value)}
 											placeholder={t(locale, 'page.journal.caretaker.addCaption')}
 											rows={3}
 											name="photo-notes"
@@ -442,14 +442,14 @@
 										<div class="flex gap-2 mt-2">
 											<button
 												type="button"
-												onclick={() => savePhotoNotes(photo.id)}
+												onclick={() => saveMediaNotes(photo.id)}
 												class="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground px-2 py-1 text-xs font-medium shadow hover:bg-primary/90 transition-colors"
 											>
 												{t(locale, 'common.save')}
 											</button>
 											<button
 												type="button"
-												onclick={() => (editingPhotoId = null)}
+												onclick={() => (editingMediaId = null)}
 												class="inline-flex items-center justify-center rounded-md border border-input bg-background px-2 py-1 text-xs font-medium shadow-sm hover:bg-accent transition-colors"
 											>
 												{t(locale, 'common.cancel')}
@@ -466,10 +466,10 @@
 											</p>
 										{/if}
 										<div class="flex items-center gap-2 mt-1">
-											{#if canModifyPhoto(data.user, photo)}
+											{#if canModifyMedia(data.user, photo)}
 												<button
 													type="button"
-													onclick={() => startEditPhotoNotes(photo)}
+													onclick={() => startEditMediaNotes(photo)}
 													class="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
 												>
 													{t(locale, 'page.journal.caretaker.editCaption')}
@@ -481,7 +481,7 @@
 								</div>
 							</div>
 						{/each}
-						{#if photos.length < data.maxDailyMedia}
+						{#if media.length < data.maxDailyMedia}
 							<label
 								class="aspect-square w-24 rounded-lg border-2 border-dashed flex flex-col items-center
 							justify-center cursor-pointer hover:opacity-80 transition-colors"

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -10,7 +10,7 @@ import { MAX_DAILY_MEDIA, UPLOAD_MAX_MB, VIDEO_MAX_MB, VIDEO_TRANSCODE } from '$
 import { isAllowedVideoMime, looksLikeVideo, videoExtFromMime } from '$lib/server/storage/mime';
 import { demuxerForMime, transcodeAvailable } from '$lib/server/video/transcode';
 import { kickWorker } from '$lib/server/video/worker';
-import { canModifyPhoto } from '$lib/permissions';
+import { canModifyMedia } from '$lib/permissions';
 import { assertCanEditCompanion } from '$lib/server/permissions';
 import { isValidDate } from '$lib/server/validation';
 
@@ -102,13 +102,13 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		entry = created;
 	}
 
-	// Check current photo count for this entry
-	const [{ value: photoCount }] = await db
+	// Check current media count for this entry
+	const [{ value: mediaCount }] = await db
 		.select({ value: count() })
 		.from(schema.journalPhotos)
 		.where(eq(schema.journalPhotos.entryId, entry.id));
 
-	if (photoCount >= MAX_DAILY_MEDIA) {
+	if (mediaCount >= MAX_DAILY_MEDIA) {
 		error(400, t(locals.locale, 'error.maxMediaExceeded', { max: MAX_DAILY_MEDIA }));
 	}
 
@@ -237,7 +237,7 @@ export const PATCH: RequestHandler = async ({ url, request, params, locals }) =>
 	if (!entry || entry.companionId !== params.companionId)
 		error(403, t(locals.locale, 'error.forbidden'));
 
-	if (!canModifyPhoto(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
+	if (!canModifyMedia(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
 
 	const contentLength = parseInt(request.headers.get('content-length') ?? '0');
 	if (contentLength > 10_000) error(400, t(locals.locale, 'error.requestBodyTooLarge'));
@@ -269,7 +269,7 @@ export const DELETE: RequestHandler = async ({ url, params, locals }) => {
 	if (!entry || entry.companionId !== params.companionId)
 		error(403, t(locals.locale, 'error.forbidden'));
 
-	if (!canModifyPhoto(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
+	if (!canModifyMedia(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
 
 	// Remove every object this row owns: the primary file plus, for a transcoded
 	// video, the kept original and the generated poster. Missing keys are no-ops

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/+server.ts
@@ -129,7 +129,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	}
 
 	const raw = Buffer.from(await file.arrayBuffer());
-	const photoId = generateId(15);
+	const mediaId = generateId(15);
 	let processed: Buffer;
 	let ext: string;
 	let mimeType: string;
@@ -175,11 +175,11 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		(await transcodeAvailable());
 
 	// A to-be-transcoded source is stored under a sentinel '.orig.' name so its
-	// key can never collide with the worker's output ('{photoId}.mp4'). Without
+	// key can never collide with the worker's output ('{mediaId}.mp4'). Without
 	// this, an mp4-container source (e.g. Apple HEVC) would share the output key:
 	// the transcode would overwrite the kept original, or — with KEEP_ORIGINAL
 	// off — the post-transcode cleanup would delete the output itself.
-	const filename = willTranscode ? `${photoId}.orig.${ext}` : `${photoId}.${ext}`;
+	const filename = willTranscode ? `${mediaId}.orig.${ext}` : `${mediaId}.${ext}`;
 	const key = journalKey(companionId, date, filename);
 	try {
 		await getStorage().put({
@@ -188,12 +188,12 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 			contentType: mimeType
 		});
 	} catch (err) {
-		console.error('[journal-photo] storage put failed:', err);
+		console.error('[journal-media] storage put failed:', err);
 		error(502, t(locals.locale, 'error.fileNotFound'));
 	}
 
 	await db.insert(schema.journalPhotos).values({
-		id: photoId,
+		id: mediaId,
 		entryId: entry.id,
 		filename,
 		provider: STORAGE_BACKEND,
@@ -209,7 +209,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	if (willTranscode) kickWorker();
 
 	const created = await db.query.journalPhotos.findFirst({
-		where: eq(schema.journalPhotos.id, photoId),
+		where: eq(schema.journalPhotos.id, mediaId),
 		with: { logger: { columns: { displayName: true } } }
 	});
 
@@ -225,19 +225,19 @@ export const PATCH: RequestHandler = async ({ url, request, params, locals }) =>
 	const photoId = url.searchParams.get('photoId');
 	if (!photoId) error(400, t(locals.locale, 'error.missingPhotoId'));
 
-	const photo = await db.query.journalPhotos.findFirst({
+	const item = await db.query.journalPhotos.findFirst({
 		where: eq(schema.journalPhotos.id, photoId)
 	});
-	if (!photo) error(404, t(locals.locale, 'error.photoNotFound'));
+	if (!item) error(404, t(locals.locale, 'error.photoNotFound'));
 
 	const entry = await db.query.journalEntries.findFirst({
-		where: eq(schema.journalEntries.id, photo.entryId),
+		where: eq(schema.journalEntries.id, item.entryId),
 		columns: { companionId: true }
 	});
 	if (!entry || entry.companionId !== params.companionId)
 		error(403, t(locals.locale, 'error.forbidden'));
 
-	if (!canModifyMedia(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
+	if (!canModifyMedia(locals.user, item)) error(403, t(locals.locale, 'error.forbidden'));
 
 	const contentLength = parseInt(request.headers.get('content-length') ?? '0');
 	if (contentLength > 10_000) error(400, t(locals.locale, 'error.requestBodyTooLarge'));
@@ -257,19 +257,19 @@ export const DELETE: RequestHandler = async ({ url, params, locals }) => {
 	const photoId = url.searchParams.get('photoId');
 	if (!photoId) error(400, t(locals.locale, 'error.missingPhotoId'));
 
-	const photo = await db.query.journalPhotos.findFirst({
+	const item = await db.query.journalPhotos.findFirst({
 		where: eq(schema.journalPhotos.id, photoId)
 	});
-	if (!photo) error(404, t(locals.locale, 'error.photoNotFound'));
+	if (!item) error(404, t(locals.locale, 'error.photoNotFound'));
 
 	const entry = await db.query.journalEntries.findFirst({
-		where: eq(schema.journalEntries.id, photo.entryId),
+		where: eq(schema.journalEntries.id, item.entryId),
 		columns: { companionId: true }
 	});
 	if (!entry || entry.companionId !== params.companionId)
 		error(403, t(locals.locale, 'error.forbidden'));
 
-	if (!canModifyMedia(locals.user, photo)) error(403, t(locals.locale, 'error.forbidden'));
+	if (!canModifyMedia(locals.user, item)) error(403, t(locals.locale, 'error.forbidden'));
 
 	// Remove every object this row owns: the primary file plus, for a transcoded
 	// video, the kept original and the generated poster. Missing keys are no-ops
@@ -278,15 +278,15 @@ export const DELETE: RequestHandler = async ({ url, params, locals }) => {
 	// of truth, so a transient backend failure on one key must not abort the
 	// others or leave an undeletable row (an orphaned object is recoverable; a
 	// stuck row is not).
-	const backend = getStorage(photo.provider);
-	const key = photo.storageKey ?? journalKey(params.companionId, params.date, photo.filename);
-	const keys = [key, photo.originalKey, photo.posterKey].filter(
+	const backend = getStorage(item.provider);
+	const key = item.storageKey ?? journalKey(params.companionId, params.date, item.filename);
+	const keys = [key, item.originalKey, item.posterKey].filter(
 		(k): k is string => typeof k === 'string' && k.length > 0
 	);
 	const results = await Promise.allSettled(keys.map((k) => backend.delete(k)));
 	results.forEach((r, i) => {
 		if (r.status === 'rejected') {
-			console.warn(`[journal-photo] failed to delete object ${keys[i]}:`, r.reason);
+			console.warn(`[journal-media] failed to delete object ${keys[i]}:`, r.reason);
 		}
 	});
 

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
@@ -57,9 +57,9 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 		entry = created;
 	}
 
-	const photoId = generateId(15);
+	const mediaId = generateId(15);
 	const ext = safeExtFromMime(asset.originalMimeType, asset.originalFileName);
-	const filename = `${photoId}.${ext}`;
+	const filename = `${mediaId}.${ext}`;
 	const entryId = entry.id;
 	const loggedBy = locals.user.id;
 
@@ -82,7 +82,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 			}
 			tx.insert(schema.journalPhotos)
 				.values({
-					id: photoId,
+					id: mediaId,
 					entryId,
 					filename,
 					provider: 'immich',
@@ -106,7 +106,7 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	}
 
 	const created = await db.query.journalPhotos.findFirst({
-		where: eq(schema.journalPhotos.id, photoId),
+		where: eq(schema.journalPhotos.id, mediaId),
 		with: { logger: { columns: { displayName: true } } }
 	});
 

--- a/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
+++ b/src/routes/api/companions/[companionId]/journal/[date]/photos/from-immich/+server.ts
@@ -76,8 +76,8 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 				.from(schema.journalPhotos)
 				.where(eq(schema.journalPhotos.entryId, entryId))
 				.all();
-			const photoCount = rows[0]?.value ?? 0;
-			if (photoCount >= MAX_DAILY_MEDIA) {
+			const mediaCount = rows[0]?.value ?? 0;
+			if (mediaCount >= MAX_DAILY_MEDIA) {
 				return { ok: false as const };
 			}
 			tx.insert(schema.journalPhotos)

--- a/tests/e2e/journal.spec.ts
+++ b/tests/e2e/journal.spec.ts
@@ -61,8 +61,8 @@ test.describe('journal day editor', () => {
 		await asMember.goto(`/${COMP}/journal/2026-05-02`);
 
 		// Make sure a photo is present; if not, upload one.
-		const photoImg = asMember.locator('img[src*="/api/photos/journal/"]').first();
-		const count = await photoImg.count();
+		const mediaImg = asMember.locator('img[src*="/api/photos/journal/"]').first();
+		const count = await mediaImg.count();
 		if (count === 0) {
 			const textarea = asMember.locator('textarea');
 			await textarea.fill('e2e caption test');
@@ -71,7 +71,7 @@ test.describe('journal day editor', () => {
 
 			const fileInput = asMember.locator('input[type="file"][name="photos"]').first();
 			await fileInput.setInputFiles(pngUpload());
-			await expect(photoImg).toBeVisible({ timeout: 15_000 });
+			await expect(mediaImg).toBeVisible({ timeout: 15_000 });
 		}
 
 		// Click "Edit Caption"
@@ -94,13 +94,13 @@ test.describe('journal day editor', () => {
 
 		// Delete the photo
 		// Hover the photo thumbnail to reveal the delete button
-		const photoContainer = asMember
+		const mediaContainer = asMember
 			.locator('div.group')
 			.filter({ has: asMember.locator('img[src*="/api/photos/journal/"]') })
 			.first();
-		await photoContainer.hover();
+		await mediaContainer.hover();
 
-		const deleteBtn = photoContainer.locator('button[aria-label]');
+		const deleteBtn = mediaContainer.locator('button[aria-label]');
 		await deleteBtn.click();
 
 		// Confirm in the dialog (scope to the confirm dialog to avoid the aria-labeled trash button)

--- a/tests/e2e/limits.spec.ts
+++ b/tests/e2e/limits.spec.ts
@@ -48,12 +48,12 @@ async function login(page: Page, baseURL: string, username: string) {
 	await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
 }
 
-async function apiUploadPhoto(
+async function apiUploadMedia(
 	page: Page,
 	baseURL: string,
 	comp: string,
 	date: string,
-	photoBuffer: Buffer,
+	mediaBuffer: Buffer,
 	name = 'photo.png'
 ) {
 	return page.request.post(`${baseURL}/api/companions/${comp}/journal/${date}/photos`, {
@@ -62,7 +62,7 @@ async function apiUploadPhoto(
 			photo: {
 				name,
 				mimeType: 'image/png',
-				buffer: photoBuffer
+				buffer: mediaBuffer
 			}
 		}
 	});
@@ -76,7 +76,7 @@ test('oversized upload is rejected with fileTooLarge', async ({ world, page }) =
 	// calling sharp, so this returns 400 with the fileTooLarge message.
 	const oversized = Buffer.concat([PNG_BYTES, Buffer.alloc(1_300_000)]);
 
-	const res = await apiUploadPhoto(page, world.server.baseURL, COMP, '2026-06-10', oversized);
+	const res = await apiUploadMedia(page, world.server.baseURL, COMP, '2026-06-10', oversized);
 	expect(res.status()).toBe(400);
 	const body = await res.text();
 	expect(body).toContain('File too large');
@@ -86,17 +86,17 @@ test('daily media cap rejects the third upload', async ({ world, page }) => {
 	await login(page, world.server.baseURL, SEED.member.username);
 
 	const date = '2026-06-11';
-	const photoData = PNG_BYTES;
+	const mediaData = PNG_BYTES;
 
 	// First two uploads must succeed
-	const first = await apiUploadPhoto(page, world.server.baseURL, COMP, date, photoData);
+	const first = await apiUploadMedia(page, world.server.baseURL, COMP, date, mediaData);
 	expect(first.status()).toBe(200);
 
-	const second = await apiUploadPhoto(page, world.server.baseURL, COMP, date, photoData);
+	const second = await apiUploadMedia(page, world.server.baseURL, COMP, date, mediaData);
 	expect(second.status()).toBe(200);
 
 	// Third upload must be rejected
-	const third = await apiUploadPhoto(page, world.server.baseURL, COMP, date, photoData);
+	const third = await apiUploadMedia(page, world.server.baseURL, COMP, date, mediaData);
 	expect(third.status()).toBe(400);
 	const body = await third.text();
 	expect(body).toContain('Maximum 2 photos or videos per day');


### PR DESCRIPTION
## Summary

Closes #85. Follow-up to journal video support (#22): internal identifiers catch up with the already-renamed user-facing names. Pure rename, no behavior change.

- `uploadPhoto`/`deletePhoto`/`savePhotoNotes`/`photoUrl`/`editingPhotoId`/`editingPhotoNotes`/`startEditPhotoNotes` → media equivalents across both journal route trees and the photos API handlers; local `photos` state arrays → `media`, `photoCount` → `mediaCount`; lightbox state too.
- `canModifyPhoto` → `canModifyMedia` in `src/lib/permissions.ts` with all callers and its unit tests.
- Everything the issue scoped out stays put: `journal_photos` table and `journalPhotos` export, `?photoId=` param, `error.missingPhotoId`, `UPLOAD_MAX_MB`, and all wire names (form fields, URL paths, JSON keys) — the e2e suite asserts on those contracts and passes untouched.

## Test plan

- [x] `npm run lint`, `npm run check` clean
- [x] `npm run test:unit` — 86 passed
- [x] `PW_SKIP_BUILD=1 npm run test:e2e` — 91 passed (no test changes beyond the canModifyMedia import — behavior-change proof)
- [x] CI green