### PR TITLE
Add full-text search

### DIFF
--- a/drizzle/0021_search_index.sql
+++ b/drizzle/0021_search_index.sql
@@ -1,0 +1,118 @@
+CREATE VIRTUAL TABLE search_index USING fts5(
+	title,
+	body,
+	entity_type UNINDEXED,
+	entity_id UNINDEXED,
+	companion_id UNINDEXED,
+	event_date UNINDEXED,
+	tokenize = 'unicode61 remove_diacritics 2',
+	prefix = '2 3 4'
+);
+--> statement-breakpoint
+CREATE TRIGGER search_journal_ai AFTER INSERT ON journal_entries BEGIN
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES ('', COALESCE(new.body, ''), 'journal', new.id, new.companion_id, new.date);
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_journal_au AFTER UPDATE ON journal_entries BEGIN
+	DELETE FROM search_index WHERE entity_type = 'journal' AND entity_id = old.id;
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES ('', COALESCE(new.body, ''), 'journal', new.id, new.companion_id, new.date);
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_journal_ad AFTER DELETE ON journal_entries BEGIN
+	DELETE FROM search_index WHERE entity_type = 'journal' AND entity_id = old.id;
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_health_ai AFTER INSERT ON health_events BEGIN
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES (COALESCE(new.title, ''), COALESCE(new.notes, ''), 'health', new.id, new.companion_id, date(new.occurred_at, 'unixepoch'));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_health_au AFTER UPDATE ON health_events BEGIN
+	DELETE FROM search_index WHERE entity_type = 'health' AND entity_id = old.id;
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES (COALESCE(new.title, ''), COALESCE(new.notes, ''), 'health', new.id, new.companion_id, date(new.occurred_at, 'unixepoch'));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_health_ad AFTER DELETE ON health_events BEGIN
+	DELETE FROM search_index WHERE entity_type = 'health' AND entity_id = old.id;
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_reminder_ai AFTER INSERT ON reminders BEGIN
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES (COALESCE(new.title, ''), COALESCE(new.description, ''), 'reminder', new.id, new.companion_id, date(new.due_at, 'unixepoch'));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_reminder_au AFTER UPDATE ON reminders BEGIN
+	DELETE FROM search_index WHERE entity_type = 'reminder' AND entity_id = old.id;
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES (COALESCE(new.title, ''), COALESCE(new.description, ''), 'reminder', new.id, new.companion_id, date(new.due_at, 'unixepoch'));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_reminder_ad AFTER DELETE ON reminders BEGIN
+	DELETE FROM search_index WHERE entity_type = 'reminder' AND entity_id = old.id;
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_document_ai AFTER INSERT ON documents BEGIN
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES (COALESCE(new.title, ''), '', 'document', new.id, new.companion_id, COALESCE(new.document_date, date(new.created_at, 'unixepoch')));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_document_au AFTER UPDATE ON documents BEGIN
+	DELETE FROM search_index WHERE entity_type = 'document' AND entity_id = old.id;
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES (COALESCE(new.title, ''), '', 'document', new.id, new.companion_id, COALESCE(new.document_date, date(new.created_at, 'unixepoch')));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_document_ad AFTER DELETE ON documents BEGIN
+	DELETE FROM search_index WHERE entity_type = 'document' AND entity_id = old.id;
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_daily_ai AFTER INSERT ON daily_events BEGIN
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES ('', COALESCE(new.notes, ''), 'daily', new.id, new.companion_id, date(new.logged_at, 'unixepoch'));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_daily_au AFTER UPDATE ON daily_events BEGIN
+	DELETE FROM search_index WHERE entity_type = 'daily' AND entity_id = old.id;
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES ('', COALESCE(new.notes, ''), 'daily', new.id, new.companion_id, date(new.logged_at, 'unixepoch'));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_daily_ad AFTER DELETE ON daily_events BEGIN
+	DELETE FROM search_index WHERE entity_type = 'daily' AND entity_id = old.id;
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_weight_ai AFTER INSERT ON weight_entries BEGIN
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES ('', COALESCE(new.notes, ''), 'weight', new.id, new.companion_id, date(new.recorded_at, 'unixepoch'));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_weight_au AFTER UPDATE ON weight_entries BEGIN
+	DELETE FROM search_index WHERE entity_type = 'weight' AND entity_id = old.id;
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	VALUES ('', COALESCE(new.notes, ''), 'weight', new.id, new.companion_id, date(new.recorded_at, 'unixepoch'));
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_weight_ad AFTER DELETE ON weight_entries BEGIN
+	DELETE FROM search_index WHERE entity_type = 'weight' AND entity_id = old.id;
+END;
+--> statement-breakpoint
+INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+SELECT '', COALESCE(body, ''), 'journal', id, companion_id, date FROM journal_entries;
+--> statement-breakpoint
+INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+SELECT COALESCE(title, ''), COALESCE(notes, ''), 'health', id, companion_id, date(occurred_at, 'unixepoch') FROM health_events;
+--> statement-breakpoint
+INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+SELECT COALESCE(title, ''), COALESCE(description, ''), 'reminder', id, companion_id, date(due_at, 'unixepoch') FROM reminders;
+--> statement-breakpoint
+INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+SELECT COALESCE(title, ''), '', 'document', id, companion_id, COALESCE(document_date, date(created_at, 'unixepoch')) FROM documents;
+--> statement-breakpoint
+INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+SELECT '', COALESCE(notes, ''), 'daily', id, companion_id, date(logged_at, 'unixepoch') FROM daily_events;
+--> statement-breakpoint
+INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+SELECT '', COALESCE(notes, ''), 'weight', id, companion_id, date(recorded_at, 'unixepoch') FROM weight_entries;

--- a/drizzle/0022_search_media.sql
+++ b/drizzle/0022_search_media.sql
@@ -1,0 +1,20 @@
+CREATE TRIGGER search_media_ai AFTER INSERT ON journal_photos BEGIN
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	SELECT '', COALESCE(new.notes, ''), 'media', new.id, je.companion_id, je.date
+	FROM journal_entries je WHERE je.id = new.entry_id;
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_media_au AFTER UPDATE ON journal_photos BEGIN
+	DELETE FROM search_index WHERE entity_type = 'media' AND entity_id = old.id;
+	INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+	SELECT '', COALESCE(new.notes, ''), 'media', new.id, je.companion_id, je.date
+	FROM journal_entries je WHERE je.id = new.entry_id;
+END;
+--> statement-breakpoint
+CREATE TRIGGER search_media_ad AFTER DELETE ON journal_photos BEGIN
+	DELETE FROM search_index WHERE entity_type = 'media' AND entity_id = old.id;
+END;
+--> statement-breakpoint
+INSERT INTO search_index (title, body, entity_type, entity_id, companion_id, event_date)
+SELECT '', COALESCE(jp.notes, ''), 'media', jp.id, je.companion_id, je.date
+FROM journal_photos jp JOIN journal_entries je ON je.id = jp.entry_id;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,167 +1,167 @@
 {
-  "version": "7",
-  "dialect": "sqlite",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "6",
-      "when": 1774311329346,
-      "tag": "0000_milky_kinsey_walden",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "6",
-      "when": 1775390240699,
-      "tag": "0001_faithful_power_man",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "6",
-      "when": 1775737577881,
-      "tag": "0002_reflective_iron_fist",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "6",
-      "when": 1775738400000,
-      "tag": "0003_fix_logged_by_fk",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "6",
-      "when": 1775908177456,
-      "tag": "0004_hesitant_fat_cobra",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "6",
-      "when": 1776254803388,
-      "tag": "0005_condemned_rachel_grey",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "6",
-      "when": 1777720933399,
-      "tag": "0006_absurd_trauma",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "6",
-      "when": 1777820851991,
-      "tag": "0007_dear_steel_serpent",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "6",
-      "when": 1778447342266,
-      "tag": "0008_happy_hulk",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "6",
-      "when": 1778498303676,
-      "tag": "0009_outstanding_blazing_skull",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "6",
-      "when": 1778504722701,
-      "tag": "0010_abnormal_major_mapleleaf",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "6",
-      "when": 1778544024638,
-      "tag": "0011_smiling_enchantress",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "6",
-      "when": 1779721030065,
-      "tag": "0012_curved_baron_zemo",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "6",
-      "when": 1780012333513,
-      "tag": "0013_brave_lenny_balinger",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "6",
-      "when": 1780662158002,
-      "tag": "0014_low_the_liberteens",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "6",
-      "when": 1780751281276,
-      "tag": "0015_fantastic_captain_america",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "6",
-      "when": 1780753898397,
-      "tag": "0016_public_miek",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "6",
-      "when": 1780778399941,
-      "tag": "0017_nostalgic_longshot",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "6",
-      "when": 1780832729465,
-      "tag": "0018_lucky_carlie_cooper",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "6",
-      "when": 1780881094924,
-      "tag": "0019_smart_dreaming_celestial",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "6",
-      "when": 1781126813759,
-      "tag": "0020_melodic_deathbird",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "6",
-      "when": 1781144492105,
-      "tag": "0021_search_index",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "6",
-      "when": 1749600000000,
-      "tag": "0022_search_media",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "sqlite",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "6",
+			"when": 1774311329346,
+			"tag": "0000_milky_kinsey_walden",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "6",
+			"when": 1775390240699,
+			"tag": "0001_faithful_power_man",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "6",
+			"when": 1775737577881,
+			"tag": "0002_reflective_iron_fist",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "6",
+			"when": 1775738400000,
+			"tag": "0003_fix_logged_by_fk",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1775908177456,
+			"tag": "0004_hesitant_fat_cobra",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "6",
+			"when": 1776254803388,
+			"tag": "0005_condemned_rachel_grey",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "6",
+			"when": 1777720933399,
+			"tag": "0006_absurd_trauma",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "6",
+			"when": 1777820851991,
+			"tag": "0007_dear_steel_serpent",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "6",
+			"when": 1778447342266,
+			"tag": "0008_happy_hulk",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "6",
+			"when": 1778498303676,
+			"tag": "0009_outstanding_blazing_skull",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "6",
+			"when": 1778504722701,
+			"tag": "0010_abnormal_major_mapleleaf",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "6",
+			"when": 1778544024638,
+			"tag": "0011_smiling_enchantress",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "6",
+			"when": 1779721030065,
+			"tag": "0012_curved_baron_zemo",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "6",
+			"when": 1780012333513,
+			"tag": "0013_brave_lenny_balinger",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "6",
+			"when": 1780662158002,
+			"tag": "0014_low_the_liberteens",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "6",
+			"when": 1780751281276,
+			"tag": "0015_fantastic_captain_america",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "6",
+			"when": 1780753898397,
+			"tag": "0016_public_miek",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "6",
+			"when": 1780778399941,
+			"tag": "0017_nostalgic_longshot",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "6",
+			"when": 1780832729465,
+			"tag": "0018_lucky_carlie_cooper",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "6",
+			"when": 1780881094924,
+			"tag": "0019_smart_dreaming_celestial",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "6",
+			"when": 1781126813759,
+			"tag": "0020_melodic_deathbird",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "6",
+			"when": 1781144492105,
+			"tag": "0021_search_index",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "6",
+			"when": 1781187000000,
+			"tag": "0022_search_media",
+			"breakpoints": true
+		}
+	]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1781144492105,
       "tag": "0021_search_index",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1749600000000,
+      "tag": "0022_search_media",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1781126813759,
       "tag": "0020_melodic_deathbird",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1781144492105,
