### PR TITLE
Search filters: @companion, #type, date range (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ EinVault is a private, self-hosted companion health and care tracker built for h
 - **Health tracking:** vet visits, vaccinations, medications, procedures, and weight history
 - **Activity logging:** walks, meals, bathroom trips, treats, play sessions, and grooming
 - **Reminders:** recurring and one-time reminders for medications, vaccinations, grooming, and more
+- **Search:** full-text search across journals, health, activity, reminders, documents, and media, with `@companion`, `#type`, and date-range filters (members and admins)
 - **Caretaker shifts:** schedule work shifts and export to calendar via iCalendar (.ics)
 - **Role-based access:** admins manage the app, members track health, caretakers log activities
 - **Self-contained:** single Docker container, SQLite database, no external dependencies

--- a/src/lib/components/SearchPalette.svelte
+++ b/src/lib/components/SearchPalette.svelte
@@ -289,6 +289,20 @@
 			}
 		}
 
+		if (e.key === 'Backspace' && query.length === 0 && hasFilters()) {
+			e.preventDefault();
+			if (before) {
+				before = '';
+			} else if (after) {
+				after = '';
+			} else if (typeFilters.length > 0) {
+				typeFilters = typeFilters.slice(0, -1);
+			} else if (companionFilters.length > 0) {
+				companionFilters = companionFilters.slice(0, -1);
+			}
+			return;
+		}
+
 		if (e.key === 'Escape') {
 			close();
 			return;

--- a/src/lib/components/SearchPalette.svelte
+++ b/src/lib/components/SearchPalette.svelte
@@ -277,11 +277,13 @@
 			if (e.key === 'ArrowDown') {
 				e.preventDefault();
 				sigilSelected = Math.min(sigilSelected + 1, sigilItems.length - 1);
+				scrollSigilIntoView();
 				return;
 			}
 			if (e.key === 'ArrowUp') {
 				e.preventDefault();
 				sigilSelected = Math.max(sigilSelected - 1, 0);
+				scrollSigilIntoView();
 				return;
 			}
 			if (e.key === 'Enter') {
@@ -367,6 +369,13 @@
 		});
 	}
 
