### PR TITLE
fix: notifications card describes the enabled channel (#113)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "einvault",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "einvault",
-			"version": "0.15.0",
+			"version": "0.15.1",
 			"dependencies": {
 				"@fontsource-variable/fraunces": "5.2.9",
 				"@fontsource-variable/geist": "5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "einvault",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",

--- a/src/lib/components/settings/NotificationsCard.svelte
+++ b/src/lib/components/settings/NotificationsCard.svelte
@@ -54,6 +54,16 @@
 	};
 
 	const emailControlsDisabled = $derived(!hasEmail || submitting);
+
+	// Lead-in copy must match the channels the admin actually enabled, so an
+	// email-only sentence is not shown when only ntfy push is configured.
+	const descriptionKey = $derived(
+		mailEnabled && ntfyEnabled
+			? 'page.settings.notificationsDescriptionBoth'
+			: ntfyEnabled
+				? 'page.settings.notificationsDescriptionNtfy'
+				: 'page.settings.notificationsDescription'
+	);
 </script>
 
 <Card>
@@ -62,7 +72,7 @@
 	</CardHeader>
 	<CardContent>
 		<p class="text-sm text-muted-foreground mb-3">
-			{t(locale, 'page.settings.notificationsDescription')}
+			{t(locale, descriptionKey)}
 		</p>
 		{#if successMessage}
 			<Alert variant="success" class="mb-3">

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -245,6 +245,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsCard': 'Benachrichtigungen',
 	'page.settings.notificationsDescription':
 		'Erhalte E-Mails von EinVault. Betreuer werden nur über Erinnerungen für zugewiesene Gefährten benachrichtigt.',
+	'page.settings.notificationsDescriptionNtfy':
+		'Erhalte Push-Benachrichtigungen von EinVault. Betreuer werden nur über Erinnerungen für zugewiesene Gefährten benachrichtigt.',
+	'page.settings.notificationsDescriptionBoth':
+		'Erhalte E-Mails und Push-Benachrichtigungen von EinVault. Betreuer werden nur über Erinnerungen für zugewiesene Gefährten benachrichtigt.',
 	'page.settings.notifyReminderEmailLabel': 'E-Mail senden, wenn eine Erinnerung fällig ist',
 	'page.settings.notifyShiftEmailLabel':
 		'E-Mail senden, 24 Stunden bevor eine Schicht beginnt oder endet',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -232,6 +232,10 @@ const messages = {
 	'page.settings.notificationsCard': 'Notifications',
 	'page.settings.notificationsDescription':
 		'Get emails from EinVault. Caretakers are only notified about reminders for companions assigned to them.',
+	'page.settings.notificationsDescriptionNtfy':
+		'Get push notifications from EinVault. Caretakers are only notified about reminders for companions assigned to them.',
+	'page.settings.notificationsDescriptionBoth':
+		'Get emails and push notifications from EinVault. Caretakers are only notified about reminders for companions assigned to them.',
 	'page.settings.notifyReminderEmailLabel': 'Email me when a reminder is due',
 	'page.settings.notifyShiftEmailLabel': 'Email me 24 hours before a shift starts or ends',
 	'page.settings.notificationsUpdated': 'Notification settings updated.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -245,6 +245,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsCard': 'Notificaciones',
 	'page.settings.notificationsDescription':
 		'Recibe correos de EinVault. Los cuidadores solo reciben avisos de recordatorios de los compañeros que tienen asignados.',
+	'page.settings.notificationsDescriptionNtfy':
+		'Recibe notificaciones push de EinVault. Los cuidadores solo reciben avisos de recordatorios de los compañeros que tienen asignados.',
+	'page.settings.notificationsDescriptionBoth':
+		'Recibe correos y notificaciones push de EinVault. Los cuidadores solo reciben avisos de recordatorios de los compañeros que tienen asignados.',
 	'page.settings.notifyReminderEmailLabel': 'Enviarme un correo cuando venza un recordatorio',
 	'page.settings.notifyShiftEmailLabel':
 		'Enviarme un correo 24 horas antes de que un turno empiece o termine',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -243,6 +243,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsCard': 'Notifications',
 	'page.settings.notificationsDescription':
 		"Recevez des e-mails d'EinVault. Les soignants ne sont notifiés que des rappels des compagnons qui leur sont assignés.",
+	'page.settings.notificationsDescriptionNtfy':
+		"Recevez des notifications push d'EinVault. Les soignants ne sont notifiés que des rappels des compagnons qui leur sont assignés.",
+	'page.settings.notificationsDescriptionBoth':
+		"Recevez des e-mails et des notifications push d'EinVault. Les soignants ne sont notifiés que des rappels des compagnons qui leur sont assignés.",
 	'page.settings.notifyReminderEmailLabel': "M'envoyer un e-mail quand un rappel est dû",
 	'page.settings.notifyShiftEmailLabel':
 		"M'envoyer un e-mail 24 heures avant le début ou la fin d'une garde",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -241,6 +241,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsCard': 'Notifiche',
 	'page.settings.notificationsDescription':
 		'Ricevi e-mail da EinVault. I custodi ricevono avvisi solo per i promemoria dei compagni a loro assegnati.',
+	'page.settings.notificationsDescriptionNtfy':
+		'Ricevi notifiche push da EinVault. I custodi ricevono avvisi solo per i promemoria dei compagni a loro assegnati.',
+	'page.settings.notificationsDescriptionBoth':
+		'Ricevi e-mail e notifiche push da EinVault. I custodi ricevono avvisi solo per i promemoria dei compagni a loro assegnati.',
 	'page.settings.notifyReminderEmailLabel': 'Inviami una e-mail quando un promemoria è in scadenza',
 	'page.settings.notifyShiftEmailLabel':
 		'Inviami una e-mail 24 ore prima che un turno inizi o finisca',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -242,6 +242,10 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.notificationsCard': 'Notificações',
 	'page.settings.notificationsDescription':
 		'Receba e-mails do EinVault. Cuidadores só são notificados sobre lembretes dos companheiros atribuídos a eles.',
+	'page.settings.notificationsDescriptionNtfy':
+		'Receba notificações push do EinVault. Cuidadores só são notificados sobre lembretes dos companheiros atribuídos a eles.',
+	'page.settings.notificationsDescriptionBoth':
+		'Receba e-mails e notificações push do EinVault. Cuidadores só são notificados sobre lembretes dos companheiros atribuídos a eles.',
 	'page.settings.notifyReminderEmailLabel': 'Enviar e-mail quando um lembrete vencer',
 	'page.settings.notifyShiftEmailLabel':
 		'Enviar e-mail 24 horas antes de um turno começar ou terminar',

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -290,3 +290,26 @@ test('shift start email fires for caretaker', async ({ world, browser }) => {
 	expect(bodyText).toMatch(/Seed Caretaker/);
 	expect(bodyText).toMatch(/begins a care shift/);
 });
+
+// Regression (#113): with email disabled and ntfy enabled, the notifications
+// card lead-in must describe push, not email.
+base('notifications card describes push when only ntfy is enabled', async ({ page }, testInfo) => {
+	const dir = path.join(REPO_ROOT, '.test-data', `notif-ntfyonly-${testInfo.workerIndex}-${testInfo.testId}`);
+	const ntfy = await startNtfyFake();
+	const dbPath = createSeededDb(dir);
+	const server = await startAppServer({ dbPath, env: { NTFY_URL: ntfy.url } });
+	try {
+		await login(page, server.baseURL, SEED.member.username);
+		await page.goto(server.baseURL + '/settings');
+		await expect(page.getByText('Get push notifications from EinVault')).toBeVisible({
+			timeout: 8_000
+		});
+		await expect(page.getByText('Get emails from EinVault')).toHaveCount(0);
+		// The ntfy topic field is present (proves we're looking at the right card).
+		await expect(page.getByLabel('ntfy topic')).toBeVisible({ timeout: 8_000 });
+	} finally {
+		await server.stop();
+		await ntfy.stop();
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -294,7 +294,11 @@ test('shift start email fires for caretaker', async ({ world, browser }) => {
 // Regression (#113): with email disabled and ntfy enabled, the notifications
 // card lead-in must describe push, not email.
 base('notifications card describes push when only ntfy is enabled', async ({ page }, testInfo) => {
-	const dir = path.join(REPO_ROOT, '.test-data', `notif-ntfyonly-${testInfo.workerIndex}-${testInfo.testId}`);
+	const dir = path.join(
+		REPO_ROOT,
+		'.test-data',
+		`notif-ntfyonly-${testInfo.workerIndex}-${testInfo.testId}`
+	);
 	const ntfy = await startNtfyFake();
 	const dbPath = createSeededDb(dir);
 	const server = await startAppServer({ dbPath, env: { NTFY_URL: ntfy.url } });


### PR DESCRIPTION
Closes #113.

The Notifications settings card always rendered email-specific copy ("Get emails from EinVault...") regardless of which channels the admin enabled. With email disabled and ntfy enabled, the lead-in was wrong (see the issue screenshot).

## Fix
The description now matches the configured channels:
- email only: "Get emails from EinVault. ..."
- push only: "Get push notifications from EinVault. ..."
- both: "Get emails and push notifications from EinVault. ..."

The caretaker clause is unchanged since it applies to either channel. New keys added across all six locales.

## Tests
Added a regression e2e that boots a ntfy-only server (email disabled) and asserts the card shows the push lead-in and not the email one. Existing notifications e2e still pass.