+      "tag": "0021_search_index",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/MediaLightbox.svelte
+++ b/src/lib/components/MediaLightbox.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+	import { tick } from 'svelte';
+	import { ChevronLeft, ChevronRight, X, Download } from '@lucide/svelte';
+	import JournalVideo from '$lib/components/JournalVideo.svelte';
+	import ByLine from '$lib/components/ByLine.svelte';
+	import { renderMarkdown } from '$lib/markdown';
+	import { t, getLocale } from '$lib/i18n';
+	import type { UserRef } from '$lib/types';
+
+	const locale = getLocale();
+
+	type MediaItem = {
+		id: string;
+		filename: string;
+		originalName: string | null;
+		mediaType: 'photo' | 'video';
+		notes: string | null;
+		status: string;
+		posterKey: string | null;
+		logger: UserRef;
+		[key: string]: unknown;
+	};
+
+	interface Props {
+		/** The companion ID, used to build /api/photos/journal/:companionId/:date/:filename URLs. */
+		companionId: string;
+		/** The media items to page through. */
+		items: MediaItem[];
+		/** Active item index — caller can set the start index. */
+		index?: number;
+		/** Entry date (YYYY-MM-DD), needed to build media URLs. */
+		date: string;
+		/** Whether the lightbox is visible. */
+		open?: boolean;
+	}
+
+	let {
+		companionId,
+		items = [],
+		index = $bindable(0),
+		date,
+		open = $bindable(false)
+	}: Props = $props();
+
+	let lightboxEl = $state<HTMLElement | null>(null);
+	let triggerEl = $state<HTMLElement | null>(null);
+
+	let item = $derived(open && items.length > 0 ? items[index] : null);
+
+	// Capture the trigger when the lightbox opens so focus can be restored on close.
+	$effect(() => {
+		if (open) {
+			triggerEl = document.activeElement as HTMLElement | null;
+			tick().then(() => lightboxEl?.focus());
+		} else {
+			tick().then(() => triggerEl?.focus());
+		}
+	});
+
+	function mediaUrl(it: MediaItem) {
+		return `/api/photos/journal/${companionId}/${date}/${it.filename}`;
+	}
+
+	function posterUrl(it: MediaItem) {
+		return it.posterKey ? `${mediaUrl(it)}?poster` : null;
+	}
+
+	function close() {
+		open = false;
+		index = 0;
+	}
+
+	function prev() {
+		if (index > 0) index--;
+	}
+
+	function next() {
+		if (index < items.length - 1) index++;
+	}
+
+	function handleKey(e: KeyboardEvent) {
+		if (!open) return;
+		if (e.key === 'Escape') {
+			close();
+		} else if (e.key === 'ArrowLeft') {
+			prev();
+		} else if (e.key === 'ArrowRight') {
+			next();
+		}
+	}
+
+	function trapFocus(e: KeyboardEvent) {
+		if (!lightboxEl || e.key !== 'Tab') return;
+		const focusable = Array.from(
+			lightboxEl.querySelectorAll<HTMLElement>(
+				'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+			)
+		);
+		if (!focusable.length) return;
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		if (e.shiftKey) {
+			if (document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			}
+		} else {
+			if (document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+	}
+</script>
+
+<svelte:window onkeydown={handleKey} />
+
+{#if item}
+	<div
+		bind:this={lightboxEl}
+		role="dialog"
+		aria-modal="true"
+		aria-label={t(locale, 'page.journal.mediaLightboxLabel')}
+		tabindex="-1"
+		class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/85 focus:outline-none"
+		onclick={close}
+		onkeydown={(e) => {
+			handleKey(e);
+			trapFocus(e);
+		}}
+	>
+		<div
+			role="presentation"
+			onclick={(e) => e.stopPropagation()}
+			onkeydown={(e) => e.stopPropagation()}
+			class="relative max-w-4xl w-full"
+		>
+			<div class="flex items-center justify-between mb-2">
+				{#if items.length > 1}
+					<span class="text-sm text-white/60">{index + 1} / {items.length}</span>
+				{:else}
+					<span></span>
+				{/if}
+				<div class="flex items-center gap-1">
+					<a
+						href={mediaUrl(item)}
+						download={item.originalName ?? item.filename}
+						class="text-white/70 hover:text-white p-1 rounded"
+						aria-label={t(locale, 'aria.downloadMedia')}
+					>
+						<Download class="h-5 w-5" />
+					</a>
+					<button
+						type="button"
+						onclick={close}
+						class="text-white/70 hover:text-white p-1 rounded"
+						aria-label={t(locale, 'aria.close')}
+					>
+						<X class="h-5 w-5" />
+					</button>
+				</div>
+			</div>
+
+			<div class="relative">
+				{#if item.mediaType === 'video'}
+					<JournalVideo
+						src={mediaUrl(item)}
+						poster={posterUrl(item)}
+						status={item.status}
+						downloadName={item.originalName}
+						label={item.originalName ?? undefined}
+						autoplay
+						class="max-h-[78vh] w-full object-contain rounded-lg bg-black"
+					/>
+				{:else}
+					<img
+						src={mediaUrl(item)}
+						alt={item.originalName ?? ''}
+						class="max-h-[78vh] w-full object-contain rounded-lg"
+					/>
+				{/if}
+				{#if items.length > 1}
+					<button
+						type="button"
+						onclick={prev}
+						disabled={index === 0}
+						class="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center text-white transition-opacity bg-black/40 {index ===
+						0
+							? 'opacity-20 cursor-default'
+							: 'opacity-70 hover:opacity-100'}"
+						aria-label={t(locale, 'aria.previousMedia')}
+					>
+						<ChevronLeft class="h-5 w-5" />
+					</button>
+					<button
+						type="button"
+						onclick={next}
+						disabled={index === items.length - 1}
+						class="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center text-white transition-opacity bg-black/40 {index ===
+						items.length - 1
+							? 'opacity-20 cursor-default'
+							: 'opacity-70 hover:opacity-100'}"
+						aria-label={t(locale, 'aria.nextMedia')}
+					>
+						<ChevronRight class="h-5 w-5" />
+					</button>
+				{/if}
+			</div>
+
+			{#if item.notes}
+				<div class="prose prose-sm prose-invert max-w-none mt-3 text-center text-sm">
+					{@html renderMarkdown(item.notes)}
+				</div>
+			{/if}
+			{#if item.logger}
+				<div class="mt-2 flex justify-center">
+					<ByLine user={item.logger} variant="inline" class="!text-white/60 !ml-0" />
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/MediaLightbox.svelte
+++ b/src/lib/components/MediaLightbox.svelte
@@ -81,6 +81,10 @@
 	function handleKey(e: KeyboardEvent) {
 		if (!open) return;
 		if (e.key === 'Escape') {
+			// The lightbox is the topmost overlay; consume Escape so a sibling
+			// window handler (e.g. the journal page's activity-detail modal) can't
+			// also close on the same keypress regardless of listener order.
+			e.stopImmediatePropagation();
 			close();
 		} else if (e.key === 'ArrowLeft') {
 			prev();

--- a/src/lib/components/SearchPalette.svelte
+++ b/src/lib/components/SearchPalette.svelte
@@ -1,0 +1,338 @@
+<script lang="ts">
+	import { tick } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { t, getLocale } from '$lib/i18n';
+	import { Search } from '@lucide/svelte';
+
+	export type SearchEntityType =
+		| 'journal'
+		| 'health'
+		| 'reminder'
+		| 'document'
+		| 'daily'
+		| 'weight';
+
+	export interface ClientSearchResult {
+		type: SearchEntityType;
+		id: string;
+		companionId: string;
+		companionName: string;
+		title: string;
+		snippet: string;
+		date: string;
+		href: string;
+	}
+
+	let { open = $bindable(false) }: { open?: boolean } = $props();
+
+	const locale = getLocale();
+
+	let dialogEl = $state<HTMLElement | null>(null);
+	let inputEl = $state<HTMLInputElement | null>(null);
+	let triggerEl = $state<HTMLElement | null>(null);
+
+	let query = $state('');
+	let results = $state<ClientSearchResult[]>([]);
+	let selectedIndex = $state(-1);
+	let loading = $state(false);
+
+	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let currentController: AbortController | undefined;
+
+	$effect(() => {
+		if (open) {
+			triggerEl = document.activeElement as HTMLElement | null;
+			query = '';
+			results = [];
+			selectedIndex = -1;
+			loading = false;
+			tick().then(() => inputEl?.focus());
+		} else {
+			tick().then(() => triggerEl?.focus());
+		}
+	});
+
+	$effect(() => {
+		// Reactive to query changes
+		const q = query;
+
+		clearTimeout(debounceTimer);
+		currentController?.abort();
+
+		if (q.trim().length < 2) {
+			results = [];
+			selectedIndex = -1;
+			loading = false;
+			return;
+		}
+
+		loading = true;
+		const controller = new AbortController();
+		currentController = controller;
+
+		debounceTimer = setTimeout(async () => {
+			try {
+				const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`, {
+					signal: controller.signal
+				});
+				if (!res.ok) {
+					results = [];
+					return;
+				}
+				const data = (await res.json()) as { results: ClientSearchResult[] };
+				results = data.results;
+				selectedIndex = -1;
+			} catch (err) {
+				if ((err as Error).name !== 'AbortError') {
+					results = [];
+				}
+			} finally {
+				if (!controller.signal.aborted) {
+					loading = false;
+				}
+			}
+		}, 200);
+	});
+
+	function close() {
+		open = false;
+	}
+
+	function splitOnce(str: string, sep: string): [string, string] {
+		const idx = str.indexOf(sep);
+		if (idx === -1) return [str, ''];
+		return [str.slice(0, idx), str.slice(idx + sep.length)];
+	}
+
+	type GroupKey = SearchEntityType;
+
+	const GROUP_ORDER: GroupKey[] = ['journal', 'daily', 'health', 'weight', 'reminder', 'document'];
+
+	let groups = $derived(
+		(() => {
+			const map = new Map<GroupKey, ClientSearchResult[]>();
+			for (const r of results) {
+				if (!map.has(r.type)) map.set(r.type, []);
+				map.get(r.type)!.push(r);
+			}
+			return GROUP_ORDER.filter((k) => map.has(k)).map((k) => ({ type: k, items: map.get(k)! }));
+		})()
+	);
+
+	// Flat ordered list for keyboard navigation
+	let flatResults = $derived(
+		groups.flatMap((g: { type: GroupKey; items: ClientSearchResult[] }) => g.items)
+	);
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			close();
+			return;
+		}
+
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			selectedIndex = Math.min(selectedIndex + 1, flatResults.length - 1);
+			scrollOptionIntoView();
+			return;
+		}
+
+		if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			selectedIndex = Math.max(selectedIndex - 1, -1);
+			scrollOptionIntoView();
+			return;
+		}
+
+		if (e.key === 'Enter' && selectedIndex >= 0 && flatResults[selectedIndex]) {
+			e.preventDefault();
+			goto(flatResults[selectedIndex].href);
+			close();
+			return;
+		}
+
+		// Tab trap
+		if (e.key === 'Tab') {
+			if (!dialogEl) return;
+			const focusable = Array.from(
+				dialogEl.querySelectorAll<HTMLElement>(
+					'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+				)
+			);
+			const first = focusable[0];
+			const last = focusable[focusable.length - 1];
+			if (e.shiftKey) {
+				if (document.activeElement === first) {
+					e.preventDefault();
+					last?.focus();
+				}
+			} else {
+				if (document.activeElement === last) {
+					e.preventDefault();
+					first?.focus();
+				}
+			}
+		}
+	}
+
+	function scrollOptionIntoView() {
+		tick().then(() => {
+			if (selectedIndex < 0) return;
+			const el = dialogEl?.querySelector(`#search-option-${selectedIndex}`);
+			el?.scrollIntoView({ block: 'nearest' });
+		});
+	}
+
+	function groupLabel(type: GroupKey): string {
+		const keyMap: Record<GroupKey, Parameters<typeof t>[1]> = {
+			journal: 'search.group.journal',
+			health: 'search.group.health',
+			reminder: 'search.group.reminder',
+			document: 'search.group.document',
+			daily: 'search.group.daily',
+			weight: 'search.group.weight'
+		};
+		return t(locale, keyMap[type]);
+	}
+
+	function flatIndex(groupIdx: number, itemIdx: number): number {
+		let idx = 0;
+		for (let g = 0; g < groupIdx; g++) {
+			idx += groups[g].items.length;
+		}
+		return idx + itemIdx;
+	}
+</script>
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex items-start justify-center pt-[10vh] px-4 pb-4"
+		role="presentation"
+		onkeydown={handleKeydown}
+	>
+		<!-- Backdrop -->
+		<div
+			role="presentation"
+			class="absolute inset-0 bg-black/50"
+			onclick={close}
+			onkeydown={() => {}}
+		></div>
+
+		<!-- Dialog -->
+		<div
+			bind:this={dialogEl}
+			role="dialog"
+			aria-modal="true"
+			aria-label={t(locale, 'aria.searchResults')}
+			tabindex="-1"
+			class="relative z-10 w-full max-w-xl rounded-lg border border-border bg-card shadow-xl flex flex-col overflow-hidden"
+		>
+			<!-- Input -->
+			<div class="flex items-center gap-2 px-4 py-3 border-b border-border">
+				<Search class="h-4 w-4 shrink-0 text-muted-foreground" />
+				<input
+					bind:this={inputEl}
+					bind:value={query}
+					type="search"
+					role="combobox"
+					aria-expanded={results.length > 0}
+					aria-controls="search-results"
+					aria-activedescendant={selectedIndex >= 0 ? `search-option-${selectedIndex}` : undefined}
+					autocomplete="off"
+					placeholder={t(locale, 'search.placeholder')}
+					class="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+				/>
+			</div>
+
+			<!-- Results area -->
+			<div class="max-h-[60vh] overflow-y-auto">
+				{#if query.trim().length < 2}
+					<p class="px-4 py-6 text-center text-sm text-muted-foreground">
+						{t(locale, 'search.hint')}
+					</p>
+				{:else if loading}
+					<p class="px-4 py-6 text-center text-sm text-muted-foreground">
+						{t(locale, 'common.loading')}
+					</p>
+				{:else if results.length === 0}
+					<p class="px-4 py-6 text-center text-sm text-muted-foreground">
+						{t(locale, 'search.noResults')}
+					</p>
+				{:else}
+					<ul
+						id="search-results"
+						role="listbox"
+						aria-label={t(locale, 'aria.searchResults')}
+						class="py-2"
+					>
+						{#each groups as group, gi (group.type)}
+							<li role="presentation">
+								<p
+									class="px-4 py-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground"
+								>
+									{groupLabel(group.type)}
+								</p>
+								<ul role="presentation">
+									{#each group.items as item, ii (item.id)}
+										{@const fi = flatIndex(gi, ii)}
+										{@const isSelected = fi === selectedIndex}
+										<li
+											id="search-option-{fi}"
+											role="option"
+											aria-selected={isSelected}
+											onclick={() => {
+												goto(item.href);
+												close();
+											}}
+											onkeydown={(e) => {
+												if (e.key === 'Enter' || e.key === ' ') {
+													e.preventDefault();
+													goto(item.href);
+													close();
+												}
+											}}
+											tabindex="-1"
+											class="flex items-start gap-3 px-4 py-2 cursor-pointer text-sm transition-colors {isSelected
+												? 'bg-accent text-accent-foreground'
+												: 'hover:bg-accent/50'}"
+										>
+											<div class="flex-1 min-w-0">
+												<!-- Title or snippet -->
+												{#if item.title && item.title.trim().length > 0}
+													<p class="font-medium truncate text-foreground">{item.title}</p>
+												{/if}
+												{#if item.snippet && item.snippet.trim().length > 0}
+													<p class="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+														{#each item.snippet.split('\x01') as part, i}
+															{#if i === 0}{part}{:else}{@const [marked, rest] = splitOnce(
+																	part,
+																	'\x02'
+																)}<mark
+																	class="bg-yellow-200 dark:bg-yellow-800 text-foreground rounded-sm px-0.5"
+																	>{marked}</mark
+																>{rest}{/if}
+														{/each}
+													</p>
+												{/if}
+											</div>
+											<div class="flex flex-col items-end gap-1 shrink-0">
+												<span
+													class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-primary/10 text-primary"
+												>
+													{item.companionName}
+												</span>
+												{#if item.date}
+													<span class="text-xs text-muted-foreground">{item.date}</span>
+												{/if}
+											</div>
+										</li>
+									{/each}
+								</ul>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/SearchPalette.svelte
+++ b/src/lib/components/SearchPalette.svelte
@@ -115,12 +115,13 @@
 
 	let groups = $derived(
 		(() => {
-			const map = new Map<GroupKey, ClientSearchResult[]>();
+			// Plain object keyed by entity type — derived locally per recompute, so no
+			// reactive Map (and no svelte/prefer-svelte-reactivity violation) needed.
+			const byType: Partial<Record<GroupKey, ClientSearchResult[]>> = {};
 			for (const r of results) {
-				if (!map.has(r.type)) map.set(r.type, []);
-				map.get(r.type)!.push(r);
+				(byType[r.type] ??= []).push(r);
 			}
-			return GROUP_ORDER.filter((k) => map.has(k)).map((k) => ({ type: k, items: map.get(k)! }));
+			return GROUP_ORDER.filter((k) => byType[k]).map((k) => ({ type: k, items: byType[k]! }));
 		})()
 	);
 
@@ -308,7 +309,7 @@
 												{/if}
 												{#if item.snippet && item.snippet.trim().length > 0}
 													<p class="text-xs text-muted-foreground mt-0.5 line-clamp-2">
-														{#each item.snippet.split('\x01') as part, i}
+														{#each item.snippet.split('\x01') as part, i (i)}
 															{#if i === 0}{part}{:else}{@const [marked, rest] = splitOnce(
 																	part,
 																	'\x02'

--- a/src/lib/components/SearchPalette.svelte
+++ b/src/lib/components/SearchPalette.svelte
@@ -10,7 +10,8 @@
 		| 'reminder'
 		| 'document'
 		| 'daily'
-		| 'weight';
+		| 'weight'
+		| 'media';
 
 	export interface ClientSearchResult {
 		type: SearchEntityType;
@@ -111,7 +112,15 @@
 
 	type GroupKey = SearchEntityType;
 
-	const GROUP_ORDER: GroupKey[] = ['journal', 'daily', 'health', 'weight', 'reminder', 'document'];
+	const GROUP_ORDER: GroupKey[] = [
+		'journal',
+		'daily',
+		'health',
+		'weight',
+		'reminder',
+		'document',
+		'media'
+	];
 
 	let groups = $derived(
 		(() => {
@@ -196,7 +205,8 @@
 			reminder: 'search.group.reminder',
 			document: 'search.group.document',
 			daily: 'search.group.daily',
-			weight: 'search.group.weight'
+			weight: 'search.group.weight',
+			media: 'search.group.media'
 		};
 		return t(locale, keyMap[type]);
 	}

--- a/src/lib/components/SearchPalette.svelte
+++ b/src/lib/components/SearchPalette.svelte
@@ -92,6 +92,11 @@
 				}
 			}
 		}, 200);
+
+		return () => {
+			clearTimeout(debounceTimer);
+			controller.abort();
+		};
 	});
 
 	function close() {

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -790,7 +790,7 @@ const messages: Record<keyof Messages, string> = {
 		'Du erhältst diese E-Mail, weil Schicht-Benachrichtigungen in deinen EinVault-Einstellungen aktiviert sind.',
 
 	// Search palette
-	'search.placeholder': 'Tagebücher, Fotos, Gesundheit, Dokumente durchsuchen…',
+	'search.placeholder': 'Tagebücher, Medien, Gesundheit, Dokumente durchsuchen…',
 	'search.hint': 'Mindestens 2 Zeichen eingeben',
 	'search.noResults': 'Keine Ergebnisse',
 	'search.group.journal': 'Tagebuch',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -790,7 +790,7 @@ const messages: Record<keyof Messages, string> = {
 		'Du erhältst diese E-Mail, weil Schicht-Benachrichtigungen in deinen EinVault-Einstellungen aktiviert sind.',
 
 	// Search palette
-	'search.placeholder': 'Tagebücher, Gesundheit, Dokumente durchsuchen…',
+	'search.placeholder': 'Tagebücher, Fotos, Gesundheit, Dokumente durchsuchen…',
 	'search.hint': 'Mindestens 2 Zeichen eingeben',
 	'search.noResults': 'Keine Ergebnisse',
 	'search.group.journal': 'Tagebuch',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -799,6 +799,7 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.document': 'Dokumente',
 	'search.group.daily': 'Tagesprotokoll',
 	'search.group.weight': 'Gewicht',
+	'search.group.media': 'Fotos & Videos',
 
 	// Immich picker
 	'immich.picker.title': 'Aus Immich auswählen',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -761,6 +761,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousPage': 'Vorherige Seite',
 	'aria.nextPage': 'Nächste Seite',
 	'aria.viewPhoto': '{name}s Foto anzeigen',
+	'aria.openSearch': 'Suche öffnen',
+	'aria.searchResults': 'Suchergebnisse',
 
 	// Email: password reset
 	'email.reset.subject': 'Setze dein EinVault-Passwort zurück',
@@ -786,6 +788,17 @@ const messages: Record<keyof Messages, string> = {
 	'email.shift.endBody': '{caretaker} beendet eine Betreuungsschicht am {end}.',
 	'email.shift.footer':
 		'Du erhältst diese E-Mail, weil Schicht-Benachrichtigungen in deinen EinVault-Einstellungen aktiviert sind.',
+
+	// Search palette
+	'search.placeholder': 'Tagebücher, Gesundheit, Dokumente durchsuchen…',
+	'search.hint': 'Mindestens 2 Zeichen eingeben',
+	'search.noResults': 'Keine Ergebnisse',
+	'search.group.journal': 'Tagebuch',
+	'search.group.health': 'Gesundheit',
+	'search.group.reminder': 'Erinnerungen',
+	'search.group.document': 'Dokumente',
+	'search.group.daily': 'Tagesprotokoll',
+	'search.group.weight': 'Gewicht',
 
 	// Immich picker
 	'immich.picker.title': 'Aus Immich auswählen',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -782,7 +782,7 @@ const messages = {
 		'You are receiving this because shift email notifications are enabled in your EinVault settings.',
 
 	// Search palette
-	'search.placeholder': 'Search journals, photos, health, documents…',
+	'search.placeholder': 'Search journals, media, health, documents…',
 	'search.hint': 'Type at least 2 characters to search',
 	'search.noResults': 'No results',
 	'search.group.journal': 'Journal',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -791,6 +791,7 @@ const messages = {
 	'search.group.document': 'Documents',
 	'search.group.daily': 'Daily log',
 	'search.group.weight': 'Weight',
+	'search.group.media': 'Photos & videos',
 
 	// Immich picker
 	'immich.picker.title': 'Pick from Immich',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -782,7 +782,7 @@ const messages = {
 		'You are receiving this because shift email notifications are enabled in your EinVault settings.',
 
 	// Search palette
-	'search.placeholder': 'Search journals, health, documents…',
+	'search.placeholder': 'Search journals, photos, health, documents…',
 	'search.hint': 'Type at least 2 characters to search',
 	'search.noResults': 'No results',
 	'search.group.journal': 'Journal',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -752,6 +752,8 @@ const messages = {
 	'aria.previousPage': 'Previous page',
 	'aria.nextPage': 'Next page',
 	'aria.viewPhoto': "View {name}'s photo",
+	'aria.openSearch': 'Open search',
+	'aria.searchResults': 'Search results',
 
 	// Email: password reset
 	'email.reset.subject': 'Reset your EinVault password',
@@ -778,6 +780,17 @@ const messages = {
 	'email.shift.endBody': '{caretaker} finishes a care shift on {end}.',
 	'email.shift.footer':
 		'You are receiving this because shift email notifications are enabled in your EinVault settings.',
+
+	// Search palette
+	'search.placeholder': 'Search journals, health, documents…',
+	'search.hint': 'Type at least 2 characters to search',
+	'search.noResults': 'No results',
+	'search.group.journal': 'Journal',
+	'search.group.health': 'Health',
+	'search.group.reminder': 'Reminders',
+	'search.group.document': 'Documents',
+	'search.group.daily': 'Daily log',
+	'search.group.weight': 'Weight',
 
 	// Immich picker
 	'immich.picker.title': 'Pick from Immich',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -799,6 +799,7 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.document': 'Documentos',
 	'search.group.daily': 'Registro diario',
 	'search.group.weight': 'Peso',
+	'search.group.media': 'Fotos y vídeos',
 
 	// Immich picker
 	'immich.picker.title': 'Elegir desde Immich',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -761,6 +761,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousPage': 'Página anterior',
 	'aria.nextPage': 'Página siguiente',
 	'aria.viewPhoto': 'Ver foto de {name}',
+	'aria.openSearch': 'Abrir búsqueda',
+	'aria.searchResults': 'Resultados de búsqueda',
 
 	// Email: password reset
 	'email.reset.subject': 'Restablece tu contraseña de EinVault',
@@ -786,6 +788,17 @@ const messages: Record<keyof Messages, string> = {
 	'email.shift.endBody': '{caretaker} termina un turno de cuidado el {end}.',
 	'email.shift.footer':
 		'Recibes este correo porque las notificaciones de turnos están activadas en tus ajustes de EinVault.',
+
+	// Search palette
+	'search.placeholder': 'Buscar diarios, salud, documentos…',
+	'search.hint': 'Escribe al menos 2 caracteres para buscar',
+	'search.noResults': 'Sin resultados',
+	'search.group.journal': 'Diario',
+	'search.group.health': 'Salud',
+	'search.group.reminder': 'Recordatorios',
+	'search.group.document': 'Documentos',
+	'search.group.daily': 'Registro diario',
+	'search.group.weight': 'Peso',
 
 	// Immich picker
 	'immich.picker.title': 'Elegir desde Immich',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -790,7 +790,7 @@ const messages: Record<keyof Messages, string> = {
 		'Recibes este correo porque las notificaciones de turnos están activadas en tus ajustes de EinVault.',
 
 	// Search palette
-	'search.placeholder': 'Buscar diarios, salud, documentos…',
+	'search.placeholder': 'Buscar diarios, fotos, salud, documentos…',
 	'search.hint': 'Escribe al menos 2 caracteres para buscar',
 	'search.noResults': 'Sin resultados',
 	'search.group.journal': 'Diario',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -790,7 +790,7 @@ const messages: Record<keyof Messages, string> = {
 		'Recibes este correo porque las notificaciones de turnos están activadas en tus ajustes de EinVault.',
 
 	// Search palette
-	'search.placeholder': 'Buscar diarios, fotos, salud, documentos…',
+	'search.placeholder': 'Buscar diarios, multimedia, salud, documentos…',
 	'search.hint': 'Escribe al menos 2 caracteres para buscar',
 	'search.noResults': 'Sin resultados',
 	'search.group.journal': 'Diario',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -792,7 +792,7 @@ const messages: Record<keyof Messages, string> = {
 		'Vous recevez cet e-mail car les notifications de garde sont activées dans vos réglages EinVault.',
 
 	// Search palette
-	'search.placeholder': 'Rechercher journaux, photos, santé, documents…',
+	'search.placeholder': 'Rechercher journaux, médias, santé, documents…',
 	'search.hint': 'Saisissez au moins 2 caractères pour rechercher',
 	'search.noResults': 'Aucun résultat',
 	'search.group.journal': 'Journal',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -763,6 +763,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousPage': 'Page précédente',
 	'aria.nextPage': 'Page suivante',
 	'aria.viewPhoto': 'Voir la photo de {name}',
+	'aria.openSearch': 'Ouvrir la recherche',
+	'aria.searchResults': 'Résultats de recherche',
 
 	// Email: password reset
 	'email.reset.subject': 'Réinitialisez votre mot de passe EinVault',
@@ -788,6 +790,17 @@ const messages: Record<keyof Messages, string> = {
 	'email.shift.endBody': '{caretaker} termine une garde le {end}.',
 	'email.shift.footer':
 		'Vous recevez cet e-mail car les notifications de garde sont activées dans vos réglages EinVault.',
+
+	// Search palette
+	'search.placeholder': 'Rechercher journaux, santé, documents…',
+	'search.hint': 'Saisissez au moins 2 caractères pour rechercher',
+	'search.noResults': 'Aucun résultat',
+	'search.group.journal': 'Journal',
+	'search.group.health': 'Santé',
+	'search.group.reminder': 'Rappels',
+	'search.group.document': 'Documents',
+	'search.group.daily': 'Journal quotidien',
+	'search.group.weight': 'Poids',
 
 	// Immich picker
 	'immich.picker.title': 'Choisir depuis Immich',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -801,6 +801,7 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.document': 'Documents',
 	'search.group.daily': 'Journal quotidien',
 	'search.group.weight': 'Poids',
+	'search.group.media': 'Photos et vidéos',
 
 	// Immich picker
 	'immich.picker.title': 'Choisir depuis Immich',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -792,7 +792,7 @@ const messages: Record<keyof Messages, string> = {
 		'Vous recevez cet e-mail car les notifications de garde sont activées dans vos réglages EinVault.',
 
 	// Search palette
-	'search.placeholder': 'Rechercher journaux, santé, documents…',
+	'search.placeholder': 'Rechercher journaux, photos, santé, documents…',
 	'search.hint': 'Saisissez au moins 2 caractères pour rechercher',
 	'search.noResults': 'Aucun résultat',
 	'search.group.journal': 'Journal',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -785,7 +785,7 @@ const messages: Record<keyof Messages, string> = {
 		'Ricevi questa e-mail perché le notifiche dei turni sono attive nelle tue impostazioni di EinVault.',
 
 	// Search palette
-	'search.placeholder': 'Cerca diari, salute, documenti…',
+	'search.placeholder': 'Cerca diari, foto, salute, documenti…',
 	'search.hint': 'Digita almeno 2 caratteri per cercare',
 	'search.noResults': 'Nessun risultato',
 	'search.group.journal': 'Diario',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -785,7 +785,7 @@ const messages: Record<keyof Messages, string> = {
 		'Ricevi questa e-mail perché le notifiche dei turni sono attive nelle tue impostazioni di EinVault.',
 
 	// Search palette
-	'search.placeholder': 'Cerca diari, foto, salute, documenti…',
+	'search.placeholder': 'Cerca diari, media, salute, documenti…',
 	'search.hint': 'Digita almeno 2 caratteri per cercare',
 	'search.noResults': 'Nessun risultato',
 	'search.group.journal': 'Diario',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -794,6 +794,7 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.document': 'Documenti',
 	'search.group.daily': 'Registro giornaliero',
 	'search.group.weight': 'Peso',
+	'search.group.media': 'Foto e video',
 
 	// Immich picker
 	'immich.picker.title': 'Scegli da Immich',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -756,6 +756,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousPage': 'Pagina precedente',
 	'aria.nextPage': 'Pagina successiva',
 	'aria.viewPhoto': 'Vedi la foto di {name}',
+	'aria.openSearch': 'Apri ricerca',
+	'aria.searchResults': 'Risultati di ricerca',
 
 	// Email: password reset
 	'email.reset.subject': 'Reimposta la tua password di EinVault',
@@ -781,6 +783,17 @@ const messages: Record<keyof Messages, string> = {
 	'email.shift.endBody': '{caretaker} termina un turno di assistenza il {end}.',
 	'email.shift.footer':
 		'Ricevi questa e-mail perché le notifiche dei turni sono attive nelle tue impostazioni di EinVault.',
+
+	// Search palette
+	'search.placeholder': 'Cerca diari, salute, documenti…',
+	'search.hint': 'Digita almeno 2 caratteri per cercare',
+	'search.noResults': 'Nessun risultato',
+	'search.group.journal': 'Diario',
+	'search.group.health': 'Salute',
+	'search.group.reminder': 'Promemoria',
+	'search.group.document': 'Documenti',
+	'search.group.daily': 'Registro giornaliero',
+	'search.group.weight': 'Peso',
 
 	// Immich picker
 	'immich.picker.title': 'Scegli da Immich',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -758,6 +758,8 @@ const messages: Record<keyof Messages, string> = {
 	'aria.previousPage': 'Página anterior',
 	'aria.nextPage': 'Próxima página',
 	'aria.viewPhoto': 'Ver foto de {name}',
+	'aria.openSearch': 'Abrir pesquisa',
+	'aria.searchResults': 'Resultados da pesquisa',
 
 	// Email: password reset
 	'email.reset.subject': 'Redefina sua senha do EinVault',
@@ -783,6 +785,17 @@ const messages: Record<keyof Messages, string> = {
 	'email.shift.endBody': '{caretaker} termina um turno de cuidado em {end}.',
 	'email.shift.footer':
 		'Você está recebendo este e-mail porque as notificações de turnos estão ativadas nas suas configurações do EinVault.',
+
+	// Search palette
+	'search.placeholder': 'Pesquisar diários, saúde, documentos…',
+	'search.hint': 'Digite pelo menos 2 caracteres para pesquisar',
+	'search.noResults': 'Sem resultados',
+	'search.group.journal': 'Diário',
+	'search.group.health': 'Saúde',
+	'search.group.reminder': 'Lembretes',
+	'search.group.document': 'Documentos',
+	'search.group.daily': 'Registo diário',
+	'search.group.weight': 'Peso',
 
 	// Immich picker
 	'immich.picker.title': 'Escolher do Immich',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -787,7 +787,7 @@ const messages: Record<keyof Messages, string> = {
 		'Você está recebendo este e-mail porque as notificações de turnos estão ativadas nas suas configurações do EinVault.',
 
 	// Search palette
-	'search.placeholder': 'Pesquisar diários, fotos, saúde, documentos…',
+	'search.placeholder': 'Pesquisar diários, mídia, saúde, documentos…',
 	'search.hint': 'Digite pelo menos 2 caracteres para pesquisar',
 	'search.noResults': 'Sem resultados',
 	'search.group.journal': 'Diário',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -787,7 +787,7 @@ const messages: Record<keyof Messages, string> = {
 		'Você está recebendo este e-mail porque as notificações de turnos estão ativadas nas suas configurações do EinVault.',
 
 	// Search palette
-	'search.placeholder': 'Pesquisar diários, saúde, documentos…',
+	'search.placeholder': 'Pesquisar diários, fotos, saúde, documentos…',
 	'search.hint': 'Digite pelo menos 2 caracteres para pesquisar',
 	'search.noResults': 'Sem resultados',
 	'search.group.journal': 'Diário',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -796,6 +796,7 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.document': 'Documentos',
 	'search.group.daily': 'Registo diário',
 	'search.group.weight': 'Peso',
+	'search.group.media': 'Fotos e vídeos',
 
 	// Immich picker
 	'immich.picker.title': 'Escolher do Immich',

--- a/src/lib/server/db/migrations.test.ts
+++ b/src/lib/server/db/migrations.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Drizzle's migrator applies a migration only when its journal `when` exceeds
+// the newest already-applied migration's timestamp. A migration whose `when` is
+// less than its predecessor's is silently skipped on any DB that already has the
+// predecessor — fresh installs apply everything in order and never reveal it. So
+// guard the invariant directly: timestamps must strictly increase with idx.
+describe('drizzle journal', () => {
+	const journal = JSON.parse(
+		readFileSync(resolve(import.meta.dirname, '../../../../drizzle/meta/_journal.json'), 'utf8')
+	) as { entries: { idx: number; when: number; tag: string }[] };
+
+	it('has strictly increasing idx and when', () => {
+		const entries = [...journal.entries].sort((a, b) => a.idx - b.idx);
+		for (let i = 1; i < entries.length; i++) {
+			expect(entries[i].idx, `idx gap before ${entries[i].tag}`).toBe(entries[i - 1].idx + 1);
+			expect(
+				entries[i].when,
+				`migration ${entries[i].tag} (when=${entries[i].when}) must be newer than ${entries[i - 1].tag} (when=${entries[i - 1].when})`
+			).toBeGreaterThan(entries[i - 1].when);
+		}
+	});
+});

--- a/src/lib/server/search.test.ts
+++ b/src/lib/server/search.test.ts
@@ -114,6 +114,44 @@ describe('search index + query', () => {
 		expect(r.snippet).toContain('\x01gargoyle\x02');
 	});
 
+	it('indexes journal media captions', async () => {
+		const { eq } = await import('drizzle-orm');
+		await db.insert(schema.journalEntries).values({
+			id: 'j-s-media',
+			companionId: 'c-s',
+			date: '2026-04-09',
+			body: 'ordinary entry',
+			loggedBy: 'u-s'
+		} as typeof schema.journalEntries.$inferInsert);
+		await db.insert(schema.journalPhotos).values({
+			id: 'p-s1',
+			entryId: 'j-s-media',
+			filename: 'sphinx.jpg',
+			mimeType: 'image/jpeg',
+			sizeBytes: 12345,
+			notes: 'sphinx caption here'
+		} as typeof schema.journalPhotos.$inferInsert);
+
+		expect(search('sphinx').length).toBe(1);
+		expect(search('sphinx')[0]).toMatchObject({
+			type: 'media',
+			href: '/c-s/journal/2026-04-09?media=p-s1'
+		});
+
+		// update: old term gone, new term found
+		await db
+			.update(schema.journalPhotos)
+			.set({ notes: 'marmot updated' })
+			.where(eq(schema.journalPhotos.id, 'p-s1'));
+		expect(search('sphinx').length).toBe(0);
+		expect(search('marmot').length).toBe(1);
+		expect(search('marmot')[0]?.type).toBe('media');
+
+		// delete: gone
+		await db.delete(schema.journalPhotos).where(eq(schema.journalPhotos.id, 'p-s1'));
+		expect(search('marmot').length).toBe(0);
+	});
+
 	it('ranks the stronger match first', async () => {
 		await db.insert(schema.journalEntries).values([
 			{

--- a/src/lib/server/search.test.ts
+++ b/src/lib/server/search.test.ts
@@ -102,6 +102,11 @@ describe('search index + query', () => {
 		expect(search('plimsoll')[0]?.type).toBe('weight');
 		// health event_date derived from occurredAt
 		expect(search('xylograph')[0]?.date).toBe('2026-04-02');
+		// deep-link hrefs
+		expect(search('xylograph')[0]?.href).toBe('/c-s/health?detailHealth=h-s1');
+		expect(search('quibble')[0]?.href).toBe('/c-s/reminders?detail=r-s1');
+		expect(search('gargoyle')[0]?.href).toBe('/c-s/journal/2026-04-04');
+		expect(search('plimsoll')[0]?.href).toBe('/c-s/health?detailWeight=w-s1');
 	});
 
 	it('snippet carries sentinel markers around the match', () => {

--- a/src/lib/server/search.test.ts
+++ b/src/lib/server/search.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { db, schema } from '$lib/server/db';
+import { buildMatchQuery, search } from './search';
+
+describe('buildMatchQuery', () => {
+	it('rejects short and empty input', () => {
+		expect(buildMatchQuery('')).toBeNull();
+		expect(buildMatchQuery(' a ')).toBeNull();
+	});
+
+	it('quotes and prefixes tokens', () => {
+		expect(buildMatchQuery('vet visit')).toBe('"vet"* "visit"*');
+	});
+
+	it('neutralizes fts operators and quotes', () => {
+		expect(buildMatchQuery('a" OR "b')).toBe('"a"* "OR"* "b"*');
+		expect(buildMatchQuery('NEAR(x y)')).toBe('"NEAR(x"* "y)"*');
+		expect(buildMatchQuery('""')).toBeNull();
+		expect(buildMatchQuery('" "')).toBeNull();
+	});
+});
+
+describe('search index + query', () => {
+	beforeAll(async () => {
+		await db.insert(schema.users).values({
+			id: 'u-s',
+			username: 'search-user',
+			displayName: 'S User',
+			role: 'member'
+		} as typeof schema.users.$inferInsert);
+		await db.insert(schema.companions).values({
+			id: 'c-s',
+			name: 'Searchy'
+		} as typeof schema.companions.$inferInsert);
+	});
+
+	it('triggers index journal inserts, updates, deletes', async () => {
+		await db.insert(schema.journalEntries).values({
+			id: 'j-s1',
+			companionId: 'c-s',
+			date: '2026-04-01',
+			body: 'zephyr quince walk',
+			loggedBy: 'u-s'
+		} as typeof schema.journalEntries.$inferInsert);
+		expect(search('zephyr').length).toBe(1);
+		expect(search('zephyr')[0]).toMatchObject({
+			type: 'journal',
+			companionName: 'Searchy',
+			href: '/c-s/journal/2026-04-01'
+		});
+
+		const { eq } = await import('drizzle-orm');
+		await db
+			.update(schema.journalEntries)
+			.set({ body: 'flummox walk' })
+			.where(eq(schema.journalEntries.id, 'j-s1'));
+		expect(search('zephyr').length).toBe(0);
+		expect(search('flummox').length).toBe(1);
+
+		await db.delete(schema.journalEntries).where(eq(schema.journalEntries.id, 'j-s1'));
+		expect(search('flummox').length).toBe(0);
+	});
+
+	it('indexes every entity type', async () => {
+		await db.insert(schema.healthEvents).values({
+			id: 'h-s1',
+			companionId: 'c-s',
+			title: 'xylograph checkup',
+			type: 'vet_visit',
+			occurredAt: new Date('2026-04-02T10:00:00Z'),
+			loggedBy: 'u-s'
+		} as typeof schema.healthEvents.$inferInsert);
+		await db.insert(schema.reminders).values({
+			id: 'r-s1',
+			companionId: 'c-s',
+			title: 'quibble pill',
+			type: 'medication',
+			dueAt: new Date('2026-04-03T09:00:00Z'),
+			loggedBy: 'u-s'
+		} as typeof schema.reminders.$inferInsert);
+		await db.insert(schema.dailyEvents).values({
+			id: 'd-s1',
+			companionId: 'c-s',
+			type: 'walk',
+			notes: 'gargoyle sighting',
+			loggedAt: new Date('2026-04-04T12:00:00Z'),
+			loggedBy: 'u-s'
+		} as typeof schema.dailyEvents.$inferInsert);
+		await db.insert(schema.weightEntries).values({
+			id: 'w-s1',
+			companionId: 'c-s',
+			weight: 12,
+			unit: 'kg',
+			notes: 'plimsoll weigh-in',
+			recordedAt: new Date('2026-04-05T12:00:00Z'),
+			loggedBy: 'u-s'
+		} as typeof schema.weightEntries.$inferInsert);
+
+		expect(search('xylograph')[0]?.type).toBe('health');
+		expect(search('quibble')[0]?.type).toBe('reminder');
+		expect(search('gargoyle')[0]?.type).toBe('daily');
+		expect(search('plimsoll')[0]?.type).toBe('weight');
+		// health event_date derived from occurredAt
+		expect(search('xylograph')[0]?.date).toBe('2026-04-02');
+	});
+
+	it('snippet carries sentinel markers around the match', () => {
+		const r = search('gargoyle')[0];
+		expect(r.snippet).toContain('\x01gargoyle\x02');
+	});
+
+	it('ranks the stronger match first', async () => {
+		await db.insert(schema.journalEntries).values([
+			{
+				id: 'j-s2',
+				companionId: 'c-s',
+				date: '2026-04-06',
+				body: 'brontide brontide brontide',
+				loggedBy: 'u-s'
+			},
+			{
+				id: 'j-s3',
+				companionId: 'c-s',
+				date: '2026-04-07',
+				body: 'one brontide among many other plain words here',
+				loggedBy: 'u-s'
+			}
+		] as (typeof schema.journalEntries.$inferInsert)[]);
+		const results = search('brontide');
+		expect(results[0].id).toBe('j-s2');
+	});
+});

--- a/src/lib/server/search.ts
+++ b/src/lib/server/search.ts
@@ -1,6 +1,13 @@
 import { db } from '$lib/server/db';
 
-export type SearchEntityType = 'journal' | 'health' | 'reminder' | 'document' | 'daily' | 'weight';
+export type SearchEntityType =
+	| 'journal'
+	| 'health'
+	| 'reminder'
+	| 'document'
+	| 'daily'
+	| 'weight'
+	| 'media';
 
 export interface SearchResult {
 	type: SearchEntityType;
@@ -41,7 +48,8 @@ const HREF_BY_TYPE: Record<
 	health: (c, _d, id) => `/${c}/health?detailHealth=${id}`,
 	weight: (c, _d, id) => `/${c}/health?detailWeight=${id}`,
 	reminder: (c, _d, id) => `/${c}/reminders?detail=${id}`,
-	document: (c, _d, id) => `/${c}/documents?preview=${id}`
+	document: (c, _d, id) => `/${c}/documents?preview=${id}`,
+	media: (c, d, id) => `/${c}/journal/${d}?media=${id}`
 };
 
 interface SearchRow {

--- a/src/lib/server/search.ts
+++ b/src/lib/server/search.ts
@@ -1,0 +1,81 @@
+import { db } from '$lib/server/db';
+
+export type SearchEntityType = 'journal' | 'health' | 'reminder' | 'document' | 'daily' | 'weight';
+
+export interface SearchResult {
+	type: SearchEntityType;
+	id: string;
+	companionId: string;
+	companionName: string;
+	title: string;
+	/** Excerpt with \x01/\x02 sentinel pairs around matched terms. Plain text otherwise. */
+	snippet: string;
+	date: string;
+	href: string;
+}
+
+/**
+ * Build an FTS5 MATCH expression from raw user input. Each whitespace token is
+ * stripped of double quotes and wrapped as "token"* — quoting renders every
+ * FTS5 operator literal, which makes the expression injection-proof. Returns
+ * null when nothing searchable remains (caller returns empty results).
+ */
+export function buildMatchQuery(raw: string): string | null {
+	const trimmed = raw.trim();
+	if (trimmed.length < 2) return null;
+	const tokens = trimmed
+		.split(/\s+/)
+		.map((t) => t.replaceAll('"', ''))
+		.filter((t) => t.length > 0)
+		.map((t) => `"${t}"*`);
+	if (tokens.length === 0) return null;
+	return tokens.join(' ');
+}
+
+const HREF_BY_TYPE: Record<SearchEntityType, (companionId: string, date: string) => string> = {
+	journal: (c, d) => `/${c}/journal/${d}`,
+	daily: (c, d) => `/${c}/journal/${d}`,
+	health: (c) => `/${c}/health`,
+	weight: (c) => `/${c}/health`,
+	reminder: (c) => `/${c}/reminders`,
+	document: (c) => `/${c}/documents`
+};
+
+interface SearchRow {
+	entity_type: SearchEntityType;
+	entity_id: string;
+	companion_id: string;
+	companion_name: string;
+	title: string;
+	excerpt: string;
+	event_date: string | null;
+}
+
+/** Members/admins only — the API route gates caretakers out with 403. */
+export function search(rawQuery: string): SearchResult[] {
+	const match = buildMatchQuery(rawQuery);
+	if (!match) return [];
+	// drizzle has no FTS5 support; raw prepared statement on the underlying client.
+	const stmt = db.$client.prepare(`
+		SELECT
+			s.entity_type, s.entity_id, s.companion_id, s.event_date, s.title,
+			snippet(search_index, 1, char(1), char(2), '…', 8) AS excerpt,
+			c.name AS companion_name
+		FROM search_index s
+		JOIN companions c ON c.id = s.companion_id
+		WHERE search_index MATCH ?
+		ORDER BY bm25(search_index), s.event_date DESC
+		LIMIT 20
+	`);
+	const rows = stmt.all(match) as SearchRow[];
+	return rows.map((r) => ({
+		type: r.entity_type,
+		id: r.entity_id,
+		companionId: r.companion_id,
+		companionName: r.companion_name,
+		title: r.title,
+		snippet: r.excerpt,
+		date: r.event_date ?? '',
+		href: HREF_BY_TYPE[r.entity_type](r.companion_id, r.event_date ?? '')
+	}));
+}

--- a/src/lib/server/search.ts
+++ b/src/lib/server/search.ts
@@ -32,13 +32,16 @@ export function buildMatchQuery(raw: string): string | null {
 	return tokens.join(' ');
 }
 
-const HREF_BY_TYPE: Record<SearchEntityType, (companionId: string, date: string) => string> = {
+const HREF_BY_TYPE: Record<
+	SearchEntityType,
+	(companionId: string, date: string, id: string) => string
+> = {
 	journal: (c, d) => `/${c}/journal/${d}`,
 	daily: (c, d) => `/${c}/journal/${d}`,
-	health: (c) => `/${c}/health`,
-	weight: (c) => `/${c}/health`,
-	reminder: (c) => `/${c}/reminders`,
-	document: (c) => `/${c}/documents`
+	health: (c, _d, id) => `/${c}/health?detailHealth=${id}`,
+	weight: (c, _d, id) => `/${c}/health?detailWeight=${id}`,
+	reminder: (c, _d, id) => `/${c}/reminders?detail=${id}`,
+	document: (c, _d, id) => `/${c}/documents?preview=${id}`
 };
 
 interface SearchRow {
@@ -76,6 +79,6 @@ export function search(rawQuery: string): SearchResult[] {
 		title: r.title,
 		snippet: r.excerpt,
 		date: r.event_date ?? '',
-		href: HREF_BY_TYPE[r.entity_type](r.companion_id, r.event_date ?? '')
+		href: HREF_BY_TYPE[r.entity_type](r.companion_id, r.event_date ?? '', r.entity_id)
 	}));
 }

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
@@ -130,12 +130,13 @@
 		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 	}
 
-	let previewApplied = false;
+	// Re-fires for a different document/companion (page component is reused
+	// across companion navigations), idempotent for the same one.
+	let lastDeepLinkId = '';
 	$effect(() => {
-		if (previewApplied) return;
 		const previewId = page.url.searchParams.get('preview');
-		if (!previewId) return;
-		previewApplied = true;
+		if (!previewId || previewId === lastDeepLinkId) return;
+		lastDeepLinkId = previewId;
 		const match = data.documents.find((d) => d.id === previewId);
 		if (match) preview = match;
 		tick().then(() => {

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
+	import { tick } from 'svelte';
+	import { page } from '$app/state';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
@@ -127,6 +129,21 @@
 		if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
 		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 	}
+
+	let previewApplied = false;
+	$effect(() => {
+		if (previewApplied) return;
+		const previewId = page.url.searchParams.get('preview');
+		if (!previewId) return;
+		previewApplied = true;
+		const match = data.documents.find((d) => d.id === previewId);
+		if (match) preview = match;
+		tick().then(() => {
+			const url = new URL(page.url);
+			url.searchParams.delete('preview');
+			history.replaceState(history.state, '', url.pathname + url.search);
+		});
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -111,6 +111,29 @@
 		});
 	});
 
+	let detailApplied = false;
+	$effect(() => {
+		if (detailApplied) return;
+		const params = page.url.searchParams;
+		const healthId = params.get('detailHealth');
+		const weightId = params.get('detailWeight');
+		if (!healthId && !weightId) return;
+		detailApplied = true;
+		if (healthId) {
+			const match = data.healthEvents.find((e) => e.id === healthId);
+			if (match) openDetail({ kind: 'health', item: match });
+		} else if (weightId) {
+			const match = data.weightEntries.find((e) => e.id === weightId);
+			if (match) openDetail({ kind: 'weight', item: match });
+		}
+		tick().then(() => {
+			const url = new URL(page.url);
+			url.searchParams.delete('detailHealth');
+			url.searchParams.delete('detailWeight');
+			history.replaceState(history.state, '', url.pathname + url.search);
+		});
+	});
+
 	// Detail modal
 	type SelectedItem =
 		| { kind: 'weight'; item: (typeof data.weightEntries)[0] }

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -111,14 +111,17 @@
 		});
 	});
 
-	let detailApplied = false;
+	// Track the last id we opened so the effect re-fires when a search result
+	// deep-links to a DIFFERENT item or companion (SvelteKit reuses this page
+	// component across companion navigations), but not for the same one.
+	let lastDeepLinkId = '';
 	$effect(() => {
-		if (detailApplied) return;
 		const params = page.url.searchParams;
 		const healthId = params.get('detailHealth');
 		const weightId = params.get('detailWeight');
-		if (!healthId && !weightId) return;
-		detailApplied = true;
+		const id = healthId ?? weightId;
+		if (!id || id === lastDeepLinkId) return;
+		lastDeepLinkId = id;
 		if (healthId) {
 			const match = data.healthEvents.find((e) => e.id === healthId);
 			if (match) openDetail({ kind: 'health', item: match });

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -5,20 +5,11 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Separator } from '$lib/components/ui/separator/index.js';
-	import {
-		ChevronLeft,
-		ChevronRight,
-		X,
-		Pencil,
-		NotebookPen,
-		ArrowRight,
-		Download,
-		Play
-	} from '@lucide/svelte';
-	import JournalVideo from '$lib/components/JournalVideo.svelte';
+	import { X, Pencil, NotebookPen, ArrowRight, Play } from '@lucide/svelte';
+	import { tick } from 'svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
-	import { tick } from 'svelte';
+	import MediaLightbox from '$lib/components/MediaLightbox.svelte';
 	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { t, getLocale } from '$lib/i18n';
 
@@ -88,71 +79,22 @@
 		return date.slice(0, 7);
 	}
 
-	// Lightbox
-	let lightboxMedia = $state<Entry['photos']>([]);
+	// Lightbox state (bound to MediaLightbox)
+	let lightboxOpen = $state(false);
+	let lightboxItems = $state<Entry['photos']>([]);
 	let lightboxDate = $state('');
 	let lightboxIndex = $state(0);
-	let lightboxItem = $derived(lightboxMedia.length > 0 ? lightboxMedia[lightboxIndex] : null);
-	let lightboxEl = $state<HTMLElement | null>(null);
-	let lightboxTrigger = $state<HTMLElement | null>(null);
 
-	async function openLightbox(items: Entry['photos'], date: string, index: number) {
-		lightboxTrigger = document.activeElement as HTMLElement | null;
-		lightboxMedia = items;
+	function openLightbox(items: Entry['photos'], date: string, index: number) {
+		lightboxItems = items;
 		lightboxDate = date;
 		lightboxIndex = index;
-		await tick();
-		lightboxEl?.focus();
-	}
-	function closeLightbox() {
-		lightboxMedia = [];
-		lightboxDate = '';
-		lightboxIndex = 0;
-		tick().then(() => lightboxTrigger?.focus());
-	}
-	function lightboxPrev() {
-		if (lightboxIndex > 0) lightboxIndex--;
-	}
-	function lightboxNext() {
-		if (lightboxIndex < lightboxMedia.length - 1) lightboxIndex++;
+		lightboxOpen = true;
 	}
 
-	function handleLightboxKey(e: KeyboardEvent) {
-		if (e.key === 'Escape') {
-			if (lightboxItem) {
-				closeLightbox();
-				return;
-			}
-			if (detailEvent) {
-				closeDetail();
-				return;
-			}
-		}
-		if (!lightboxItem) return;
-		if (e.key === 'ArrowLeft') lightboxPrev();
-		else if (e.key === 'ArrowRight') lightboxNext();
-	}
-
-	function trapLightboxFocus(e: KeyboardEvent) {
-		if (!lightboxEl || e.key !== 'Tab') return;
-		const focusable = Array.from(
-			lightboxEl.querySelectorAll<HTMLElement>(
-				'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
-			)
-		);
-		if (!focusable.length) return;
-		const first = focusable[0];
-		const last = focusable[focusable.length - 1];
-		if (e.shiftKey) {
-			if (document.activeElement === first) {
-				e.preventDefault();
-				last.focus();
-			}
-		} else {
-			if (document.activeElement === last) {
-				e.preventDefault();
-				first.focus();
-			}
+	function handleEscapeForDetail(e: KeyboardEvent) {
+		if (e.key === 'Escape' && !lightboxOpen && detailEvent) {
+			closeDetail();
 		}
 	}
 
@@ -201,114 +143,16 @@
 	<title>{t(locale, 'page.journal.title')} | {companion.name} | EinVault</title>
 </svelte:head>
 
-<svelte:window onkeydown={handleLightboxKey} />
+<svelte:window onkeydown={handleEscapeForDetail} />
 
 <!-- Lightbox -->
-{#if lightboxItem}
-	<div
-		bind:this={lightboxEl}
-		role="dialog"
-		aria-modal="true"
-		aria-label={t(locale, 'page.journal.mediaLightboxLabel')}
-		tabindex="-1"
-		class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/85 focus:outline-none"
-		onclick={closeLightbox}
-		onkeydown={(e) => {
-			handleLightboxKey(e);
-			trapLightboxFocus(e);
-		}}
-	>
-		<div
-			role="presentation"
-			onclick={(e) => e.stopPropagation()}
-			onkeydown={(e) => e.stopPropagation()}
-			class="relative max-w-4xl w-full"
-		>
-			<div class="flex items-center justify-between mb-2">
-				{#if lightboxMedia.length > 1}
-					<span class="text-sm text-white/60">{lightboxIndex + 1} / {lightboxMedia.length}</span>
-				{:else}
-					<span></span>
-				{/if}
-				<div class="flex items-center gap-1">
-					<a
-						href={mediaUrl(lightboxItem, lightboxDate)}
-						download={lightboxItem.originalName ?? lightboxItem.filename}
-						class="text-white/70 hover:text-white p-1 rounded"
-						aria-label={t(locale, 'aria.downloadMedia')}
-					>
-						<Download class="h-5 w-5" />
-					</a>
-					<button
-						type="button"
-						onclick={closeLightbox}
-						class="text-white/70 hover:text-white p-1 rounded"
-						aria-label={t(locale, 'aria.close')}
-					>
-						<X class="h-5 w-5" />
-					</button>
-				</div>
-			</div>
-
-			<div class="relative">
-				{#if lightboxItem.mediaType === 'video'}
-					<JournalVideo
-						src={mediaUrl(lightboxItem, lightboxDate)}
-						poster={posterUrl(lightboxItem, lightboxDate)}
-						status={lightboxItem.status}
-						downloadName={lightboxItem.originalName}
-						label={lightboxItem.originalName ?? undefined}
-						autoplay
-						class="max-h-[78vh] w-full object-contain rounded-lg bg-black"
-					/>
-				{:else}
-					<img
-						src={mediaUrl(lightboxItem, lightboxDate)}
-						alt={lightboxItem.originalName ?? ''}
-						class="max-h-[78vh] w-full object-contain rounded-lg"
-					/>
-				{/if}
-				{#if lightboxMedia.length > 1}
-					<button
-						type="button"
-						onclick={lightboxPrev}
-						disabled={lightboxIndex === 0}
-						class="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center text-white transition-opacity bg-black/40 {lightboxIndex ===
-						0
-							? 'opacity-20 cursor-default'
-							: 'opacity-70 hover:opacity-100'}"
-						aria-label={t(locale, 'aria.previousMedia')}
-					>
-						<ChevronLeft class="h-5 w-5" />
-					</button>
-					<button
-						type="button"
-						onclick={lightboxNext}
-						disabled={lightboxIndex === lightboxMedia.length - 1}
-						class="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center text-white transition-opacity bg-black/40 {lightboxIndex ===
-						lightboxMedia.length - 1
-							? 'opacity-20 cursor-default'
-							: 'opacity-70 hover:opacity-100'}"
-						aria-label={t(locale, 'aria.nextMedia')}
-					>
-						<ChevronRight class="h-5 w-5" />
-					</button>
-				{/if}
-			</div>
-
-			{#if lightboxItem.notes}
-				<div class="prose prose-sm prose-invert max-w-none mt-3 text-center text-sm">
-					{@html renderMarkdown(lightboxItem.notes)}
-				</div>
-			{/if}
-			{#if lightboxItem.logger}
-				<div class="mt-2 flex justify-center">
-					<ByLine user={lightboxItem.logger} variant="inline" class="!text-white/60 !ml-0" />
-				</div>
-			{/if}
-		</div>
-	</div>
-{/if}
+<MediaLightbox
+	companionId={companion.id}
+	items={lightboxItems}
+	date={lightboxDate}
+	bind:open={lightboxOpen}
+	bind:index={lightboxIndex}
+/>
 
 <!-- Activity detail modal -->
 {#if detailEvent}

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -3,8 +3,10 @@
 	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { tick } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { enhance } from '$app/forms';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
+	import MediaLightbox from '$lib/components/MediaLightbox.svelte';
 	import { canModifyMedia } from '$lib/permissions';
 	import { isVideoMime, MEDIA_ACCEPT } from '$lib/media';
 	import JournalVideo from '$lib/components/JournalVideo.svelte';
@@ -219,6 +221,41 @@
 	}
 
 	let immichPickerOpen = $state(false);
+
+	// Lightbox state
+	let lightboxOpen = $state(false);
+	let lightboxIndex = $state(0);
+
+	function openLightbox(index: number) {
+		lightboxIndex = index;
+		lightboxOpen = true;
+	}
+
+	// Deep-link: ?media={id} opens the lightbox at that item.
+	// lastDeepLinkId is only committed once the item is found so the effect can
+	// re-run if the media array is still empty when the param is first read.
+	// deepLinkStripped tracks whether the URL has been cleaned for the current id
+	// so we strip exactly once even when the item is not found.
+	let lastDeepLinkId = '';
+	let deepLinkStripped = false;
+	$effect(() => {
+		const mediaId = page.url.searchParams.get('media');
+		if (!mediaId || mediaId === lastDeepLinkId) return;
+		const idx = media.findIndex((m) => m.id === mediaId);
+		if (idx !== -1) {
+			lastDeepLinkId = mediaId;
+			lightboxIndex = idx;
+			lightboxOpen = true;
+		}
+		if (!deepLinkStripped) {
+			deepLinkStripped = true;
+			tick().then(() => {
+				const url = new URL(page.url);
+				url.searchParams.delete('media');
+				history.replaceState(history.state, '', url.pathname + url.search);
+			});
+		}
+	});
 
 	async function pickFromImmich(assetId: string) {
 		try {
@@ -812,12 +849,19 @@
 										compact
 									/>
 								{:else}
-									<img
-										src={mediaUrl(item)}
-										alt={item.originalName ?? t(locale, 'page.journal.photoAlt')}
-										class="w-full h-full object-cover"
-										loading="lazy"
-									/>
+									<button
+										type="button"
+										onclick={() => openLightbox(media.indexOf(item))}
+										class="block w-full h-full focus:outline-none"
+										aria-label={item.originalName ?? t(locale, 'page.journal.photoAlt')}
+									>
+										<img
+											src={mediaUrl(item)}
+											alt={item.originalName ?? t(locale, 'page.journal.photoAlt')}
+											class="w-full h-full object-cover"
+											loading="lazy"
+										/>
+									</button>
 								{/if}
 								{#if canModifyMedia(data.user, item)}
 									<button
@@ -1245,6 +1289,14 @@
 >
 	<input type="hidden" name="id" value={deleteActivityId} />
 </form>
+
+<MediaLightbox
+	companionId={data.companion.id}
+	items={media}
+	date={data.date}
+	bind:open={lightboxOpen}
+	bind:index={lightboxIndex}
+/>
 
 <ConfirmDialog
 	open={confirmOpen}

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -231,30 +231,27 @@
 		lightboxOpen = true;
 	}
 
-	// Deep-link: ?media={id} opens the lightbox at that item.
-	// lastDeepLinkId is only committed once the item is found so the effect can
-	// re-run if the media array is still empty when the param is first read.
-	// deepLinkStripped tracks whether the URL has been cleaned for the current id
-	// so we strip exactly once even when the item is not found.
+	// Deep-link: ?media={id} opens the lightbox at that item. Re-fires for a
+	// different id/date (the page component is reused across date navigations),
+	// idempotent for the same one. Wait until `media` has loaded (a sibling
+	// effect fills it from data.photos) so we don't strip the param before the
+	// item can resolve, then resolve + strip exactly once per id.
 	let lastDeepLinkId = '';
-	let deepLinkStripped = false;
 	$effect(() => {
 		const mediaId = page.url.searchParams.get('media');
 		if (!mediaId || mediaId === lastDeepLinkId) return;
+		if (media.length === 0) return;
+		lastDeepLinkId = mediaId;
 		const idx = media.findIndex((m) => m.id === mediaId);
 		if (idx !== -1) {
-			lastDeepLinkId = mediaId;
 			lightboxIndex = idx;
 			lightboxOpen = true;
 		}
-		if (!deepLinkStripped) {
-			deepLinkStripped = true;
-			tick().then(() => {
-				const url = new URL(page.url);
-				url.searchParams.delete('media');
-				history.replaceState(history.state, '', url.pathname + url.search);
-			});
-		}
+		tick().then(() => {
+			const url = new URL(page.url);
+			url.searchParams.delete('media');
+			history.replaceState(history.state, '', url.pathname + url.search);
+		});
 	});
 
 	async function pickFromImmich(assetId: string) {

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -98,12 +98,13 @@
 		});
 	});
 
-	let detailApplied = false;
+	// Re-fires for a different reminder/companion (page component is reused
+	// across companion navigations), idempotent for the same one.
+	let lastDeepLinkId = '';
 	$effect(() => {
-		if (detailApplied) return;
 		const detailId = page.url.searchParams.get('detail');
-		if (!detailId) return;
-		detailApplied = true;
+		if (!detailId || detailId === lastDeepLinkId) return;
+		lastDeepLinkId = detailId;
 		const match = data.reminders.find((r) => r.id === detailId);
 		if (match) openDetail(match);
 		tick().then(() => {

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -98,6 +98,21 @@
 		});
 	});
 
+	let detailApplied = false;
+	$effect(() => {
+		if (detailApplied) return;
+		const detailId = page.url.searchParams.get('detail');
+		if (!detailId) return;
+		detailApplied = true;
+		const match = data.reminders.find((r) => r.id === detailId);
+		if (match) openDetail(match);
+		tick().then(() => {
+			const url = new URL(page.url);
+			url.searchParams.delete('detail');
+			history.replaceState(history.state, '', url.pathname + url.search);
+		});
+	});
+
 	function startEdit(reminder: (typeof data.reminders)[0]) {
 		editingId = reminder.id;
 	}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -15,11 +15,13 @@
 		FileText,
 		Settings,
 		LogOut,
-		ShieldCheck
+		ShieldCheck,
+		Search
 	} from '@lucide/svelte';
 	import { THEME_ICONS, THEMES, applyTheme, saveTheme, type Theme } from '$lib/theme';
 	import AppFooter from '$lib/components/AppFooter.svelte';
 	import { ToastRegion } from '$lib/components/ui/toast';
+	import SearchPalette from '$lib/components/SearchPalette.svelte';
 	import { t, getLocale } from '$lib/i18n';
 
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
@@ -83,6 +85,8 @@
 		}
 	}
 
+	let searchOpen = $state(false);
+
 	// Theme toggle
 	let themeOverride = $state<Theme | null>(null);
 	let currentTheme = $derived<Theme>(themeOverride ?? (data.user?.theme as Theme) ?? 'system');
@@ -93,6 +97,21 @@
 		await saveTheme(theme);
 	}
 </script>
+
+<svelte:window
+	onkeydown={(e) => {
+		if (!(e.ctrlKey || e.metaKey) || e.key !== 'k' || e.defaultPrevented) return;
+		const tgt = e.target as HTMLElement;
+		if (
+			tgt instanceof HTMLInputElement ||
+			tgt instanceof HTMLTextAreaElement ||
+			tgt.isContentEditable
+		)
+			return;
+		e.preventDefault();
+		searchOpen = true;
+	}}
+/>
 
 <div class="min-h-screen flex flex-col bg-background">
 	<header
@@ -164,6 +183,17 @@
 
 				<!-- Right: theme toggle + user menu -->
 				<div class="flex items-center gap-1 shrink-0">
+					<!-- Search button -->
+					<button
+						type="button"
+						onclick={() => (searchOpen = true)}
+						aria-label={t(locale, 'aria.openSearch')}
+						class="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+					>
+						<Search class="h-4 w-4" />
+						<span class="hidden sm:inline text-xs text-muted-foreground/70">⌘K</span>
+					</button>
+
 					<!-- Theme toggle -->
 					<div class="flex rounded-md border border-border p-0.5 gap-0.5 bg-muted">
 						{#each THEMES as theme (theme)}
@@ -239,6 +269,8 @@
 	<AppFooter version={data.version} year={data.year} />
 
 	<ToastRegion ariaLabel={t(locale, 'common.reminder.toastAriaRegion')} />
+
+	<SearchPalette bind:open={searchOpen} />
 
 	<!-- Mobile bottom nav -->
 	{#if navItems.length > 0}

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -1,0 +1,19 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { t } from '$lib/i18n';
+import { search } from '$lib/server/search';
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
+	// v1: members/admins only. Caretaker results would be limited to content the
+	// care UI cannot display (no date navigation); revisit with tags/part 2.
+	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
+
+	const q = url.searchParams.get('q') ?? '';
+	try {
+		return json({ results: search(q) });
+	} catch (err) {
+		console.error('[search] query failed:', err);
+		return json({ results: [] });
+	}
+};

--- a/tests/e2e/journal.spec.ts
+++ b/tests/e2e/journal.spec.ts
@@ -100,7 +100,7 @@ test.describe('journal day editor', () => {
 			.first();
 		await mediaContainer.hover();
 
-		const deleteBtn = mediaContainer.locator('button[aria-label]');
+		const deleteBtn = mediaContainer.getByRole('button', { name: 'Delete media' });
 		await deleteBtn.click();
 
 		// Confirm in the dialog (scope to the confirm dialog to avoid the aria-labeled trash button)

--- a/tests/e2e/s3.spec.ts
+++ b/tests/e2e/s3.spec.ts
@@ -102,7 +102,9 @@ test('delete removes from bucket', async ({ world, page }) => {
 		.first();
 	await photoContainer.hover();
 
-	const deleteBtn = photoContainer.locator('button[aria-label]');
+	// The thumbnail is itself a button (opens the lightbox), so scope to the
+	// delete control by its accessible name rather than "any aria-labelled button".
+	const deleteBtn = photoContainer.getByRole('button', { name: 'Delete media' });
 	await deleteBtn.click();
 
 	// Confirm in the dialog

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -68,6 +68,52 @@ test.describe('global search palette', () => {
 		await expect(dialog.getByText('e2e-srch-xenolith')).toBeVisible({ timeout: 8_000 });
 	});
 
+	test('search result for health event deep-links to its detail modal', async ({ asMember }) => {
+		await asMember.goto('/');
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
+
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+		const palette = asMember.locator('[role="dialog"]');
+		await expect(palette).toBeVisible({ timeout: 8_000 });
+
+		await asMember.keyboard.type('Seed checkup');
+		await expect(palette.locator('[role="option"]').first()).toBeVisible({ timeout: 8_000 });
+
+		// Click the result to navigate
+		await palette.locator('[role="option"]').first().click();
+
+		// After navigation the palette closes; wait for the detail dialog on the health page
+		await asMember.waitForURL(new RegExp(`/${COMP}/health`), { timeout: 8_000 });
+		const detailDialog = asMember.locator('[role="dialog"][aria-modal="true"]');
+		await expect(detailDialog).toBeVisible({ timeout: 8_000 });
+		await expect(detailDialog).toContainText('Seed checkup', { timeout: 8_000 });
+	});
+
+	test('search result for reminder deep-links to its detail modal', async ({ asMember }) => {
+		await asMember.goto('/');
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
+
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+		const palette = asMember.locator('[role="dialog"]');
+		await expect(palette).toBeVisible({ timeout: 8_000 });
+
+		await asMember.keyboard.type('Seed vet visit');
+		await expect(palette.locator('[role="option"]').first()).toBeVisible({ timeout: 8_000 });
+
+		// Click the result to navigate
+		await palette.locator('[role="option"]').first().click();
+
+		// After navigation the palette closes; wait for the detail dialog on the reminders page
+		await asMember.waitForURL(new RegExp(`/${COMP}/reminders`), { timeout: 8_000 });
+		const detailDialog = asMember.locator('[role="dialog"][aria-modal="true"]');
+		await expect(detailDialog).toBeVisible({ timeout: 8_000 });
+		await expect(detailDialog).toContainText('Seed vet visit', { timeout: 8_000 });
+	});
+
 	test('caretaker gets 403 on /api/search and has no search button', async ({
 		asCaretaker,
 		app,

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -5,7 +5,11 @@ const COMP = 'seed-comp-biscuit';
 test.describe('global search palette', () => {
 	test('shortcut opens palette and seed journal entry navigates on Enter', async ({ asMember }) => {
 		await asMember.goto('/');
-		// Focus the page body so the window keydown handler receives Control+k
+		// The search button rendering proves the layout (and its window keydown
+		// handler) has hydrated, so the Ctrl+K below won't race mount.
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
 		await asMember.evaluate(() => document.body.focus());
 
 		await asMember.keyboard.press('Control+k');
@@ -90,10 +94,10 @@ test.describe('global search palette', () => {
 	}) => {
 		await asMember.goto('/');
 		const startUrl = asMember.url();
-		// Focus the page body so the window keydown handler receives Control+k
-		await asMember.evaluate(() => document.body.focus());
-
-		await asMember.keyboard.press('Control+k');
+		// Open via the button (the Ctrl+K shortcut is covered in the first test;
+		// here we exercise in-palette keyboard nav, and the button avoids a race
+		// where the key fires before the window handler has hydrated).
+		await asMember.getByRole('button', { name: 'Open search' }).click();
 		const dialog = asMember.locator('[role="dialog"]');
 		await expect(dialog).toBeVisible({ timeout: 8_000 });
 

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -18,6 +18,8 @@ test.describe('global search palette', () => {
 		// Wait for the result option to appear before attempting keyboard navigation
 		const firstOption = dialog.locator('[role="option"]').first();
 		await expect(firstOption).toBeVisible({ timeout: 8_000 });
+		// Result is grouped under the Journal heading.
+		await expect(dialog.getByText('Journal', { exact: true })).toBeVisible({ timeout: 8_000 });
 
 		// ArrowDown to select the first result, then Enter to navigate
 		await asMember.keyboard.press('ArrowDown');

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '../lib/fixtures';
+
+const COMP = 'seed-comp-biscuit';
+
+test.describe('global search palette', () => {
+	test('shortcut opens palette and seed journal entry navigates on Enter', async ({ asMember }) => {
+		await asMember.goto('/');
+		// Focus the page body so the window keydown handler receives Control+k
+		await asMember.evaluate(() => document.body.focus());
+
+		await asMember.keyboard.press('Control+k');
+
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		await asMember.keyboard.type('Seed journal');
+
+		// Wait for the result option to appear before attempting keyboard navigation
+		const firstOption = dialog.locator('[role="option"]').first();
+		await expect(firstOption).toBeVisible({ timeout: 8_000 });
+
+		// ArrowDown to select the first result, then Enter to navigate
+		await asMember.keyboard.press('ArrowDown');
+		await asMember.keyboard.press('Enter');
+
+		await expect(asMember).toHaveURL(`/${COMP}/journal/2026-01-15`, { timeout: 8_000 });
+	});
+
+	test('button click opens palette and finds seed health event', async ({ asMember }) => {
+		await asMember.goto('/');
+
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		await asMember.keyboard.type('Seed checkup');
+
+		// Wait for the Health group heading to appear
+		await expect(asMember.getByText('Health')).toBeVisible({ timeout: 8_000 });
+
+		// The result should be visible
+		await expect(dialog.getByText('Seed checkup')).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('live roundtrip: newly created health event is searchable', async ({ asMember }) => {
+		// Create a health event with a unique title
+		await asMember.goto(`/${COMP}/health`);
+		await asMember.getByRole('button', { name: 'Add Event' }).click();
+		await asMember.locator('#title').fill('e2e-srch-xenolith');
+		await asMember.locator('select[name="type"]').selectOption('vet_visit');
+		await asMember.getByRole('button', { name: 'Save Event' }).click();
+		await expect(asMember.getByText('e2e-srch-xenolith')).toBeVisible({ timeout: 8_000 });
+
+		// Now open the search palette and find the new event
+		await asMember.keyboard.press('Control+k');
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		await asMember.keyboard.type('xenolith');
+
+		await expect(dialog.getByText('e2e-srch-xenolith')).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('caretaker gets 403 on /api/search and has no search button', async ({
+		asCaretaker,
+		app,
+		browser
+	}) => {
+		// API returns 403 for caretaker
+		const res = await asCaretaker.request.get('/api/search?q=seed');
+		expect(res.status()).toBe(403);
+
+		// The caretaker layout (/care) must not have an "Open search" button
+		await asCaretaker.goto('/care');
+		await expect(asCaretaker.getByRole('button', { name: 'Open search' })).toHaveCount(0);
+	});
+
+	test('anonymous request to /api/search returns 401', async ({ app, browser }) => {
+		const ctx = await browser.newContext({ baseURL: app.server.baseURL });
+		const res = await ctx.request.get('/api/search?q=seed');
+		expect(res.status()).toBe(401);
+		await ctx.close();
+	});
+
+	test('keyboard navigation: ArrowDown then Enter navigates to a seed content page', async ({
+		asMember
+	}) => {
+		await asMember.goto('/');
+		const startUrl = asMember.url();
+		// Focus the page body so the window keydown handler receives Control+k
+		await asMember.evaluate(() => document.body.focus());
+
+		await asMember.keyboard.press('Control+k');
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		await asMember.keyboard.type('Seed');
+
+		// Wait for results to appear
+		await expect(dialog.locator('[role="option"]').first()).toBeVisible({ timeout: 8_000 });
+
+		await asMember.keyboard.press('ArrowDown');
+		await asMember.keyboard.press('Enter');
+
+		// URL should have changed away from the start page and into seed-comp-biscuit
+		await expect(asMember).not.toHaveURL(startUrl, { timeout: 8_000 });
+		await expect(asMember).toHaveURL(new RegExp(`/${COMP}/`), { timeout: 8_000 });
+	});
+});

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -118,6 +118,63 @@ test.describe('global search palette', () => {
 		await expect(detailDialog).toContainText('Seed vet visit', { timeout: 8_000 });
 	});
 
+	test('media caption deep-links to journal day with lightbox open', async ({ asMember }) => {
+		const DATE = '2026-05-10';
+		const COMP_ID = COMP;
+
+		// Navigate to the day page and upload a photo.
+		await asMember.goto(`/${COMP_ID}/journal/${DATE}`);
+
+		const textarea = asMember.locator('textarea');
+		await textarea.fill('e2e lightbox test entry');
+		await asMember.locator('h1').first().click();
+		await expect(asMember.getByText('✓ Saved')).toBeVisible({ timeout: 8_000 });
+
+		const fileInput = asMember.locator('input[type="file"][name="photos"]').first();
+		await fileInput.setInputFiles({
+			name: 'photo.png',
+			mimeType: 'image/png',
+			buffer: Buffer.from(
+				'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+				'base64'
+			)
+		});
+		await expect(asMember.locator('img[src*="/api/photos/journal/"]').first()).toBeVisible({
+			timeout: 15_000
+		});
+
+		// Set the caption with a term that only appears here, not in the journal body.
+		await asMember.getByRole('button', { name: 'Edit Caption' }).first().click();
+		await asMember.locator('textarea[name="photo-notes"]').first().fill('e2e-cap-zelkova');
+		await asMember.getByRole('button', { name: 'Save' }).first().click();
+		await expect(asMember.getByText('e2e-cap-zelkova')).toBeVisible({ timeout: 8_000 });
+
+		// Navigate away so the journal page mounts fresh when the search result is clicked.
+		await asMember.goto('/');
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
+
+		// Open search palette and find the caption.
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+		const palette = asMember.locator('[role="dialog"]');
+		await expect(palette).toBeVisible({ timeout: 8_000 });
+
+		await asMember.keyboard.type('zelkova');
+		await expect(palette.locator('[role="option"]').first()).toBeVisible({ timeout: 8_000 });
+
+		// Click the media result.
+		await palette.locator('[role="option"]').first().click();
+
+		// Wait for navigation to the journal day page and palette to detach.
+		await asMember.waitForURL(new RegExp(`/${COMP_ID}/journal/${DATE}`), { timeout: 8_000 });
+		await expect(asMember.locator('[role="combobox"]')).toHaveCount(0, { timeout: 8_000 });
+
+		// MediaLightbox should be open.
+		const lightbox = asMember.locator('[role="dialog"][aria-modal="true"]');
+		await expect(lightbox).toBeVisible({ timeout: 8_000 });
+	});
+
 	test('caretaker gets 403 on /api/search and has no search button', async ({
 		asCaretaker,
 		app,

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -84,8 +84,10 @@ test.describe('global search palette', () => {
 		// Click the result to navigate
 		await palette.locator('[role="option"]').first().click();
 
-		// After navigation the palette closes; wait for the detail dialog on the health page
+		// After navigation the palette (a combobox dialog) closes; wait for it to
+		// detach so the dialog selector resolves only to the page's detail modal.
 		await asMember.waitForURL(new RegExp(`/${COMP}/health`), { timeout: 8_000 });
+		await expect(asMember.locator('[role="combobox"]')).toHaveCount(0, { timeout: 8_000 });
 		const detailDialog = asMember.locator('[role="dialog"][aria-modal="true"]');
 		await expect(detailDialog).toBeVisible({ timeout: 8_000 });
 		await expect(detailDialog).toContainText('Seed checkup', { timeout: 8_000 });
@@ -107,8 +109,10 @@ test.describe('global search palette', () => {
 		// Click the result to navigate
 		await palette.locator('[role="option"]').first().click();
 
-		// After navigation the palette closes; wait for the detail dialog on the reminders page
+		// Wait for the palette (combobox dialog) to detach before resolving the
+		// page's detail modal via the shared dialog selector.
 		await asMember.waitForURL(new RegExp(`/${COMP}/reminders`), { timeout: 8_000 });
+		await expect(asMember.locator('[role="combobox"]')).toHaveCount(0, { timeout: 8_000 });
 		const detailDialog = asMember.locator('[role="dialog"][aria-modal="true"]');
 		await expect(detailDialog).toBeVisible({ timeout: 8_000 });
 		await expect(detailDialog).toContainText('Seed vet visit', { timeout: 8_000 });


### PR DESCRIPTION
## Summary

Closes the search half of #10 (tags are a planned part 2). Global FTS5-backed search over all companion content, reached from a header palette (Ctrl/Cmd-K), with results that deep-link straight to the matching item.

### Search
- **SQLite FTS5 index** (migration 0021): one unified `search_index` virtual table fed by triggers on six content tables — journal bodies, health events, reminders, document titles, daily-log notes, weight notes. bm25 ranking, sentinel-based snippets (no HTML on the wire), prefix matching for as-you-type.
- **Query layer**: every token is quoted, which makes the FTS5 MATCH injection-proof; adversarially unit-tested.
- **API**: `/api/search` — 401 anon, 403 caretaker. Caretaker search is intentionally out of v1 (the care UI has no date navigation, so results could only ever be today's already-visible entries; revisit with part 2).
- **Palette**: combobox/listbox ARIA, keyboard nav, debounced + abortable fetch, snippet highlighting via real `<mark>` elements.

### Deep-links
Results don't just land on the section page — they open the item:
- health/weight/reminder/document → the section page with the item's detail modal open
- journal/daily → the journal day page
- **media captions** (migration 0022): photo/video captions are indexed too; a match opens the photo's lightbox on the day page. Required extracting a reusable `MediaLightbox` component (shared by the journal list and day pages).

### Bugs caught along the way
The review passes and your testing surfaced several real bugs, all fixed here:
- A migration-timestamp ordering bug that would have silently skipped 0022 on every existing install (fresh installs were unaffected, which hid it from CI). Fixed, plus a guard test asserting journal timestamps increase monotonically.
- Cross-companion and cross-date deep-link effects that fired once per mount instead of per item.
- An Escape keypress that could close two modals at once after the lightbox extraction.
- A localeDetect hook whose Accept-Language fallback was unreachable.

## Test plan

- [x] `npm run lint`, `npm run check` clean
- [x] `npm run test:unit` — 95 passed
- [x] `PW_SKIP_BUILD=1 npm run test:e2e` — 99 passed, run repeatedly with no flake
- [x] `npm run db:generate` reports no drift across both migrations
- [x] CI green