+	function scrollSigilIntoView() {
+		tick().then(() => {
+			const el = dialogEl?.querySelector(`#sigil-option-${sigilSelected}`);
+			el?.scrollIntoView({ block: 'nearest' });
+		});
+	}
+
 	function groupLabel(type: GroupKey): string {
 		const keyMap: Record<GroupKey, Parameters<typeof t>[1]> = {
 			journal: 'search.group.journal',
@@ -413,7 +422,7 @@
 			aria-modal="true"
 			aria-label={t(locale, 'aria.searchResults')}
 			tabindex="-1"
-			class="relative z-10 w-full max-w-xl rounded-lg border border-border bg-card shadow-xl flex flex-col overflow-hidden"
+			class="relative z-10 w-full max-w-xl rounded-lg border border-border bg-card shadow-xl flex flex-col"
 		>
 			<!-- Input row -->
 			<div class="flex items-center gap-2 px-4 py-3 border-b border-border">
@@ -442,7 +451,7 @@
 							id="search-sigil-popup"
 							role="listbox"
 							aria-label={t(locale, 'aria.sigilAutocomplete')}
-							class="absolute left-0 top-full mt-1 z-20 w-full min-w-[12rem] rounded-md border border-border bg-popover shadow-md py-1"
+							class="absolute left-0 top-full mt-1 z-20 max-h-72 w-full min-w-[12rem] overflow-y-auto rounded-md border border-border bg-popover shadow-md py-1"
 						>
 							{#each sigilItems as item, i (item.value)}
 								<li
@@ -646,6 +655,20 @@
 						{/each}
 					</ul>
 				{/if}
+			</div>
+
+			<!-- Shortcut tips -->
+			<div
+				class="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-2 border-t border-border text-xs text-muted-foreground"
+			>
+				<span>
+					<kbd class="rounded bg-muted px-1 font-mono text-foreground">@</kbd>
+					{t(locale, 'search.tipCompanion')}
+				</span>
+				<span>
+					<kbd class="rounded bg-muted px-1 font-mono text-foreground">#</kbd>
+					{t(locale, 'search.tipType')}
+				</span>
 			</div>
 		</div>
 	</div>

--- a/src/lib/components/SearchPalette.svelte
+++ b/src/lib/components/SearchPalette.svelte
@@ -2,7 +2,8 @@
 	import { tick } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { t, getLocale } from '$lib/i18n';
-	import { Search } from '@lucide/svelte';
+	import { Search, X } from '@lucide/svelte';
+	import { parseSigilToken, stripSigilToken } from '$lib/searchSigil';
 
 	export type SearchEntityType =
 		| 'journal'
@@ -24,9 +25,31 @@
 		href: string;
 	}
 
-	let { open = $bindable(false) }: { open?: boolean } = $props();
+	const ENTITY_TYPES: SearchEntityType[] = [
+		'journal',
+		'daily',
+		'health',
+		'weight',
+		'reminder',
+		'document',
+		'media'
+	];
+
+	let {
+		open = $bindable(false),
+		companions = []
+	}: {
+		open?: boolean;
+		companions?: { id: string; name: string }[];
+	} = $props();
 
 	const locale = getLocale();
+
+	// Build the type list (label derived from existing search.group.* keys)
+	const typeList = ENTITY_TYPES.map((value) => ({
+		value,
+		label: t(locale, `search.group.${value}` as Parameters<typeof t>[1])
+	}));
 
 	let dialogEl = $state<HTMLElement | null>(null);
 	let inputEl = $state<HTMLInputElement | null>(null);
@@ -37,8 +60,24 @@
 	let selectedIndex = $state(-1);
 	let loading = $state(false);
 
+	// Filter state
+	let companionFilters = $state<{ id: string; name: string }[]>([]);
+	let typeFilters = $state<SearchEntityType[]>([]);
+	let after = $state('');
+	let before = $state('');
+
+	// Sigil autocomplete state
+	let autocompleteOpen = $state(false);
+	let sigilSelected = $state(0);
+	let sigilItems = $state<{ label: string; value: string; id?: string }[]>([]);
+
 	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 	let currentController: AbortController | undefined;
+
+	// True when any filter is active (even without query text)
+	function hasFilters(): boolean {
+		return companionFilters.length > 0 || typeFilters.length > 0 || !!after || !!before;
+	}
 
 	$effect(() => {
 		if (open) {
@@ -47,6 +86,13 @@
 			results = [];
 			selectedIndex = -1;
 			loading = false;
+			companionFilters = [];
+			typeFilters = [];
+			after = '';
+			before = '';
+			autocompleteOpen = false;
+			sigilItems = [];
+			sigilSelected = 0;
 			tick().then(() => inputEl?.focus());
 		} else {
 			tick().then(() => triggerEl?.focus());
@@ -54,13 +100,51 @@
 	});
 
 	$effect(() => {
-		// Reactive to query changes
+		// Reactive to query changes — sigil detection
+		const tok = parseSigilToken(query);
+		if (tok) {
+			const partial = tok.partial.toLowerCase();
+			if (tok.sigil === '@') {
+				const filtered = companions
+					.filter((c) => !companionFilters.some((f) => f.id === c.id))
+					.filter((c) => c.name.toLowerCase().includes(partial));
+				sigilItems = filtered.map((c) => ({ label: c.name, value: c.id, id: c.id }));
+			} else {
+				// '#'
+				const filtered = typeList.filter(
+					(t) =>
+						!typeFilters.includes(t.value) &&
+						(t.label.toLowerCase().includes(partial) || t.value.toLowerCase().includes(partial))
+				);
+				sigilItems = filtered.map((t) => ({ label: t.label, value: t.value }));
+			}
+			if (sigilItems.length > 0) {
+				autocompleteOpen = true;
+				sigilSelected = 0;
+			} else {
+				autocompleteOpen = false;
+			}
+		} else {
+			autocompleteOpen = false;
+			sigilItems = [];
+		}
+	});
+
+	$effect(() => {
+		// Reactive to all filter state + query
 		const q = query;
+		const cFilters = companionFilters;
+		const tFilters = typeFilters;
+		const af = after;
+		const bf = before;
 
 		clearTimeout(debounceTimer);
 		currentController?.abort();
 
-		if (q.trim().length < 2) {
+		const trimmed = q.trim();
+		const active = cFilters.length > 0 || tFilters.length > 0 || !!af || !!bf;
+
+		if (trimmed.length < 2 && !active) {
 			results = [];
 			selectedIndex = -1;
 			loading = false;
@@ -73,7 +157,15 @@
 
 		debounceTimer = setTimeout(async () => {
 			try {
-				const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`, {
+				const parts: string[] = [];
+				if (trimmed.length >= 2) parts.push(`q=${encodeURIComponent(trimmed)}`);
+				for (const cf of cFilters) parts.push(`companion=${encodeURIComponent(cf.id)}`);
+				for (const tf of tFilters) parts.push(`type=${encodeURIComponent(tf)}`);
+				if (af) parts.push(`after=${encodeURIComponent(af)}`);
+				if (bf) parts.push(`before=${encodeURIComponent(bf)}`);
+				const qs = parts.join('&');
+
+				const res = await fetch(`/api/search?${qs}`, {
 					signal: controller.signal
 				});
 				if (!res.ok) {
@@ -99,6 +191,40 @@
 			controller.abort();
 		};
 	});
+
+	function selectSigil(i: number) {
+		const item = sigilItems[i];
+		if (!item) return;
+		const tok = parseSigilToken(query);
+		if (!tok) return;
+
+		if (tok.sigil === '@') {
+			// companion
+			if (!companionFilters.some((f) => f.id === item.value)) {
+				companionFilters = [...companionFilters, { id: item.value, name: item.label }];
+			}
+		} else {
+			// type
+			const v = item.value as SearchEntityType;
+			if (!typeFilters.includes(v)) {
+				typeFilters = [...typeFilters, v];
+			}
+		}
+
+		query = stripSigilToken(query, tok);
+		autocompleteOpen = false;
+		sigilItems = [];
+		sigilSelected = 0;
+		tick().then(() => inputEl?.focus());
+	}
+
+	function removeCompanionFilter(id: string) {
+		companionFilters = companionFilters.filter((f) => f.id !== id);
+	}
+
+	function removeTypeFilter(type: SearchEntityType) {
+		typeFilters = typeFilters.filter((t) => t !== type);
+	}
 
 	function close() {
 		open = false;
@@ -140,6 +266,29 @@
 	);
 
 	function handleKeydown(e: KeyboardEvent) {
+		// Sigil autocomplete intercept — must run before any other handling
+		if (autocompleteOpen) {
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				sigilSelected = Math.min(sigilSelected + 1, sigilItems.length - 1);
+				return;
+			}
+			if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				sigilSelected = Math.max(sigilSelected - 1, 0);
+				return;
+			}
+			if (e.key === 'Enter') {
+				e.preventDefault();
+				selectSigil(sigilSelected);
+				return;
+			}
+			if (e.key === 'Escape') {
+				autocompleteOpen = false;
+				return;
+			}
+		}
+
 		if (e.key === 'Escape') {
 			close();
 			return;
@@ -218,6 +367,9 @@
 		}
 		return idx + itemIdx;
 	}
+
+	// Whether to show the results hint (no query, no filters)
+	let showHint = $derived(query.trim().length < 2 && !hasFilters());
 </script>
 
 {#if open}
@@ -243,26 +395,152 @@
 			tabindex="-1"
 			class="relative z-10 w-full max-w-xl rounded-lg border border-border bg-card shadow-xl flex flex-col overflow-hidden"
 		>
-			<!-- Input -->
+			<!-- Input row -->
 			<div class="flex items-center gap-2 px-4 py-3 border-b border-border">
 				<Search class="h-4 w-4 shrink-0 text-muted-foreground" />
-				<input
-					bind:this={inputEl}
-					bind:value={query}
-					type="search"
-					role="combobox"
-					aria-expanded={results.length > 0}
-					aria-controls="search-results"
-					aria-activedescendant={selectedIndex >= 0 ? `search-option-${selectedIndex}` : undefined}
-					autocomplete="off"
-					placeholder={t(locale, 'search.placeholder')}
-					class="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-				/>
+				<div class="relative flex-1">
+					<input
+						bind:this={inputEl}
+						bind:value={query}
+						type="search"
+						role="combobox"
+						aria-expanded={autocompleteOpen || results.length > 0}
+						aria-controls={autocompleteOpen ? 'search-sigil-popup' : 'search-results'}
+						aria-activedescendant={autocompleteOpen
+							? `sigil-option-${sigilSelected}`
+							: selectedIndex >= 0
+								? `search-option-${selectedIndex}`
+								: undefined}
+						autocomplete="off"
+						placeholder={t(locale, 'search.placeholder')}
+						class="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+					/>
+
+					<!-- Sigil autocomplete popup -->
+					{#if autocompleteOpen}
+						<ul
+							id="search-sigil-popup"
+							role="listbox"
+							aria-label={t(locale, 'aria.sigilAutocomplete')}
+							class="absolute left-0 top-full mt-1 z-20 w-full min-w-[12rem] rounded-md border border-border bg-popover shadow-md py-1"
+						>
+							{#each sigilItems as item, i (item.value)}
+								<li
+									id="sigil-option-{i}"
+									role="option"
+									aria-selected={i === sigilSelected}
+									onclick={() => selectSigil(i)}
+									onkeydown={(e) => {
+										if (e.key === 'Enter' || e.key === ' ') {
+											e.preventDefault();
+											selectSigil(i);
+										}
+									}}
+									tabindex="-1"
+									class="px-3 py-1.5 text-sm cursor-pointer {i === sigilSelected
+										? 'bg-accent text-accent-foreground'
+										: 'hover:bg-accent/50'}"
+								>
+									{item.label}
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				</div>
+			</div>
+
+			<!-- Active filter chips -->
+			{#if companionFilters.length > 0 || typeFilters.length > 0 || after || before}
+				<div class="flex flex-wrap gap-1.5 px-4 py-2 border-b border-border">
+					{#each companionFilters as cf (cf.id)}
+						<span
+							class="inline-flex items-center gap-1 rounded-full bg-primary/10 text-primary text-xs font-medium px-2 py-0.5"
+						>
+							{cf.name}
+							<button
+								type="button"
+								aria-label={t(locale, 'search.filter.removeCompanion', { name: cf.name })}
+								onclick={() => removeCompanionFilter(cf.id)}
+								class="hover:opacity-70 transition-opacity"
+							>
+								<X class="h-3 w-3" />
+							</button>
+						</span>
+					{/each}
+					{#each typeFilters as tf (tf)}
+						{@const label = groupLabel(tf)}
+						<span
+							class="inline-flex items-center gap-1 rounded-full bg-secondary text-secondary-foreground text-xs font-medium px-2 py-0.5"
+						>
+							{label}
+							<button
+								type="button"
+								aria-label={t(locale, 'search.filter.removeType', { type: label })}
+								onclick={() => removeTypeFilter(tf)}
+								class="hover:opacity-70 transition-opacity"
+							>
+								<X class="h-3 w-3" />
+							</button>
+						</span>
+					{/each}
+					{#if after}
+						<span
+							class="inline-flex items-center gap-1 rounded-full bg-secondary text-secondary-foreground text-xs font-medium px-2 py-0.5"
+						>
+							{t(locale, 'search.filter.after')}: {after}
+							<button
+								type="button"
+								aria-label={t(locale, 'search.filter.removeAfter')}
+								onclick={() => (after = '')}
+								class="hover:opacity-70 transition-opacity"
+							>
+								<X class="h-3 w-3" />
+							</button>
+						</span>
+					{/if}
+					{#if before}
+						<span
+							class="inline-flex items-center gap-1 rounded-full bg-secondary text-secondary-foreground text-xs font-medium px-2 py-0.5"
+						>
+							{t(locale, 'search.filter.before')}: {before}
+							<button
+								type="button"
+								aria-label={t(locale, 'search.filter.removeBefore')}
+								onclick={() => (before = '')}
+								class="hover:opacity-70 transition-opacity"
+							>
+								<X class="h-3 w-3" />
+							</button>
+						</span>
+					{/if}
+				</div>
+			{/if}
+
+			<!-- Date range controls -->
+			<div class="flex gap-4 px-4 py-2 border-b border-border">
+				<label class="flex items-center gap-2 text-xs text-muted-foreground">
+					<span>{t(locale, 'search.filter.after')}</span>
+					<input
+						type="date"
+						name="after"
+						bind:value={after}
+						class="rounded border border-border bg-transparent px-2 py-0.5 text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
+					/>
+				</label>
+				<label class="flex items-center gap-2 text-xs text-muted-foreground">
+					<span>{t(locale, 'search.filter.before')}</span>
+					<input
+						type="date"
+						name="before"
+						bind:value={before}
+						class="rounded border border-border bg-transparent px-2 py-0.5 text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
+					/>
+				</label>
 			</div>
 
 			<!-- Results area -->
 			<div class="max-h-[60vh] overflow-y-auto">
-				{#if query.trim().length < 2}
+				{#if showHint}
 					<p class="px-4 py-6 text-center text-sm text-muted-foreground">
 						{t(locale, 'search.hint')}
 					</p>

--- a/src/lib/components/SearchPalette.svelte
+++ b/src/lib/components/SearchPalette.svelte
@@ -104,21 +104,27 @@
 		const tok = parseSigilToken(query);
 		if (tok) {
 			const partial = tok.partial.toLowerCase();
+			// Compute into a local first; reading the `sigilItems` state we just
+			// wrote inside this same effect would make it self-triggering (Svelte 5
+			// effect_update_depth loop).
+			let items: { label: string; value: string; id?: string }[];
 			if (tok.sigil === '@') {
-				const filtered = companions
+				items = companions
 					.filter((c) => !companionFilters.some((f) => f.id === c.id))
-					.filter((c) => c.name.toLowerCase().includes(partial));
-				sigilItems = filtered.map((c) => ({ label: c.name, value: c.id, id: c.id }));
+					.filter((c) => c.name.toLowerCase().includes(partial))
+					.map((c) => ({ label: c.name, value: c.id, id: c.id }));
 			} else {
 				// '#'
-				const filtered = typeList.filter(
-					(t) =>
-						!typeFilters.includes(t.value) &&
-						(t.label.toLowerCase().includes(partial) || t.value.toLowerCase().includes(partial))
-				);
-				sigilItems = filtered.map((t) => ({ label: t.label, value: t.value }));
+				items = typeList
+					.filter(
+						(t) =>
+							!typeFilters.includes(t.value) &&
+							(t.label.toLowerCase().includes(partial) || t.value.toLowerCase().includes(partial))
+					)
+					.map((t) => ({ label: t.label, value: t.value }));
 			}
-			if (sigilItems.length > 0) {
+			sigilItems = items;
+			if (items.length > 0) {
 				autocompleteOpen = true;
 				sigilSelected = 0;
 			} else {

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -800,6 +800,13 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.daily': 'Tagesprotokoll',
 	'search.group.weight': 'Gewicht',
 	'search.group.media': 'Fotos & Videos',
+	'search.filter.after': 'Nach',
+	'search.filter.before': 'Vor',
+	'search.filter.removeCompanion': '{name}-Filter entfernen',
+	'search.filter.removeType': '{type}-Filter entfernen',
+	'search.filter.removeAfter': 'Nach-Datum-Filter entfernen',
+	'search.filter.removeBefore': 'Vor-Datum-Filter entfernen',
+	'aria.sigilAutocomplete': 'Filtervorschläge',
 
 	// Immich picker
 	'immich.picker.title': 'Aus Immich auswählen',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -806,6 +806,8 @@ const messages: Record<keyof Messages, string> = {
 	'search.filter.removeType': '{type}-Filter entfernen',
 	'search.filter.removeAfter': 'Nach-Datum-Filter entfernen',
 	'search.filter.removeBefore': 'Vor-Datum-Filter entfernen',
+	'search.tipCompanion': 'nach Begleiter filtern',
+	'search.tipType': 'nach Typ filtern',
 	'aria.sigilAutocomplete': 'Filtervorschläge',
 
 	// Immich picker

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -798,6 +798,8 @@ const messages = {
 	'search.filter.removeType': 'Remove {type} filter',
 	'search.filter.removeAfter': 'Remove after date filter',
 	'search.filter.removeBefore': 'Remove before date filter',
+	'search.tipCompanion': 'filter by companion',
+	'search.tipType': 'filter by type',
 	'aria.sigilAutocomplete': 'Filter suggestions',
 
 	// Immich picker

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -792,6 +792,13 @@ const messages = {
 	'search.group.daily': 'Daily log',
 	'search.group.weight': 'Weight',
 	'search.group.media': 'Photos & videos',
+	'search.filter.after': 'After',
+	'search.filter.before': 'Before',
+	'search.filter.removeCompanion': 'Remove {name} filter',
+	'search.filter.removeType': 'Remove {type} filter',
+	'search.filter.removeAfter': 'Remove after date filter',
+	'search.filter.removeBefore': 'Remove before date filter',
+	'aria.sigilAutocomplete': 'Filter suggestions',
 
 	// Immich picker
 	'immich.picker.title': 'Pick from Immich',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -806,6 +806,8 @@ const messages: Record<keyof Messages, string> = {
 	'search.filter.removeType': 'Quitar filtro {type}',
 	'search.filter.removeAfter': 'Quitar filtro de fecha posterior',
 	'search.filter.removeBefore': 'Quitar filtro de fecha anterior',
+	'search.tipCompanion': 'filtrar por compañero',
+	'search.tipType': 'filtrar por tipo',
 	'aria.sigilAutocomplete': 'Sugerencias de filtro',
 
 	// Immich picker

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -800,6 +800,13 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.daily': 'Registro diario',
 	'search.group.weight': 'Peso',
 	'search.group.media': 'Fotos y vídeos',
+	'search.filter.after': 'Después',
+	'search.filter.before': 'Antes',
+	'search.filter.removeCompanion': 'Quitar filtro {name}',
+	'search.filter.removeType': 'Quitar filtro {type}',
+	'search.filter.removeAfter': 'Quitar filtro de fecha posterior',
+	'search.filter.removeBefore': 'Quitar filtro de fecha anterior',
+	'aria.sigilAutocomplete': 'Sugerencias de filtro',
 
 	// Immich picker
 	'immich.picker.title': 'Elegir desde Immich',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -808,6 +808,8 @@ const messages: Record<keyof Messages, string> = {
 	'search.filter.removeType': 'Retirer le filtre {type}',
 	'search.filter.removeAfter': 'Retirer le filtre date après',
 	'search.filter.removeBefore': 'Retirer le filtre date avant',
+	'search.tipCompanion': 'filtrer par compagnon',
+	'search.tipType': 'filtrer par type',
 	'aria.sigilAutocomplete': 'Suggestions de filtre',
 
 	// Immich picker

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -802,6 +802,13 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.daily': 'Journal quotidien',
 	'search.group.weight': 'Poids',
 	'search.group.media': 'Photos et vidéos',
+	'search.filter.after': 'Après',
+	'search.filter.before': 'Avant',
+	'search.filter.removeCompanion': 'Retirer le filtre {name}',
+	'search.filter.removeType': 'Retirer le filtre {type}',
+	'search.filter.removeAfter': 'Retirer le filtre date après',
+	'search.filter.removeBefore': 'Retirer le filtre date avant',
+	'aria.sigilAutocomplete': 'Suggestions de filtre',
 
 	// Immich picker
 	'immich.picker.title': 'Choisir depuis Immich',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -801,6 +801,8 @@ const messages: Record<keyof Messages, string> = {
 	'search.filter.removeType': 'Rimuovi filtro {type}',
 	'search.filter.removeAfter': 'Rimuovi filtro data dopo',
 	'search.filter.removeBefore': 'Rimuovi filtro data prima',
+	'search.tipCompanion': 'filtra per compagno',
+	'search.tipType': 'filtra per tipo',
 	'aria.sigilAutocomplete': 'Suggerimenti filtro',
 
 	// Immich picker

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -795,6 +795,13 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.daily': 'Registro giornaliero',
 	'search.group.weight': 'Peso',
 	'search.group.media': 'Foto e video',
+	'search.filter.after': 'Dopo',
+	'search.filter.before': 'Prima',
+	'search.filter.removeCompanion': 'Rimuovi filtro {name}',
+	'search.filter.removeType': 'Rimuovi filtro {type}',
+	'search.filter.removeAfter': 'Rimuovi filtro data dopo',
+	'search.filter.removeBefore': 'Rimuovi filtro data prima',
+	'aria.sigilAutocomplete': 'Suggerimenti filtro',
 
 	// Immich picker
 	'immich.picker.title': 'Scegli da Immich',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -797,6 +797,13 @@ const messages: Record<keyof Messages, string> = {
 	'search.group.daily': 'Registo diário',
 	'search.group.weight': 'Peso',
 	'search.group.media': 'Fotos e vídeos',
+	'search.filter.after': 'Depois',
+	'search.filter.before': 'Antes',
+	'search.filter.removeCompanion': 'Remover filtro {name}',
+	'search.filter.removeType': 'Remover filtro {type}',
+	'search.filter.removeAfter': 'Remover filtro de data posterior',
+	'search.filter.removeBefore': 'Remover filtro de data anterior',
+	'aria.sigilAutocomplete': 'Sugestões de filtro',
 
 	// Immich picker
 	'immich.picker.title': 'Escolher do Immich',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -803,6 +803,8 @@ const messages: Record<keyof Messages, string> = {
 	'search.filter.removeType': 'Remover filtro {type}',
 	'search.filter.removeAfter': 'Remover filtro de data posterior',
 	'search.filter.removeBefore': 'Remover filtro de data anterior',
+	'search.tipCompanion': 'filtrar por companheiro',
+	'search.tipType': 'filtrar por tipo',
 	'aria.sigilAutocomplete': 'Sugestões de filtro',
 
 	// Immich picker

--- a/src/lib/searchSigil.test.ts
+++ b/src/lib/searchSigil.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { parseSigilToken, stripSigilToken } from './searchSigil';
+
+describe('parseSigilToken', () => {
+	it('detects a trailing @ token at start', () => {
+		expect(parseSigilToken('@bis')).toEqual({ sigil: '@', partial: 'bis', start: 0 });
+	});
+	it('detects a trailing # token after whitespace', () => {
+		expect(parseSigilToken('limp @bisc #hea')).toEqual({ sigil: '#', partial: 'hea', start: 11 });
+	});
+	it('treats an empty partial as show-all', () => {
+		expect(parseSigilToken('walk @')).toEqual({ sigil: '@', partial: '', start: 5 });
+	});
+	it('does NOT trigger on email-like a@b', () => {
+		expect(parseSigilToken('mail a@b')).toBeNull();
+	});
+	it('returns null when the trailing token is plain text', () => {
+		expect(parseSigilToken('@bisc walk')).toBeNull();
+	});
+	it('returns null for empty input', () => {
+		expect(parseSigilToken('')).toBeNull();
+	});
+});
+
+describe('stripSigilToken', () => {
+	it('removes the trailing token, keeping prior text', () => {
+		const v = 'limp #hea';
+		const tok = parseSigilToken(v)!;
+		expect(stripSigilToken(v, tok)).toBe('limp ');
+	});
+	it('clears a sole token', () => {
+		const v = '@bis';
+		expect(stripSigilToken(v, parseSigilToken(v)!)).toBe('');
+	});
+});

--- a/src/lib/searchSigil.ts
+++ b/src/lib/searchSigil.ts
@@ -1,0 +1,22 @@
+export interface SigilToken {
+	sigil: '@' | '#';
+	partial: string;
+	/** index in the input where the sigil starts (for splicing it out). */
+	start: number;
+}
+
+/**
+ * Detect a trailing @ or # token currently being typed. The sigil must be at
+ * string start or right after whitespace (so `a@b` email text never triggers).
+ * The partial may be empty (sigil just typed → show the full list).
+ */
+export function parseSigilToken(value: string): SigilToken | null {
+	const m = /(?:^|(?<=\s))([@#])(\S*)$/.exec(value);
+	if (!m) return null;
+	return { sigil: m[1] as '@' | '#', partial: m[2], start: m.index };
+}
+
+/** Remove the trailing sigil token from the value (after a selection). */
+export function stripSigilToken(value: string, token: SigilToken): string {
+	return value.slice(0, token.start);
+}

--- a/src/lib/server/search.test.ts
+++ b/src/lib/server/search.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { db, schema } from '$lib/server/db';
-import { buildMatchQuery, search } from './search';
+import { search, buildMatchQuery, buildFilterClause, hasActiveFilters } from './search';
+import type { SearchFilters } from './search';
+
+function q(partial: Partial<SearchFilters>): SearchFilters {
+	return { text: '', companionIds: [], types: [], ...partial };
+}
 
 describe('buildMatchQuery', () => {
 	it('rejects short and empty input', () => {
@@ -17,6 +22,34 @@ describe('buildMatchQuery', () => {
 		expect(buildMatchQuery('NEAR(x y)')).toBe('"NEAR(x"* "y)"*');
 		expect(buildMatchQuery('""')).toBeNull();
 		expect(buildMatchQuery('" "')).toBeNull();
+	});
+});
+
+describe('buildFilterClause', () => {
+	it('is empty for no filters', () => {
+		expect(buildFilterClause(q({}))).toEqual({ sql: '', params: [] });
+	});
+	it('ORs within a kind, ANDs across kinds, params in order', () => {
+		const r = buildFilterClause(
+			q({
+				companionIds: ['c1', 'c2'],
+				types: ['health'],
+				after: '2026-01-01',
+				before: '2026-12-31'
+			})
+		);
+		expect(r.sql).toBe(
+			's.companion_id IN (?, ?) AND s.entity_type IN (?) AND s.event_date >= ? AND s.event_date <= ?'
+		);
+		expect(r.params).toEqual(['c1', 'c2', 'health', '2026-01-01', '2026-12-31']);
+	});
+});
+
+describe('hasActiveFilters', () => {
+	it('detects any filter', () => {
+		expect(hasActiveFilters(q({}))).toBe(false);
+		expect(hasActiveFilters(q({ types: ['health'] }))).toBe(true);
+		expect(hasActiveFilters(q({ after: '2026-01-01' }))).toBe(true);
 	});
 });
 
@@ -42,8 +75,8 @@ describe('search index + query', () => {
 			body: 'zephyr quince walk',
 			loggedBy: 'u-s'
 		} as typeof schema.journalEntries.$inferInsert);
-		expect(search('zephyr').length).toBe(1);
-		expect(search('zephyr')[0]).toMatchObject({
+		expect(search(q({ text: 'zephyr' })).length).toBe(1);
+		expect(search(q({ text: 'zephyr' }))[0]).toMatchObject({
 			type: 'journal',
 			companionName: 'Searchy',
 			href: '/c-s/journal/2026-04-01'
@@ -54,11 +87,11 @@ describe('search index + query', () => {
 			.update(schema.journalEntries)
 			.set({ body: 'flummox walk' })
 			.where(eq(schema.journalEntries.id, 'j-s1'));
-		expect(search('zephyr').length).toBe(0);
-		expect(search('flummox').length).toBe(1);
+		expect(search(q({ text: 'zephyr' })).length).toBe(0);
+		expect(search(q({ text: 'flummox' })).length).toBe(1);
 
 		await db.delete(schema.journalEntries).where(eq(schema.journalEntries.id, 'j-s1'));
-		expect(search('flummox').length).toBe(0);
+		expect(search(q({ text: 'flummox' })).length).toBe(0);
 	});
 
 	it('indexes every entity type', async () => {
@@ -96,21 +129,21 @@ describe('search index + query', () => {
 			loggedBy: 'u-s'
 		} as typeof schema.weightEntries.$inferInsert);
 
-		expect(search('xylograph')[0]?.type).toBe('health');
-		expect(search('quibble')[0]?.type).toBe('reminder');
-		expect(search('gargoyle')[0]?.type).toBe('daily');
-		expect(search('plimsoll')[0]?.type).toBe('weight');
+		expect(search(q({ text: 'xylograph' }))[0]?.type).toBe('health');
+		expect(search(q({ text: 'quibble' }))[0]?.type).toBe('reminder');
+		expect(search(q({ text: 'gargoyle' }))[0]?.type).toBe('daily');
+		expect(search(q({ text: 'plimsoll' }))[0]?.type).toBe('weight');
 		// health event_date derived from occurredAt
-		expect(search('xylograph')[0]?.date).toBe('2026-04-02');
+		expect(search(q({ text: 'xylograph' }))[0]?.date).toBe('2026-04-02');
 		// deep-link hrefs
-		expect(search('xylograph')[0]?.href).toBe('/c-s/health?detailHealth=h-s1');
-		expect(search('quibble')[0]?.href).toBe('/c-s/reminders?detail=r-s1');
-		expect(search('gargoyle')[0]?.href).toBe('/c-s/journal/2026-04-04');
-		expect(search('plimsoll')[0]?.href).toBe('/c-s/health?detailWeight=w-s1');
+		expect(search(q({ text: 'xylograph' }))[0]?.href).toBe('/c-s/health?detailHealth=h-s1');
+		expect(search(q({ text: 'quibble' }))[0]?.href).toBe('/c-s/reminders?detail=r-s1');
+		expect(search(q({ text: 'gargoyle' }))[0]?.href).toBe('/c-s/journal/2026-04-04');
+		expect(search(q({ text: 'plimsoll' }))[0]?.href).toBe('/c-s/health?detailWeight=w-s1');
 	});
 
 	it('snippet carries sentinel markers around the match', () => {
-		const r = search('gargoyle')[0];
+		const r = search(q({ text: 'gargoyle' }))[0];
 		expect(r.snippet).toContain('\x01gargoyle\x02');
 	});
 
@@ -132,8 +165,8 @@ describe('search index + query', () => {
 			notes: 'sphinx caption here'
 		} as typeof schema.journalPhotos.$inferInsert);
 
-		expect(search('sphinx').length).toBe(1);
-		expect(search('sphinx')[0]).toMatchObject({
+		expect(search(q({ text: 'sphinx' })).length).toBe(1);
+		expect(search(q({ text: 'sphinx' }))[0]).toMatchObject({
 			type: 'media',
 			href: '/c-s/journal/2026-04-09?media=p-s1'
 		});
@@ -143,13 +176,13 @@ describe('search index + query', () => {
 			.update(schema.journalPhotos)
 			.set({ notes: 'marmot updated' })
 			.where(eq(schema.journalPhotos.id, 'p-s1'));
-		expect(search('sphinx').length).toBe(0);
-		expect(search('marmot').length).toBe(1);
-		expect(search('marmot')[0]?.type).toBe('media');
+		expect(search(q({ text: 'sphinx' })).length).toBe(0);
+		expect(search(q({ text: 'marmot' })).length).toBe(1);
+		expect(search(q({ text: 'marmot' }))[0]?.type).toBe('media');
 
 		// delete: gone
 		await db.delete(schema.journalPhotos).where(eq(schema.journalPhotos.id, 'p-s1'));
-		expect(search('marmot').length).toBe(0);
+		expect(search(q({ text: 'marmot' })).length).toBe(0);
 	});
 
 	it('ranks the stronger match first', async () => {
@@ -169,7 +202,37 @@ describe('search index + query', () => {
 				loggedBy: 'u-s'
 			}
 		] as (typeof schema.journalEntries.$inferInsert)[]);
-		const results = search('brontide');
+		const results = search(q({ text: 'brontide' }));
 		expect(results[0].id).toBe('j-s2');
+	});
+
+	describe('search filters', () => {
+		it('text + type filter narrows to that type', () => {
+			expect(search(q({ text: 'xylograph' })).some((r) => r.type === 'health')).toBe(true);
+			expect(search(q({ text: 'xylograph', types: ['journal'] }))).toHaveLength(0);
+		});
+		it('filter-only browse returns that type, no text', () => {
+			const health = search(q({ types: ['health'] }));
+			expect(health.length).toBeGreaterThan(0);
+			expect(health.every((r) => r.type === 'health')).toBe(true);
+		});
+		it('companion filter restricts', () => {
+			const mine = search(q({ companionIds: ['c-s'], types: ['health'] }));
+			expect(mine.every((r) => r.companionId === 'c-s')).toBe(true);
+			expect(search(q({ companionIds: ['nope'], types: ['health'] }))).toHaveLength(0);
+		});
+		it('date range bounds are inclusive', () => {
+			expect(
+				search(q({ types: ['health'], after: '2026-04-02', before: '2026-04-02' })).some(
+					(r) => r.date === '2026-04-02'
+				)
+			).toBe(true);
+			expect(
+				search(q({ types: ['health'], after: '2026-04-03' })).some((r) => r.date === '2026-04-02')
+			).toBe(false);
+		});
+		it('empty everything returns nothing', () => {
+			expect(search(q({}))).toEqual([]);
+		});
 	});
 });

--- a/src/lib/server/search.ts
+++ b/src/lib/server/search.ts
@@ -1,13 +1,53 @@
 import { db } from '$lib/server/db';
 
-export type SearchEntityType =
-	| 'journal'
-	| 'health'
-	| 'reminder'
-	| 'document'
-	| 'daily'
-	| 'weight'
-	| 'media';
+export const SEARCH_ENTITY_TYPES = [
+	'journal',
+	'health',
+	'reminder',
+	'document',
+	'daily',
+	'weight',
+	'media'
+] as const;
+export type SearchEntityType = (typeof SEARCH_ENTITY_TYPES)[number];
+
+export interface SearchFilters {
+	text: string;
+	companionIds: string[];
+	types: SearchEntityType[];
+	after?: string; // YYYY-MM-DD inclusive lower bound on event_date
+	before?: string; // YYYY-MM-DD inclusive upper bound
+}
+
+export function hasActiveFilters(f: SearchFilters): boolean {
+	return f.companionIds.length > 0 || f.types.length > 0 || !!f.after || !!f.before;
+}
+
+/**
+ * Build the shared filter WHERE fragment + bound params. Same-kind lists are OR
+ * (IN), different kinds are AND. Returns an empty sql string when no filters.
+ */
+export function buildFilterClause(f: SearchFilters): { sql: string; params: string[] } {
+	const parts: string[] = [];
+	const params: string[] = [];
+	if (f.companionIds.length) {
+		parts.push(`s.companion_id IN (${f.companionIds.map(() => '?').join(', ')})`);
+		params.push(...f.companionIds);
+	}
+	if (f.types.length) {
+		parts.push(`s.entity_type IN (${f.types.map(() => '?').join(', ')})`);
+		params.push(...f.types);
+	}
+	if (f.after) {
+		parts.push('s.event_date >= ?');
+		params.push(f.after);
+	}
+	if (f.before) {
+		parts.push('s.event_date <= ?');
+		params.push(f.before);
+	}
+	return { sql: parts.join(' AND '), params };
+}
 
 export interface SearchResult {
 	type: SearchEntityType;
@@ -63,22 +103,46 @@ interface SearchRow {
 }
 
 /** Members/admins only — the API route gates caretakers out with 403. */
-export function search(rawQuery: string): SearchResult[] {
-	const match = buildMatchQuery(rawQuery);
-	if (!match) return [];
-	// drizzle has no FTS5 support; raw prepared statement on the underlying client.
-	const stmt = db.$client.prepare(`
-		SELECT
-			s.entity_type, s.entity_id, s.companion_id, s.event_date, s.title,
-			snippet(search_index, 1, char(1), char(2), '…', 8) AS excerpt,
-			c.name AS companion_name
-		FROM search_index s
-		JOIN companions c ON c.id = s.companion_id
-		WHERE search_index MATCH ?
-		ORDER BY bm25(search_index), s.event_date DESC
-		LIMIT 20
-	`);
-	const rows = stmt.all(match) as SearchRow[];
+export function search(filters: SearchFilters): SearchResult[] {
+	const match = buildMatchQuery(filters.text);
+	const fc = buildFilterClause(filters);
+	let rows: SearchRow[];
+
+	if (match) {
+		const where = ['search_index MATCH ?', fc.sql].filter(Boolean).join(' AND ');
+		const stmt = db.$client.prepare(`
+			SELECT
+				s.entity_type, s.entity_id, s.companion_id, s.event_date, s.title,
+				snippet(search_index, 1, char(1), char(2), '…', 8) AS excerpt,
+				c.name AS companion_name
+			FROM search_index s
+			JOIN companions c ON c.id = s.companion_id
+			WHERE ${where}
+			ORDER BY bm25(search_index), s.event_date DESC
+			LIMIT 20
+		`);
+		rows = stmt.all(match, ...fc.params) as SearchRow[];
+	} else if (hasActiveFilters(filters)) {
+		// Browse: filters only, no MATCH. FTS5 full-scans the virtual table by the
+		// UNINDEXED columns (no B-tree index possible on an FTS5 table — do not
+		// CREATE INDEX). Plain body excerpt (no matched terms to highlight).
+		// Relies on the index only holding data the user can already read.
+		const stmt = db.$client.prepare(`
+			SELECT
+				s.entity_type, s.entity_id, s.companion_id, s.event_date, s.title,
+				substr(s.body, 1, 80) AS excerpt,
+				c.name AS companion_name
+			FROM search_index s
+			JOIN companions c ON c.id = s.companion_id
+			WHERE ${fc.sql}
+			ORDER BY s.event_date DESC
+			LIMIT 20
+		`);
+		rows = stmt.all(...fc.params) as SearchRow[];
+	} else {
+		return [];
+	}
+
 	return rows.map((r) => ({
 		type: r.entity_type,
 		id: r.entity_id,

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -270,7 +270,10 @@
 
 	<ToastRegion ariaLabel={t(locale, 'common.reminder.toastAriaRegion')} />
 
-	<SearchPalette bind:open={searchOpen} />
+	<SearchPalette
+		bind:open={searchOpen}
+		companions={data.companions.map((c) => ({ id: c.id, name: c.name }))}
+	/>
 
 	<!-- Mobile bottom nav -->
 	{#if navItems.length > 0}

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -1,26 +1,31 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
-import { search, SEARCH_ENTITY_TYPES } from '$lib/server/search';
-import type { SearchEntityType } from '$lib/server/search';
+import { search, SEARCH_ENTITY_TYPES, type SearchEntityType } from '$lib/server/search';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export const GET: RequestHandler = async ({ url, locals }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
-	// v1: members/admins only. Caretaker results would be limited to content the
-	// care UI cannot display (no date navigation); revisit with tags/part 2.
 	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
 
-	const text = url.searchParams.get('q') ?? '';
-	const companionIds = url.searchParams.getAll('companionId');
-	const rawTypes = url.searchParams.getAll('type');
-	const types = rawTypes.filter((t): t is SearchEntityType =>
-		(SEARCH_ENTITY_TYPES as readonly string[]).includes(t)
-	);
-	const after = url.searchParams.get('after') ?? undefined;
-	const before = url.searchParams.get('before') ?? undefined;
+	const p = url.searchParams;
+	const types = p
+		.getAll('type')
+		.filter((v): v is SearchEntityType => (SEARCH_ENTITY_TYPES as readonly string[]).includes(v));
+	const after = p.get('after');
+	const before = p.get('before');
 
 	try {
-		return json({ results: search({ text, companionIds, types, after, before }) });
+		return json({
+			results: search({
+				text: p.get('q') ?? '',
+				companionIds: p.getAll('companion'),
+				types,
+				after: after && DATE_RE.test(after) ? after : undefined,
+				before: before && DATE_RE.test(before) ? before : undefined
+			})
+		});
 	} catch (err) {
 		console.error('[search] query failed:', err);
 		return json({ results: [] });

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -1,7 +1,8 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { t } from '$lib/i18n';
-import { search } from '$lib/server/search';
+import { search, SEARCH_ENTITY_TYPES } from '$lib/server/search';
+import type { SearchEntityType } from '$lib/server/search';
 
 export const GET: RequestHandler = async ({ url, locals }) => {
 	if (!locals.user) error(401, t(locals.locale, 'error.unauthorized'));
@@ -9,9 +10,17 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	// care UI cannot display (no date navigation); revisit with tags/part 2.
 	if (locals.user.role === 'caretaker') error(403, t(locals.locale, 'error.forbidden'));
 
-	const q = url.searchParams.get('q') ?? '';
+	const text = url.searchParams.get('q') ?? '';
+	const companionIds = url.searchParams.getAll('companionId');
+	const rawTypes = url.searchParams.getAll('type');
+	const types = rawTypes.filter((t): t is SearchEntityType =>
+		(SEARCH_ENTITY_TYPES as readonly string[]).includes(t)
+	);
+	const after = url.searchParams.get('after') ?? undefined;
+	const before = url.searchParams.get('before') ?? undefined;
+
 	try {
-		return json({ results: search(q) });
+		return json({ results: search({ text, companionIds, types, after, before }) });
 	} catch (err) {
 		console.error('[search] query failed:', err);
 		return json({ results: [] });

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,6 +1,22 @@
+import { type Page } from '@playwright/test';
 import { test, expect } from '../lib/fixtures';
 
 const COMP = 'seed-comp-biscuit';
+
+// Select a sigil filter option. Fills the input with the full sigil token so
+// the reactive effect narrows the popup to its first match, then presses Enter
+// to commit the selection through the component's own keydown handler (the
+// input keeps focus after fill(), so Enter reaches handleKeydown's
+// autocomplete-open branch).
+async function selectSigilOption(page: Page, fullSigil: string, optionLabel: string) {
+	const input = page.locator('input[role="combobox"]');
+	await input.fill(fullSigil);
+	const sigilPopup = page.locator('#search-sigil-popup');
+	await expect(sigilPopup).toBeVisible({ timeout: 8_000 });
+	await expect(page.locator('#sigil-option-0')).toContainText(optionLabel, { timeout: 8_000 });
+	await input.press('Enter');
+	await expect(sigilPopup).toBeHidden({ timeout: 8_000 });
+}
 
 test.describe('global search palette', () => {
 	test('shortcut opens palette and seed journal entry navigates on Enter', async ({ asMember }) => {
@@ -219,5 +235,172 @@ test.describe('global search palette', () => {
 		// URL should have changed away from the start page and into seed-comp-biscuit
 		await expect(asMember).not.toHaveURL(startUrl, { timeout: 8_000 });
 		await expect(asMember).toHaveURL(new RegExp(`/${COMP}/`), { timeout: 8_000 });
+	});
+
+	// ---- Filter tests ----
+
+	test('#type filter narrows results to health only', async ({ asMember }) => {
+		await asMember.goto('/');
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		// Select the Health type filter via the sigil popup
+		await selectSigilOption(asMember, '#health', 'Health');
+
+		// A Health chip should appear — check on the full page first for debugging
+		await expect(asMember.getByRole('button', { name: 'Remove Health filter' })).toBeVisible({
+			timeout: 8_000
+		});
+
+		// Now search for "Seed"
+		await asMember.keyboard.type('Seed');
+
+		// The health result should appear
+		await expect(dialog.getByText('Seed checkup')).toBeVisible({ timeout: 8_000 });
+
+		// No Journal group heading should be present in the results list
+		await expect(
+			dialog.locator('#search-results').getByText('Journal', { exact: true })
+		).toHaveCount(0, { timeout: 8_000 });
+	});
+
+	test('@companion filter scopes results to Biscuit', async ({ asMember }) => {
+		await asMember.goto('/');
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		// Select the Biscuit companion filter via the sigil popup
+		await selectSigilOption(asMember, '@biscuit', 'Biscuit');
+
+		// Biscuit chip should appear
+		const biscuitChip = dialog.getByRole('button', { name: 'Remove Biscuit filter' });
+		await expect(biscuitChip).toBeVisible({ timeout: 8_000 });
+
+		// Search for "Seed"
+		await asMember.keyboard.type('Seed');
+
+		// A result should appear with Biscuit as companion badge
+		await expect(dialog.locator('[role="option"]').first()).toBeVisible({ timeout: 8_000 });
+		await expect(dialog.locator('[role="option"]').first()).toContainText('Biscuit');
+	});
+
+	test('date after filter excludes then includes Seed checkup', async ({ asMember }) => {
+		await asMember.goto('/');
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		// Select #health filter via keyboard
+		await selectSigilOption(asMember, '#health', 'Health');
+		await expect(dialog.getByRole('button', { name: 'Remove Health filter' })).toBeVisible({
+			timeout: 8_000
+		});
+
+		// With no text, filter-only browse shows Seed checkup
+		await expect(dialog.getByText('Seed checkup')).toBeVisible({ timeout: 8_000 });
+
+		// Set after date past the health event date — it should disappear
+		await asMember.fill('input[name="after"]', '2026-03-02');
+		await expect(dialog.getByText('Seed checkup')).toBeHidden({ timeout: 8_000 });
+
+		// Clear the after filter — Seed checkup should reappear
+		await asMember.fill('input[name="after"]', '');
+		await expect(dialog.getByText('Seed checkup')).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('filter-only browse: #reminder shows Seed vet visit', async ({ asMember }) => {
+		await asMember.goto('/');
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		// Select the Reminders type filter via the sigil popup
+		await selectSigilOption(asMember, '#reminder', 'Reminders');
+
+		// With no text, browse shows Seed vet visit under Reminders group.
+		// Scope the group-heading check to the results listbox so it doesn't
+		// also match the "Reminders" filter chip (same localized label).
+		await expect(dialog.getByText('Seed vet visit')).toBeVisible({ timeout: 8_000 });
+		await expect(
+			dialog.locator('#search-results').getByText('Reminders', { exact: true })
+		).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('combined #health + @biscuit filter shows Seed checkup', async ({ asMember }) => {
+		await asMember.goto('/');
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		// Select #health filter via keyboard
+		await selectSigilOption(asMember, '#health', 'Health');
+		await expect(dialog.getByRole('button', { name: 'Remove Health filter' })).toBeVisible({
+			timeout: 8_000
+		});
+
+		// Select @biscuit companion filter via keyboard
+		await selectSigilOption(asMember, '@biscuit', 'Biscuit');
+		await expect(dialog.getByRole('button', { name: 'Remove Biscuit filter' })).toBeVisible({
+			timeout: 8_000
+		});
+
+		// Type "Seed" — health result for Biscuit should appear
+		await asMember.keyboard.type('Seed');
+		await expect(dialog.getByText('Seed checkup')).toBeVisible({ timeout: 8_000 });
+		// Companion badge should say Biscuit
+		await expect(dialog.locator('[role="option"]').first()).toContainText('Biscuit');
+	});
+
+	test('removing health chip broadens results to include journal', async ({ asMember }) => {
+		await asMember.goto('/');
+		await expect(asMember.getByRole('button', { name: 'Open search' })).toBeVisible({
+			timeout: 8_000
+		});
+		await asMember.getByRole('button', { name: 'Open search' }).click();
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		// Select #health filter via keyboard
+		await selectSigilOption(asMember, '#health', 'Health');
+		await expect(dialog.getByRole('button', { name: 'Remove Health filter' })).toBeVisible({
+			timeout: 8_000
+		});
+
+		// Search "Seed" — with health filter, only health results visible; no Journal group
+		await asMember.keyboard.type('Seed');
+		await expect(dialog.getByText('Seed checkup')).toBeVisible({ timeout: 8_000 });
+		await expect(
+			dialog.locator('#search-results').getByText('Journal', { exact: true })
+		).toHaveCount(0, { timeout: 8_000 });
+
+		// Remove the Health chip
+		await dialog.getByRole('button', { name: 'Remove Health filter' }).click();
+
+		// Journal group should now appear in the results list (seed 'Seed journal entry')
+		await expect(
+			dialog.locator('#search-results').getByText('Journal', { exact: true })
+		).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('caretaker gets 403 on /api/search with type filter', async ({ asCaretaker }) => {
+		const res = await asCaretaker.request.get('/api/search?q=seed&type=health');
+		expect(res.status()).toBe(403);
 	});
 });

--- a/tests/lib/seed.ts
+++ b/tests/lib/seed.ts
@@ -97,7 +97,7 @@ export function createSeededDb(dir: string): string {
 			companionId: SEED.companions.biscuit.id,
 			type: 'vet_visit',
 			title: 'Seed checkup',
-			occurredAt: new Date(now - 60 * day),
+			occurredAt: new Date('2026-03-01T12:00:00Z'),
 			loggedBy: SEED.member.id
 		})
 		.run();


### PR DESCRIPTION
Adds scoping filters to the search palette, completing #10. Builds on the merged full-text search (#109).

## Filters
- `@companion` — filter content by companion (sigil autocomplete → chip). Multiple allowed, OR within.
- `#type` — filter by content type (journal/daily/health/weight/reminder/document/media). Multiple, OR within.
- Date range — before/after, inclusive, AND-ed.
- Combination: OR within a kind, AND across kinds.
- Filter-only browse: filters with no text term run a WHERE-only query, newest-first, LIMIT 20.

## Implementation
- Query layer (`search.ts`): `buildFilterClause` (parameterized `IN` lists + `event_date` bounds), three branches — MATCH+filters, filter-only browse, empty→[] guard.
- API: repeatable `type=` (validated against the known set) and `companion=`, `after`/`before` validated `^\d{4}-\d{2}-\d{2}$`. 401 anon / 403 caretaker unchanged.
- Sigil parser (`searchSigil.ts`): trailing `@`/`#` token only; `a@b` does not trigger.
- Palette UI: sigil autocomplete popup → removable chips, native date inputs, Backspace removes last chip (LIFO), ARIA controls/activedescendant swap between results and popup.
- i18n: 7 new keys across all 6 locales.
- Seed: pinned the health event date so date-range tests don't drift.

## Notable fix
The sigil autocomplete `$effect` read the `sigilItems` state it had just written in the same run — a self-dependency that re-triggered the effect unboundedly and clobbered filter selection. Fixed by computing the list into a local and branching on that.

## Verification
- Unit 111/111, e2e 107/107, filter e2e flake-checked (32/32 over repeats).
- `db:generate` reports no schema change.
- lint + check clean.