### PR TITLE
Redesign SP2: IA & Navigation

### DIFF
--- a/src/lib/components/shell/AccountSheet.svelte
+++ b/src/lib/components/shell/AccountSheet.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 	import { Settings, LogOut, ShieldCheck, PawPrint, X } from '@lucide/svelte';
+	import { tick } from 'svelte';
 	import { t, getLocale } from '$lib/i18n';
 
 	type User = {
@@ -21,9 +22,23 @@
 	let { user, open, onclose, variant = 'sheet' }: Props = $props();
 	const locale = getLocale();
 
+	let dialogEl = $state<HTMLElement | null>(null);
+	let triggerEl = $state<HTMLElement | null>(null);
+
 	function onkeydown(e: KeyboardEvent) {
 		if (e.key === 'Escape') onclose();
 	}
+
+	$effect(() => {
+		if (open) {
+			triggerEl = document.activeElement as HTMLElement | null;
+			tick().then(() => {
+				dialogEl?.querySelector<HTMLElement>('[href], button:not([disabled])')?.focus();
+			});
+		} else {
+			tick().then(() => triggerEl?.focus());
+		}
+	});
 </script>
 
 {#if open}
@@ -33,10 +48,12 @@
 			? 'bg-black/50 backdrop-blur-sm'
 			: ''}"
 		aria-label={t(locale, 'aria.closeAccountMenu')}
+		aria-hidden="true"
 		onclick={onclose}
 		tabindex="-1"
 	></button>
 	<div
+		bind:this={dialogEl}
 		role="dialog"
 		aria-modal="true"
 		aria-label={t(locale, 'aria.accountMenu')}

--- a/src/lib/components/shell/AccountSheet.svelte
+++ b/src/lib/components/shell/AccountSheet.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import UserAvatar from '$lib/components/UserAvatar.svelte';
+	import { Settings, LogOut, ShieldCheck, PawPrint, X } from '@lucide/svelte';
+	import { t, getLocale } from '$lib/i18n';
+
+	type User = {
+		id: string;
+		displayName: string;
+		role: 'admin' | 'member' | 'caretaker';
+		avatarPath?: string | null;
+	};
+
+	interface Props {
+		user: User;
+		open: boolean;
+		onclose: () => void;
+		/** 'sheet' = mobile bottom sheet; 'popover' = desktop sidebar popover. */
+		variant?: 'sheet' | 'popover';
+	}
+
+	let { user, open, onclose, variant = 'sheet' }: Props = $props();
+	const locale = getLocale();
+
+	function onkeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onclose();
+	}
+</script>
+
+{#if open}
+	<button
+		type="button"
+		class="fixed inset-0 z-40 cursor-default {variant === 'sheet'
+			? 'bg-black/50 backdrop-blur-sm'
+			: ''}"
+		aria-label={t(locale, 'aria.closeAccountMenu')}
+		onclick={onclose}
+		tabindex="-1"
+	></button>
+	<div
+		role="dialog"
+		aria-modal="true"
+		aria-label={t(locale, 'aria.accountMenu')}
+		tabindex="-1"
+		{onkeydown}
+		class={variant === 'sheet'
+			? 'fixed inset-x-0 bottom-0 z-50 rounded-t-2xl border-t border-border bg-popover pb-safe shadow-xl animate-in slide-in-from-bottom-4 duration-200'
+			: 'absolute bottom-full left-0 right-0 z-50 mb-2 rounded-xl border border-border bg-popover shadow-xl'}
+	>
+		<div class="flex items-center gap-3 px-4 py-3 border-b border-border">
+			<UserAvatar
+				userId={user.id}
+				displayName={user.displayName}
+				avatarPath={user.avatarPath}
+				size="sm"
+			/>
+			<div class="min-w-0 flex-1">
+				<p class="text-sm font-semibold text-foreground truncate">{user.displayName}</p>
+				<p class="text-[11px] text-muted-foreground capitalize">{user.role}</p>
+			</div>
+			{#if variant === 'sheet'}
+				<button
+					type="button"
+					onclick={onclose}
+					aria-label={t(locale, 'aria.closeAccountMenu')}
+					class="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-accent"
+				>
+					<X class="h-4 w-4" />
+				</button>
+			{/if}
+		</div>
+
+		<div class="py-1">
+			<a
+				href="/settings"
+				onclick={onclose}
+				class="flex items-center gap-3 px-4 py-2.5 text-sm text-foreground hover:bg-accent transition-colors"
+			>
+				<Settings class="h-4 w-4 shrink-0 text-muted-foreground" />{t(locale, 'nav.settings')}
+			</a>
+
+			{#if user.role === 'admin'}
+				<p
+					class="px-4 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60"
+				>
+					{t(locale, 'nav.admin')}
+				</p>
+				<a
+					href="/admin/users"
+					onclick={onclose}
+					class="flex items-center gap-3 px-4 py-2.5 text-sm text-foreground hover:bg-accent transition-colors"
+				>
+					<ShieldCheck class="h-4 w-4 shrink-0 text-muted-foreground" />{t(locale, 'nav.members')}
+				</a>
+				<a
+					href="/admin/companions"
+					onclick={onclose}
+					class="flex items-center gap-3 px-4 py-2.5 text-sm text-foreground hover:bg-accent transition-colors"
+				>
+					<PawPrint class="h-4 w-4 shrink-0 text-muted-foreground" />{t(
+						locale,
+						'nav.adminCompanions'
+					)}
+				</a>
+			{/if}
+
+			<div class="my-1 h-px bg-border"></div>
+			<form method="POST" action="/auth/logout">
+				<button
+					type="submit"
+					class="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-foreground hover:bg-accent transition-colors"
+				>
+					<LogOut class="h-4 w-4 shrink-0 text-muted-foreground" />{t(locale, 'nav.signOut')}
+				</button>
+			</form>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/shell/AccountSheet.svelte
+++ b/src/lib/components/shell/AccountSheet.svelte
@@ -47,7 +47,6 @@
 		class="fixed inset-0 z-40 cursor-default {variant === 'sheet'
 			? 'bg-black/50 backdrop-blur-sm'
 			: ''}"
-		aria-label={t(locale, 'aria.closeAccountMenu')}
 		aria-hidden="true"
 		onclick={onclose}
 		tabindex="-1"

--- a/src/lib/components/shell/AppMobileNav.svelte
+++ b/src/lib/components/shell/AppMobileNav.svelte
@@ -114,7 +114,9 @@
 	// FAB menu state
 	let fabOpen = $state(false);
 
-	const FAB_ICONS: Record<string, typeof BookOpen> = {
+	type FabKey = 'journal' | 'health' | 'reminders' | 'weight';
+
+	const FAB_ICONS: Record<FabKey, typeof BookOpen> = {
 		journal: BookOpen,
 		health: Activity,
 		reminders: Bell,
@@ -262,7 +264,7 @@
 						class="absolute bottom-full mb-3 left-1/2 -translate-x-1/2 z-50 bg-popover border border-border rounded-2xl shadow-xl overflow-hidden min-w-[200px]"
 					>
 						{#each fabActions as action (action.key)}
-							{@const ActionIcon = FAB_ICONS[action.key]}
+							{@const ActionIcon = FAB_ICONS[action.key as FabKey]}
 							<a
 								href={action.href}
 								onclick={() => (fabOpen = false)}

--- a/src/lib/components/shell/AppMobileNav.svelte
+++ b/src/lib/components/shell/AppMobileNav.svelte
@@ -18,6 +18,7 @@
 		FileText
 	} from '@lucide/svelte';
 	import { t, getLocale } from '$lib/i18n';
+	import { currentFabSection, orderFabActions } from '$lib/nav/fabSections';
 	import type { CareStatus } from '$lib/careStatus';
 	import AccountSheet from './AccountSheet.svelte';
 
@@ -113,22 +114,40 @@
 	// FAB menu state
 	let fabOpen = $state(false);
 
+	const FAB_ICONS: Record<string, typeof BookOpen> = {
+		journal: BookOpen,
+		health: Activity,
+		reminders: Bell,
+		weight: Weight
+	};
+
 	let fabActions = $derived(
 		activeCompanion
-			? [
-					{
-						href: `/${activeCompanion.id}/journal/${today}`,
-						label: 'Add journal entry',
-						icon: BookOpen
-					},
-					{
-						href: `/${activeCompanion.id}/health?new=1`,
-						label: 'Log health event',
-						icon: Activity
-					},
-					{ href: `/${activeCompanion.id}/reminders?new=1`, label: 'Add reminder', icon: Bell },
-					{ href: `/${activeCompanion.id}/health?new=weight`, label: 'Record weight', icon: Weight }
-				]
+			? orderFabActions(
+					[
+						{
+							key: 'journal',
+							href: `/${activeCompanion.id}/journal/${today}`,
+							label: t(locale, 'nav.fab.addJournal')
+						},
+						{
+							key: 'health',
+							href: `/${activeCompanion.id}/health?new=1`,
+							label: t(locale, 'nav.fab.logHealth')
+						},
+						{
+							key: 'reminders',
+							href: `/${activeCompanion.id}/reminders?new=1`,
+							label: t(locale, 'nav.fab.addReminder')
+						},
+						{
+							key: 'weight',
+							href: `/${activeCompanion.id}/health?new=weight`,
+							label: t(locale, 'nav.fab.recordWeight')
+						}
+					],
+					currentFabSection(page.url.pathname)
+				)
 			: []
 	);
 
@@ -236,20 +255,26 @@
 						type="button"
 						class="fixed inset-0 z-40 cursor-default"
 						onclick={() => (fabOpen = false)}
-						aria-label="Close quick add menu"
+						aria-label={t(locale, 'aria.closeQuickAdd')}
 						tabindex="-1"
 					></button>
 					<div
 						class="absolute bottom-full mb-3 left-1/2 -translate-x-1/2 z-50 bg-popover border border-border rounded-2xl shadow-xl overflow-hidden min-w-[200px]"
 					>
-						{#each fabActions as action (action.label)}
-							{@const ActionIcon = action.icon}
+						{#each fabActions as action (action.key)}
+							{@const ActionIcon = FAB_ICONS[action.key]}
 							<a
 								href={action.href}
 								onclick={() => (fabOpen = false)}
-								class="flex items-center gap-3 px-4 py-3 text-sm text-foreground transition-colors hover:bg-accent"
+								class="flex items-center gap-3 px-4 py-3 text-sm transition-colors hover:bg-accent {action.highlight
+									? 'bg-primary/10 text-primary font-medium'
+									: 'text-foreground'}"
 							>
-								<ActionIcon class="h-4 w-4 shrink-0 text-muted-foreground" />
+								<ActionIcon
+									class="h-4 w-4 shrink-0 {action.highlight
+										? 'text-primary'
+										: 'text-muted-foreground'}"
+								/>
 								{action.label}
 							</a>
 						{/each}
@@ -261,7 +286,7 @@
 					type="button"
 					onclick={() => (fabOpen = !fabOpen)}
 					onkeydown={handleFabKeydown}
-					aria-label="Quick add"
+					aria-label={t(locale, 'nav.fab.quickAdd')}
 					aria-expanded={fabOpen}
 					class="relative -top-3 h-12 w-12 rounded-full flex items-center justify-center text-white shadow-lg transition-transform hover:scale-105 active:scale-95"
 					style="background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary) / 0.7)); box-shadow: 0 8px 20px hsl(var(--primary) / 0.4);"

--- a/src/lib/components/shell/AppMobileNav.svelte
+++ b/src/lib/components/shell/AppMobileNav.svelte
@@ -264,7 +264,7 @@
 						class="absolute bottom-full mb-3 left-1/2 -translate-x-1/2 z-50 bg-popover border border-border rounded-2xl shadow-xl overflow-hidden min-w-[200px]"
 					>
 						{#each fabActions as action (action.key)}
-							{@const ActionIcon = FAB_ICONS[action.key as FabKey]}
+							{@const ActionIcon = FAB_ICONS[action.key as FabKey] ?? BookOpen}
 							<a
 								href={action.href}
 								onclick={() => (fabOpen = false)}

--- a/src/lib/components/shell/AppMobileNav.svelte
+++ b/src/lib/components/shell/AppMobileNav.svelte
@@ -10,7 +10,6 @@
 		Bell,
 		Search,
 		LayoutGrid,
-		Users,
 		UserRound,
 		Plus,
 		Activity,
@@ -20,6 +19,7 @@
 	} from '@lucide/svelte';
 	import { t, getLocale } from '$lib/i18n';
 	import type { CareStatus } from '$lib/careStatus';
+	import AccountSheet from './AccountSheet.svelte';
 
 	type Companion = {
 		id: string;
@@ -60,6 +60,8 @@
 
 	let isCompanionContext = $derived(activeCompanion !== null);
 
+	let accountOpen = $state(false);
+
 	// Companion context nav tabs (4 + central FAB)
 	let companionTabs = $derived(
 		activeCompanion
@@ -85,20 +87,23 @@
 			: []
 	);
 
-	// Overview context tabs (4 + no FAB; we insert FAB at position 2)
+	// Overview context tabs (3 equal tabs, no FAB)
 	let overviewTabs = $derived([
 		{ href: '/', label: t(locale, 'nav.overview'), icon: LayoutGrid, key: 'overview' },
 		{
 			href: '#search',
-			label: 'Search',
+			label: t(locale, 'nav.search'),
 			icon: Search,
 			key: 'search',
 			action: () => onOpenSearch()
 		},
-		...(user?.role === 'admin'
-			? [{ href: '/admin/users', label: 'Members', icon: Users, key: 'members' }]
-			: []),
-		{ href: '/settings', label: 'You', icon: UserRound, key: 'you' }
+		{
+			href: '#you',
+			label: t(locale, 'nav.you'),
+			icon: UserRound,
+			key: 'you',
+			action: () => (accountOpen = true)
+		}
 	]);
 
 	// FAB menu state
@@ -277,20 +282,20 @@
 				</a>
 			{/each}
 		{:else}
-			<!-- Overview context: 4 equal tabs, no FAB -->
+			<!-- Overview context: 3 equal tabs, no FAB -->
 			{#each overviewTabs as tab (tab.key)}
-				{@const isSearch = tab.key === 'search'}
-				{@const active = !isSearch && isTabActive(tab.href)}
+				{@const isAction = tab.key === 'search' || tab.key === 'you'}
+				{@const active = !isAction && isTabActive(tab.href)}
 				{@const TabIcon = tab.icon}
-				{#if isSearch}
+				{#if isAction}
 					<button
 						type="button"
-						onclick={onOpenSearch}
-						aria-label={t(locale, 'aria.openSearch')}
+						onclick={tab.action}
+						aria-label={tab.label}
 						class="flex flex-1 flex-col items-center gap-0.5 py-2 text-[10px] font-medium text-muted-foreground transition-colors min-h-[56px] justify-end pb-2 hover:text-foreground"
 					>
 						<TabIcon class="h-5 w-5 mb-0.5" />
-						Search
+						{tab.label}
 					</button>
 				{:else}
 					<a
@@ -308,3 +313,7 @@
 		{/if}
 	</div>
 </nav>
+
+{#if user && !isCompanionContext}
+	<AccountSheet {user} open={accountOpen} onclose={() => (accountOpen = false)} variant="sheet" />
+{/if}

--- a/src/lib/components/shell/AppMobileNav.svelte
+++ b/src/lib/components/shell/AppMobileNav.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
-	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
+	import CompanionSwitcher from './CompanionSwitcher.svelte';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 	import PawLogo from '$lib/components/PawLogo.svelte';
 	import {
@@ -17,8 +16,7 @@
 		Activity,
 		BookOpen,
 		Weight,
-		FileText,
-		ChevronDown
+		FileText
 	} from '@lucide/svelte';
 	import { t, getLocale } from '$lib/i18n';
 	import type { CareStatus } from '$lib/careStatus';
@@ -59,26 +57,6 @@
 	}: Props = $props();
 
 	const locale = getLocale();
-
-	function statusDotClass(id: string): string {
-		const s = companionStatus[id] ?? 'up-to-date';
-		if (s === 'needs-attention') return 'bg-coral';
-		if (s === 'due-today') return 'bg-gold';
-		return 'bg-teal';
-	}
-
-	function statusTitle(id: string): string {
-		const s = companionStatus[id] ?? 'up-to-date';
-		if (s === 'needs-attention') return t(locale, 'overview.careStatus.needsAttention');
-		if (s === 'due-today') return t(locale, 'overview.careStatus.dueToday');
-		return t(locale, 'overview.careStatus.upToDate');
-	}
-
-	const OVERVIEW_VALUE = '__overview__';
-
-	let isOverview = $derived(
-		activeCompanion === null && page.url.pathname === '/' && companions.length > 1
-	);
 
 	let isCompanionContext = $derived(activeCompanion !== null);
 
@@ -145,28 +123,6 @@
 			: []
 	);
 
-	// Companion switcher state
-	let switcherOpen = $state(false);
-
-	function switchCompanion(id: string) {
-		switcherOpen = false;
-		if (id === OVERVIEW_VALUE) {
-			goto('/');
-			return;
-		}
-		const parts = page.url.pathname.split('/');
-		if (parts[1] === activeCompanion?.id) {
-			const section = parts.slice(2).join('/');
-			goto(`/${id}${section ? `/${section}` : ''}`);
-		} else {
-			goto(`/${id}`);
-		}
-	}
-
-	function handleSwitcherKeydown(e: KeyboardEvent) {
-		if (e.key === 'Escape') switcherOpen = false;
-	}
-
 	function handleFabKeydown(e: KeyboardEvent) {
 		if (e.key === 'Escape') fabOpen = false;
 	}
@@ -184,100 +140,9 @@
 >
 	<div class="flex h-14 items-center gap-3 px-4">
 		{#if isCompanionContext && activeCompanion}
-			<!-- Companion switcher -->
-			{#if companions.length > 1}
-				<div class="relative flex-1 min-w-0" role="none">
-					<button
-						type="button"
-						onclick={() => (switcherOpen = !switcherOpen)}
-						onkeydown={handleSwitcherKeydown}
-						aria-label={t(locale, 'layout.switchCompanion')}
-						aria-expanded={switcherOpen}
-						aria-haspopup="listbox"
-						class="flex w-full items-center gap-2.5 rounded-xl px-2 py-1.5 text-left transition-colors hover:bg-accent min-w-0"
-					>
-						<CompanionAvatar
-							companionId={activeCompanion.id}
-							avatarPath={activeCompanion.avatarPath}
-							name={activeCompanion.name}
-							size="sm"
-						/>
-						<span class="flex-1 min-w-0 font-semibold text-sm text-foreground truncate">
-							{activeCompanion.name}
-						</span>
-						<ChevronDown
-							class="h-4 w-4 shrink-0 text-muted-foreground transition-transform {switcherOpen
-								? 'rotate-180'
-								: ''}"
-						/>
-					</button>
-
-					{#if switcherOpen}
-						<button
-							type="button"
-							class="fixed inset-0 z-40 cursor-default"
-							onclick={() => (switcherOpen = false)}
-							aria-label="Close companion switcher"
-							tabindex="-1"
-						></button>
-						<ul
-							role="listbox"
-							aria-label={t(locale, 'layout.switchCompanion')}
-							class="absolute left-0 right-0 top-full z-50 mt-1 overflow-hidden rounded-xl border border-border bg-popover py-1 shadow-lg"
-						>
-							<li role="option" aria-selected={isOverview}>
-								<button
-									type="button"
-									onclick={() => switchCompanion(OVERVIEW_VALUE)}
-									class="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground {isOverview
-										? 'bg-accent text-foreground'
-										: ''}"
-								>
-									<LayoutGrid class="h-4 w-4 shrink-0" />
-									{t(locale, 'nav.overview')}
-								</button>
-							</li>
-							{#each companions as c (c.id)}
-								<li role="option" aria-selected={c.id === activeCompanion.id}>
-									<button
-										type="button"
-										onclick={() => switchCompanion(c.id)}
-										class="flex w-full items-center gap-2.5 px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-foreground {c.id ===
-										activeCompanion.id
-											? 'bg-accent text-foreground font-medium'
-											: 'text-muted-foreground'}"
-									>
-										<CompanionAvatar
-											companionId={c.id}
-											avatarPath={c.avatarPath}
-											name={c.name}
-											size="sm"
-										/>
-										<span class="truncate">{c.name}</span>
-										<span
-											class="ml-auto h-2 w-2 rounded-full shrink-0 {statusDotClass(c.id)}"
-											title={statusTitle(c.id)}
-										></span>
-									</button>
-								</li>
-							{/each}
-						</ul>
-					{/if}
-				</div>
-			{:else}
-				<!-- Single companion — static display -->
-				<div class="flex items-center gap-2.5 flex-1 min-w-0">
-					<CompanionAvatar
-						companionId={activeCompanion.id}
-						avatarPath={activeCompanion.avatarPath}
-						name={activeCompanion.name}
-						size="sm"
-					/>
-					<span class="font-semibold text-sm text-foreground truncate flex-1 min-w-0">
-						{activeCompanion.name}
-					</span>
-				</div>
-			{/if}
+			<div class="flex-1 min-w-0">
+				<CompanionSwitcher {companions} {activeCompanion} {companionStatus} includeOverview />
+			</div>
 		{:else}
 			<!-- Overview / no companion: brand greeting -->
 			<div class="flex items-center gap-2.5 flex-1 min-w-0">
@@ -298,7 +163,9 @@
 					</div>
 				{/if}
 				<span class="font-display font-bold text-base text-foreground truncate">
-					{user ? `Hi, ${user.displayName.split(' ')[0]}` : 'EinVault'}
+					{user
+						? t(locale, 'overview.greeting', { name: user.displayName.split(' ')[0] })
+						: 'EinVault'}
 				</span>
 			</div>
 		{/if}

--- a/src/lib/components/shell/AppMobileNav.svelte
+++ b/src/lib/components/shell/AppMobileNav.svelte
@@ -62,6 +62,10 @@
 
 	let accountOpen = $state(false);
 
+	$effect(() => {
+		if (isCompanionContext) accountOpen = false;
+	});
+
 	// Companion context nav tabs (4 + central FAB)
 	let companionTabs = $derived(
 		activeCompanion
@@ -290,7 +294,7 @@
 				{#if isAction}
 					<button
 						type="button"
-						onclick={tab.action}
+						onclick={() => tab.action?.()}
 						aria-label={tab.label}
 						class="flex flex-1 flex-col items-center gap-0.5 py-2 text-[10px] font-medium text-muted-foreground transition-colors min-h-[56px] justify-end pb-2 hover:text-foreground"
 					>

--- a/src/lib/components/shell/AppSidebar.svelte
+++ b/src/lib/components/shell/AppSidebar.svelte
@@ -143,7 +143,10 @@
 				<div class="relative" role="none">
 					<button
 						type="button"
-						onclick={() => (switcherOpen = !switcherOpen)}
+						onclick={() => {
+							switcherOpen = !switcherOpen;
+							accountOpen = false;
+						}}
 						onkeydown={handleSwitcherKeydown}
 						aria-label={t(locale, 'layout.switchCompanion')}
 						aria-expanded={switcherOpen}
@@ -344,7 +347,10 @@
 			{#if user}
 				<button
 					type="button"
-					onclick={() => (accountOpen = !accountOpen)}
+					onclick={() => {
+						accountOpen = !accountOpen;
+						switcherOpen = false;
+					}}
 					aria-haspopup="dialog"
 					aria-expanded={accountOpen}
 					class="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors hover:bg-accent"

--- a/src/lib/components/shell/AppSidebar.svelte
+++ b/src/lib/components/shell/AppSidebar.svelte
@@ -97,6 +97,12 @@
 	let switcherOpen = $state(false);
 	let accountOpen = $state(false);
 
+	$effect(() => {
+		page.url.pathname; // track
+		accountOpen = false;
+		switcherOpen = false;
+	});
+
 	function switchCompanion(id: string) {
 		switcherOpen = false;
 		if (id === OVERVIEW_VALUE) {
@@ -174,7 +180,7 @@
 							type="button"
 							class="fixed inset-0 z-40 cursor-default"
 							onclick={() => (switcherOpen = false)}
-							aria-label="Close companion switcher"
+							aria-label={t(locale, 'aria.closeSwitcher')}
 							tabindex="-1"
 						></button>
 						<ul
@@ -253,7 +259,7 @@
 				<p
 					class="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60"
 				>
-					Companions
+					{t(locale, 'layout.companionsHeading')}
 				</p>
 
 				{#each companions as c (c.id)}

--- a/src/lib/components/shell/AppSidebar.svelte
+++ b/src/lib/components/shell/AppSidebar.svelte
@@ -10,17 +10,14 @@
 		HeartPulse,
 		Bell,
 		FileText,
-		Settings,
-		LogOut,
-		ShieldCheck,
 		Search,
 		ChevronDown,
 		LayoutGrid,
-		PlusCircle,
-		PawPrint
+		PlusCircle
 	} from '@lucide/svelte';
 	import { t, getLocale } from '$lib/i18n';
 	import type { CareStatus } from '$lib/careStatus';
+	import AccountSheet from './AccountSheet.svelte';
 
 	type Companion = {
 		id: string;
@@ -98,6 +95,7 @@
 	);
 
 	let switcherOpen = $state(false);
+	let accountOpen = $state(false);
 
 	function switchCompanion(id: string) {
 		switcherOpen = false;
@@ -341,72 +339,39 @@
 			</kbd>
 		</button>
 
-		<!-- Admin: Users link -->
-		{#if user?.role === 'admin'}
-			<a
-				href="/admin/users"
-				class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground hover:bg-accent {page.url.pathname.startsWith(
-					'/admin/users'
-				)
-					? 'bg-accent text-foreground'
-					: ''}"
-				aria-current={page.url.pathname.startsWith('/admin/users') ? 'page' : undefined}
-			>
-				<ShieldCheck class="h-4 w-4 shrink-0" />
-				{t(locale, 'nav.admin')}
-			</a>
-			<a
-				href="/admin/companions"
-				class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground hover:bg-accent {page.url.pathname.startsWith(
-					'/admin/companions'
-				)
-					? 'bg-accent text-foreground'
-					: ''}"
-				aria-current={page.url.pathname.startsWith('/admin/companions') ? 'page' : undefined}
-			>
-				<PawPrint class="h-4 w-4 shrink-0" />
-				{t(locale, 'nav.adminCompanions')}
-			</a>
-		{/if}
-
-		<!-- Settings -->
-		<a
-			href="/settings"
-			class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground hover:bg-accent {page.url.pathname.startsWith(
-				'/settings'
-			)
-				? 'bg-accent text-foreground'
-				: ''}"
-			aria-current={page.url.pathname.startsWith('/settings') ? 'page' : undefined}
-		>
-			<Settings class="h-4 w-4 shrink-0" />
-			{t(locale, 'nav.settings')}
-		</a>
-
-		<!-- Account area -->
-		<div class="flex items-center gap-2.5 rounded-lg px-3 py-2">
+		<!-- Account trigger + popover -->
+		<div class="relative">
 			{#if user}
-				<UserAvatar
-					userId={user.id}
-					displayName={user.displayName}
-					avatarPath={user.avatarPath}
-					size="sm"
-				/>
-				<div class="flex-1 min-w-0">
-					<p class="text-xs font-medium text-foreground truncate">{user.displayName}</p>
-					<p class="text-[10px] text-muted-foreground capitalize">{user.role}</p>
-				</div>
-			{/if}
-			<form method="POST" action="/auth/logout" class="shrink-0">
 				<button
-					type="submit"
-					aria-label={t(locale, 'nav.signOut')}
-					title={t(locale, 'nav.signOut')}
-					class="rounded p-1.5 text-muted-foreground transition-colors hover:text-foreground hover:bg-accent"
+					type="button"
+					onclick={() => (accountOpen = !accountOpen)}
+					aria-haspopup="dialog"
+					aria-expanded={accountOpen}
+					class="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors hover:bg-accent"
 				>
-					<LogOut class="h-3.5 w-3.5" />
+					<UserAvatar
+						userId={user.id}
+						displayName={user.displayName}
+						avatarPath={user.avatarPath}
+						size="sm"
+					/>
+					<div class="flex-1 min-w-0">
+						<p class="text-xs font-medium text-foreground truncate">{user.displayName}</p>
+						<p class="text-[10px] text-muted-foreground capitalize">{user.role}</p>
+					</div>
+					<ChevronDown
+						class="h-4 w-4 shrink-0 text-muted-foreground transition-transform {accountOpen
+							? 'rotate-180'
+							: ''}"
+					/>
 				</button>
-			</form>
+				<AccountSheet
+					{user}
+					open={accountOpen}
+					onclose={() => (accountOpen = false)}
+					variant="popover"
+				/>
+			{/if}
 		</div>
 	</div>
 </aside>

--- a/src/lib/components/shell/CompanionSwitcher.svelte
+++ b/src/lib/components/shell/CompanionSwitcher.svelte
@@ -6,7 +6,7 @@
 	import { t, getLocale } from '$lib/i18n';
 	import type { CareStatus } from '$lib/careStatus';
 
-	type Companion = { id: string; name: string; avatarPath?: string | null; isActive?: boolean };
+	type Companion = { id: string; name: string; avatarPath?: string | null };
 
 	interface Props {
 		companions: Companion[];
@@ -48,7 +48,7 @@
 	function switchTo(id: string) {
 		open = false;
 		if (id === OVERVIEW_VALUE) {
-			goto('/');
+			goto(basePath || '/');
 			return;
 		}
 		const parts = page.url.pathname.split('/');
@@ -65,7 +65,7 @@
 		if (e.key === 'Escape') open = false;
 	}
 
-	let isOnOverview = $derived(page.url.pathname === '/');
+	let isOnOverview = $derived(page.url.pathname === (basePath || '/'));
 </script>
 
 {#if companions.length > 1}

--- a/src/lib/components/shell/CompanionSwitcher.svelte
+++ b/src/lib/components/shell/CompanionSwitcher.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
+	import { ChevronDown, LayoutGrid } from '@lucide/svelte';
+	import { t, getLocale } from '$lib/i18n';
+	import type { CareStatus } from '$lib/careStatus';
+
+	type Companion = { id: string; name: string; avatarPath?: string | null; isActive?: boolean };
+
+	interface Props {
+		companions: Companion[];
+		activeCompanion: Companion;
+		/** Status dots in the dropdown. Pass {} to omit dot coloring (defaults to up-to-date). */
+		companionStatus?: Record<string, CareStatus>;
+		/** Owner switcher offers an "Overview" entry; caretaker does not. */
+		includeOverview?: boolean;
+		/** Route prefix for switching: '' for owner (/{id}), '/care' for caretaker (/care/{id}). */
+		basePath?: '' | '/care';
+	}
+
+	let {
+		companions,
+		activeCompanion,
+		companionStatus = {},
+		includeOverview = false,
+		basePath = ''
+	}: Props = $props();
+
+	const locale = getLocale();
+	const OVERVIEW_VALUE = '__overview__';
+	let open = $state(false);
+
+	function statusDotClass(id: string): string {
+		const s = companionStatus[id] ?? 'up-to-date';
+		if (s === 'needs-attention') return 'bg-coral';
+		if (s === 'due-today') return 'bg-gold';
+		return 'bg-teal';
+	}
+
+	function statusTitle(id: string): string {
+		const s = companionStatus[id] ?? 'up-to-date';
+		if (s === 'needs-attention') return t(locale, 'overview.careStatus.needsAttention');
+		if (s === 'due-today') return t(locale, 'overview.careStatus.dueToday');
+		return t(locale, 'overview.careStatus.upToDate');
+	}
+
+	function switchTo(id: string) {
+		open = false;
+		if (id === OVERVIEW_VALUE) {
+			goto('/');
+			return;
+		}
+		const parts = page.url.pathname.split('/');
+		const idIndex = basePath === '/care' ? 2 : 1;
+		if (parts[idIndex] === activeCompanion.id) {
+			const section = parts.slice(idIndex + 1).join('/');
+			goto(`${basePath}/${id}${section ? `/${section}` : ''}`);
+		} else {
+			goto(`${basePath}/${id}`);
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') open = false;
+	}
+
+	let isOnOverview = $derived(page.url.pathname === '/');
+</script>
+
+{#if companions.length > 1}
+	<div class="relative flex-1 min-w-0" role="none">
+		<button
+			type="button"
+			onclick={() => (open = !open)}
+			onkeydown={handleKeydown}
+			aria-label={t(locale, 'layout.switchCompanion')}
+			aria-expanded={open}
+			aria-haspopup="listbox"
+			class="flex w-full items-center gap-2.5 rounded-xl px-2 py-1.5 text-left transition-colors hover:bg-accent min-w-0"
+		>
+			<CompanionAvatar
+				companionId={activeCompanion.id}
+				avatarPath={activeCompanion.avatarPath}
+				name={activeCompanion.name}
+				size="sm"
+			/>
+			<span class="flex-1 min-w-0 font-semibold text-sm text-foreground truncate">
+				{activeCompanion.name}
+			</span>
+			<ChevronDown
+				class="h-4 w-4 shrink-0 text-muted-foreground transition-transform {open
+					? 'rotate-180'
+					: ''}"
+			/>
+		</button>
+
+		{#if open}
+			<button
+				type="button"
+				class="fixed inset-0 z-40 cursor-default"
+				onclick={() => (open = false)}
+				aria-label={t(locale, 'aria.closeSwitcher')}
+				tabindex="-1"
+			></button>
+			<ul
+				role="listbox"
+				aria-label={t(locale, 'layout.switchCompanion')}
+				class="absolute left-0 right-0 top-full z-50 mt-1 overflow-hidden rounded-xl border border-border bg-popover py-1 shadow-lg"
+			>
+				{#if includeOverview}
+					<li role="option" aria-selected={isOnOverview}>
+						<button
+							type="button"
+							onclick={() => switchTo(OVERVIEW_VALUE)}
+							class="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground {isOnOverview
+								? 'bg-accent text-foreground'
+								: ''}"
+						>
+							<LayoutGrid class="h-4 w-4 shrink-0" />
+							{t(locale, 'nav.overview')}
+						</button>
+					</li>
+				{/if}
+				{#each companions as c (c.id)}
+					<li role="option" aria-selected={c.id === activeCompanion.id}>
+						<button
+							type="button"
+							onclick={() => switchTo(c.id)}
+							class="flex w-full items-center gap-2.5 px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-foreground {c.id ===
+							activeCompanion.id
+								? 'bg-accent text-foreground font-medium'
+								: 'text-muted-foreground'}"
+						>
+							<CompanionAvatar
+								companionId={c.id}
+								avatarPath={c.avatarPath}
+								name={c.name}
+								size="sm"
+							/>
+							<span class="truncate">{c.name}</span>
+							<span
+								class="ml-auto h-2 w-2 rounded-full shrink-0 {statusDotClass(c.id)}"
+								title={statusTitle(c.id)}
+							></span>
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
+{:else}
+	<!-- Single companion — static display -->
+	<div class="flex items-center gap-2.5 flex-1 min-w-0">
+		<CompanionAvatar
+			companionId={activeCompanion.id}
+			avatarPath={activeCompanion.avatarPath}
+			name={activeCompanion.name}
+			size="sm"
+		/>
+		<span class="font-semibold text-sm text-foreground truncate flex-1 min-w-0">
+			{activeCompanion.name}
+		</span>
+	</div>
+{/if}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -183,6 +183,15 @@ const messages: Record<keyof Messages, string> = {
 	// Navigation: caretaker-specific
 	'nav.caretaker.overview': 'Übersicht',
 	'nav.caretaker.logActivity': 'Aktivität erfassen',
+	'nav.caretaker.addJournal': 'Journaleintrag hinzufügen',
+	'nav.search': 'Suche',
+	'nav.you': 'Du',
+	'nav.members': 'Mitglieder',
+	'nav.fab.quickAdd': 'Schnell hinzufügen',
+	'nav.fab.addJournal': 'Journaleintrag hinzufügen',
+	'nav.fab.logHealth': 'Gesundheitsereignis erfassen',
+	'nav.fab.addReminder': 'Erinnerung hinzufügen',
+	'nav.fab.recordWeight': 'Gewicht erfassen',
 
 	// Layout: app
 	'layout.archived': '(archiviert)',
@@ -815,6 +824,10 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPage': 'Nächste Seite',
 	'aria.viewPhoto': '{name}s Foto anzeigen',
 	'aria.openSearch': 'Suche öffnen',
+	'aria.closeQuickAdd': 'Schnellmenü schließen',
+	'aria.closeSwitcher': 'Begleiterauswahl schließen',
+	'aria.accountMenu': 'Kontomenü',
+	'aria.closeAccountMenu': 'Kontomenü schließen',
 	'aria.searchResults': 'Suchergebnisse',
 
 	// Email: password reset

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -195,6 +195,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Layout: app
 	'layout.archived': '(archiviert)',
+	'layout.companionsHeading': 'Begleiter',
 	'layout.addCompanion': 'Begleiter hinzufügen',
 	'layout.addFirstCompanion': 'Ersten Begleiter hinzufügen',
 	'layout.switchCompanion': 'Begleiter wechseln',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -170,6 +170,15 @@ const messages = {
 	// Navigation: caretaker-specific
 	'nav.caretaker.overview': 'Overview',
 	'nav.caretaker.logActivity': 'Log activity',
+	'nav.caretaker.addJournal': 'Add journal entry',
+	'nav.search': 'Search',
+	'nav.you': 'You',
+	'nav.members': 'Members',
+	'nav.fab.quickAdd': 'Quick add',
+	'nav.fab.addJournal': 'Add journal entry',
+	'nav.fab.logHealth': 'Log health event',
+	'nav.fab.addReminder': 'Add reminder',
+	'nav.fab.recordWeight': 'Record weight',
 
 	// Layout: app
 	'layout.archived': '(archived)',
@@ -806,6 +815,10 @@ const messages = {
 	'aria.nextPage': 'Next page',
 	'aria.viewPhoto': "View {name}'s photo",
 	'aria.openSearch': 'Open search',
+	'aria.closeQuickAdd': 'Close quick add menu',
+	'aria.closeSwitcher': 'Close companion switcher',
+	'aria.accountMenu': 'Account menu',
+	'aria.closeAccountMenu': 'Close account menu',
 	'aria.searchResults': 'Search results',
 
 	// Email: password reset

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -182,6 +182,7 @@ const messages = {
 
 	// Layout: app
 	'layout.archived': '(archived)',
+	'layout.companionsHeading': 'Companions',
 	'layout.addCompanion': 'Add a Companion',
 	'layout.addFirstCompanion': 'Add Your First Companion',
 	'layout.switchCompanion': 'Switch companion',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -183,6 +183,15 @@ const messages: Record<keyof Messages, string> = {
 	// Navigation: caretaker-specific
 	'nav.caretaker.overview': 'Resumen',
 	'nav.caretaker.logActivity': 'Registrar actividad',
+	'nav.caretaker.addJournal': 'Añadir entrada de diario',
+	'nav.search': 'Buscar',
+	'nav.you': 'Tú',
+	'nav.members': 'Miembros',
+	'nav.fab.quickAdd': 'Añadir rápido',
+	'nav.fab.addJournal': 'Añadir entrada de diario',
+	'nav.fab.logHealth': 'Registrar evento de salud',
+	'nav.fab.addReminder': 'Añadir recordatorio',
+	'nav.fab.recordWeight': 'Registrar peso',
 
 	// Layout: app
 	'layout.archived': '(archivado)',
@@ -815,6 +824,10 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPage': 'Página siguiente',
 	'aria.viewPhoto': 'Ver foto de {name}',
 	'aria.openSearch': 'Abrir búsqueda',
+	'aria.closeQuickAdd': 'Cerrar menú de añadir',
+	'aria.closeSwitcher': 'Cerrar selector de compañero',
+	'aria.accountMenu': 'Menú de cuenta',
+	'aria.closeAccountMenu': 'Cerrar menú de cuenta',
 	'aria.searchResults': 'Resultados de búsqueda',
 
 	// Email: password reset

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -195,6 +195,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Layout: app
 	'layout.archived': '(archivado)',
+	'layout.companionsHeading': 'Compañeros',
 	'layout.addCompanion': 'Añadir compañero',
 	'layout.addFirstCompanion': 'Añade tu primer compañero',
 	'layout.switchCompanion': 'Cambiar compañero',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -181,6 +181,15 @@ const messages: Record<keyof Messages, string> = {
 	// Navigation: caretaker-specific
 	'nav.caretaker.overview': 'Aperçu',
 	'nav.caretaker.logActivity': 'Enregistrer une activité',
+	'nav.caretaker.addJournal': 'Ajouter une entrée de journal',
+	'nav.search': 'Rechercher',
+	'nav.you': 'Vous',
+	'nav.members': 'Membres',
+	'nav.fab.quickAdd': 'Ajout rapide',
+	'nav.fab.addJournal': 'Ajouter une entrée de journal',
+	'nav.fab.logHealth': 'Consigner un événement de santé',
+	'nav.fab.addReminder': 'Ajouter un rappel',
+	'nav.fab.recordWeight': 'Enregistrer le poids',
 
 	// Layout: app
 	'layout.archived': '(archivé)',
@@ -817,6 +826,10 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPage': 'Page suivante',
 	'aria.viewPhoto': 'Voir la photo de {name}',
 	'aria.openSearch': 'Ouvrir la recherche',
+	'aria.closeQuickAdd': "Fermer le menu d'ajout",
+	'aria.closeSwitcher': 'Fermer le sélecteur de compagnon',
+	'aria.accountMenu': 'Menu du compte',
+	'aria.closeAccountMenu': 'Fermer le menu du compte',
 	'aria.searchResults': 'Résultats de recherche',
 
 	// Email: password reset

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -193,6 +193,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Layout: app
 	'layout.archived': '(archivé)',
+	'layout.companionsHeading': 'Compagnons',
 	'layout.addCompanion': 'Ajouter un compagnon',
 	'layout.addFirstCompanion': 'Ajoutez votre premier compagnon',
 	'layout.switchCompanion': 'Changer de compagnon',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -179,6 +179,15 @@ const messages: Record<keyof Messages, string> = {
 	// Navigation: caretaker-specific
 	'nav.caretaker.overview': 'Panoramica',
 	'nav.caretaker.logActivity': 'Registra attività',
+	'nav.caretaker.addJournal': 'Aggiungi voce di diario',
+	'nav.search': 'Cerca',
+	'nav.you': 'Tu',
+	'nav.members': 'Membri',
+	'nav.fab.quickAdd': 'Aggiunta rapida',
+	'nav.fab.addJournal': 'Aggiungi voce di diario',
+	'nav.fab.logHealth': 'Registra evento sanitario',
+	'nav.fab.addReminder': 'Aggiungi promemoria',
+	'nav.fab.recordWeight': 'Registra peso',
 
 	// Layout: app
 	'layout.archived': '(archiviato)',
@@ -810,6 +819,10 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPage': 'Pagina successiva',
 	'aria.viewPhoto': 'Vedi la foto di {name}',
 	'aria.openSearch': 'Apri ricerca',
+	'aria.closeQuickAdd': 'Chiudi menu di aggiunta',
+	'aria.closeSwitcher': 'Chiudi selettore compagno',
+	'aria.accountMenu': 'Menu account',
+	'aria.closeAccountMenu': 'Chiudi menu account',
 	'aria.searchResults': 'Risultati di ricerca',
 
 	// Email: password reset

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -191,6 +191,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Layout: app
 	'layout.archived': '(archiviato)',
+	'layout.companionsHeading': 'Compagni',
 	'layout.addCompanion': 'Aggiungi un compagno',
 	'layout.addFirstCompanion': 'Aggiungi il tuo primo compagno',
 	'layout.switchCompanion': 'Cambia compagno',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -180,6 +180,15 @@ const messages: Record<keyof Messages, string> = {
 	// Navigation: caretaker-specific
 	'nav.caretaker.overview': 'Resumo',
 	'nav.caretaker.logActivity': 'Registar atividade',
+	'nav.caretaker.addJournal': 'Adicionar entrada de diário',
+	'nav.search': 'Pesquisar',
+	'nav.you': 'Você',
+	'nav.members': 'Membros',
+	'nav.fab.quickAdd': 'Adicionar rápido',
+	'nav.fab.addJournal': 'Adicionar entrada de diário',
+	'nav.fab.logHealth': 'Registar evento de saúde',
+	'nav.fab.addReminder': 'Adicionar lembrete',
+	'nav.fab.recordWeight': 'Registar peso',
 
 	// Layout: app
 	'layout.archived': '(arquivado)',
@@ -812,6 +821,10 @@ const messages: Record<keyof Messages, string> = {
 	'aria.nextPage': 'Próxima página',
 	'aria.viewPhoto': 'Ver foto de {name}',
 	'aria.openSearch': 'Abrir pesquisa',
+	'aria.closeQuickAdd': 'Fechar menu de adição',
+	'aria.closeSwitcher': 'Fechar seletor de companheiro',
+	'aria.accountMenu': 'Menu da conta',
+	'aria.closeAccountMenu': 'Fechar menu da conta',
 	'aria.searchResults': 'Resultados da pesquisa',
 
 	// Email: password reset

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -192,6 +192,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Layout: app
 	'layout.archived': '(arquivado)',
+	'layout.companionsHeading': 'Companheiros',
 	'layout.addCompanion': 'Adicionar companheiro',
 	'layout.addFirstCompanion': 'Adicione o seu primeiro companheiro',
 	'layout.switchCompanion': 'Mudar de companheiro',

--- a/src/lib/nav/fabSections.test.ts
+++ b/src/lib/nav/fabSections.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { currentFabSection, orderFabActions, type FabAction } from './fabSections';
+
+const ACTIONS: FabAction[] = [
+	{ key: 'journal', href: '/c1/journal/2026-06-12', label: 'Add journal entry' },
+	{ key: 'health', href: '/c1/health?new=1', label: 'Log health event' },
+	{ key: 'reminders', href: '/c1/reminders?new=1', label: 'Add reminder' },
+	{ key: 'weight', href: '/c1/health?new=weight', label: 'Record weight' }
+];
+
+describe('currentFabSection', () => {
+	it('maps the dashboard (companion root) to null', () => {
+		expect(currentFabSection('/c1')).toBeNull();
+	});
+	it('maps a journal path to journal', () => {
+		expect(currentFabSection('/c1/journal')).toBe('journal');
+		expect(currentFabSection('/c1/journal/2026-06-12')).toBe('journal');
+	});
+	it('maps health paths to health', () => {
+		expect(currentFabSection('/c1/health')).toBe('health');
+	});
+	it('maps reminders paths to reminders', () => {
+		expect(currentFabSection('/c1/reminders')).toBe('reminders');
+	});
+	it('maps caretaker log paths to log', () => {
+		expect(currentFabSection('/care/c1/log')).toBe('log');
+	});
+	it('maps caretaker journal paths to journal', () => {
+		expect(currentFabSection('/care/c1/journal')).toBe('journal');
+	});
+	it('returns null for unknown paths', () => {
+		expect(currentFabSection('/settings')).toBeNull();
+		expect(currentFabSection('/')).toBeNull();
+	});
+});
+
+describe('orderFabActions', () => {
+	it('returns default order with no highlight when section is null', () => {
+		const out = orderFabActions(ACTIONS, null);
+		expect(out.map((a) => a.key)).toEqual(['journal', 'health', 'reminders', 'weight']);
+		expect(out.every((a) => a.highlight === false)).toBe(true);
+	});
+	it('floats the matching section action to the top and highlights it', () => {
+		const out = orderFabActions(ACTIONS, 'reminders');
+		expect(out[0].key).toBe('reminders');
+		expect(out[0].highlight).toBe(true);
+		expect(out.filter((a) => a.highlight).map((a) => a.key)).toEqual(['reminders']);
+	});
+	it('treats health as matching both health and weight actions', () => {
+		const out = orderFabActions(ACTIONS, 'health');
+		expect(
+			out
+				.slice(0, 2)
+				.map((a) => a.key)
+				.sort()
+		).toEqual(['health', 'weight']);
+		expect(
+			out
+				.filter((a) => a.highlight)
+				.map((a) => a.key)
+				.sort()
+		).toEqual(['health', 'weight']);
+	});
+	it('preserves the relative order of non-matching actions', () => {
+		const out = orderFabActions(ACTIONS, 'journal');
+		expect(out.map((a) => a.key)).toEqual(['journal', 'health', 'reminders', 'weight']);
+	});
+	it('does not mutate the input array', () => {
+		const copy = [...ACTIONS];
+		orderFabActions(ACTIONS, 'reminders');
+		expect(ACTIONS).toEqual(copy);
+	});
+});

--- a/src/lib/nav/fabSections.ts
+++ b/src/lib/nav/fabSections.ts
@@ -1,0 +1,53 @@
+/** A quick-add action shown in the FAB menu. `key` ties it to a section. */
+export interface FabAction {
+	key: string;
+	href: string;
+	label: string;
+}
+
+export type FabActionOrdered = FabAction & { highlight: boolean };
+
+/**
+ * Map a pathname to the FAB "section" it belongs to, or null when the section
+ * has no matching quick-add action (e.g. the companion dashboard root, or any
+ * non-companion page). Works for both owner (`/{id}/...`) and caretaker
+ * (`/care/{id}/...`) routes.
+ */
+export function currentFabSection(pathname: string): string | null {
+	const parts = pathname.split('/').filter(Boolean);
+	if (parts[0] === 'care') {
+		const section = parts[2];
+		if (section === 'log') return 'log';
+		if (section === 'journal') return 'journal';
+		return null;
+	}
+	const section = parts[1];
+	if (section === 'journal') return 'journal';
+	if (section === 'health') return 'health';
+	if (section === 'reminders') return 'reminders';
+	return null;
+}
+
+/**
+ * Which action keys a section should surface/highlight. A section may map to
+ * more than one action (health → log event + record weight).
+ */
+const SECTION_TO_ACTION_KEYS: Record<string, string[]> = {
+	journal: ['journal'],
+	health: ['health', 'weight'],
+	reminders: ['reminders'],
+	log: ['log']
+};
+
+/**
+ * Return the actions reordered so the current section's action(s) come first
+ * and are flagged `highlight: true`. Stable for the rest. Pure — never mutates
+ * the input.
+ */
+export function orderFabActions(actions: FabAction[], section: string | null): FabActionOrdered[] {
+	const matchKeys = section ? (SECTION_TO_ACTION_KEYS[section] ?? []) : [];
+	const isMatch = (a: FabAction) => matchKeys.includes(a.key);
+	const matched = actions.filter(isMatch).map((a) => ({ ...a, highlight: true }));
+	const rest = actions.filter((a) => !isMatch(a)).map((a) => ({ ...a, highlight: false }));
+	return [...matched, ...rest];
+}

--- a/src/routes/(caretaker)/+layout.svelte
+++ b/src/routes/(caretaker)/+layout.svelte
@@ -112,7 +112,7 @@
 				<!-- Logo (linked) -->
 				<a
 					href="/care/{data.companions?.[0]?.id ?? ''}"
-					class="logo-link flex items-center gap-2 shrink-0"
+					class="logo-link hidden sm:flex items-center gap-2 shrink-0"
 				>
 					<PawLogo
 						class="logo-paw w-7 h-7 text-muted-foreground transition-[color,transform] duration-200"
@@ -306,7 +306,8 @@
 								class="absolute bottom-full mb-3 left-1/2 -translate-x-1/2 z-50 bg-popover border border-border rounded-2xl shadow-xl overflow-hidden min-w-[200px]"
 							>
 								{#each fabActions as action (action.key)}
-									{@const ActionIcon = CARE_FAB_ICONS[action.key as keyof typeof CARE_FAB_ICONS]}
+									{@const ActionIcon =
+										CARE_FAB_ICONS[action.key as keyof typeof CARE_FAB_ICONS] ?? ClipboardList}
 									<a
 										href={action.href}
 										onclick={() => (fabOpen = false)}
@@ -388,7 +389,7 @@
 						? 'text-primary'
 						: 'text-muted-foreground'}"
 				>
-					<Settings class="h-5 w-5" />
+					<Settings class="h-5 w-5 mb-0.5" />
 					{t(locale, 'nav.settings')}
 				</a>
 			</div>

--- a/src/routes/(caretaker)/+layout.svelte
+++ b/src/routes/(caretaker)/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 	import PawLogo from '$lib/components/PawLogo.svelte';
@@ -27,7 +27,7 @@
 
 	const locale = getLocale();
 
-	let activeCompanionId = $derived($page.params.companionId ?? null);
+	let activeCompanionId = $derived(page.params.companionId ?? null);
 	let activeCompanion = $derived(
 		data.companions.find((c) => c.id === activeCompanionId) ?? data.companions[0] ?? null
 	);
@@ -78,7 +78,7 @@
 							label: t(locale, 'nav.caretaker.addJournal')
 						}
 					],
-					currentFabSection($page.url.pathname)
+					currentFabSection(page.url.pathname)
 				)
 			: []
 	);
@@ -91,12 +91,12 @@
 	let overviewHref = $derived(activeCompanion ? `/care/${activeCompanion.id}` : '');
 	let journalHref = $derived(activeCompanion ? `/care/${activeCompanion.id}/journal` : '');
 	let logHref = $derived(activeCompanion ? `/care/${activeCompanion.id}/log` : '');
-	let overviewActive = $derived($page.url.pathname === overviewHref);
+	let overviewActive = $derived(page.url.pathname === overviewHref);
 	let journalActive = $derived(
-		$page.url.pathname === journalHref || $page.url.pathname.startsWith(journalHref + '/')
+		page.url.pathname === journalHref || page.url.pathname.startsWith(journalHref + '/')
 	);
 	let logActive = $derived(
-		$page.url.pathname === logHref || $page.url.pathname.startsWith(logHref + '/')
+		page.url.pathname === logHref || page.url.pathname.startsWith(logHref + '/')
 	);
 	let journalLabel = $derived(t(locale, 'nav.journal'));
 	let logLabel = $derived(t(locale, 'nav.caretaker.logActivity'));
@@ -211,8 +211,8 @@
 			>
 				{#each navItems as item (item.href)}
 					{@const isActive =
-						$page.url.pathname === item.href ||
-						($page.url.pathname.startsWith(item.href + '/') &&
+						page.url.pathname === item.href ||
+						(page.url.pathname.startsWith(item.href + '/') &&
 							item.href !== `/care/${activeCompanion?.id}`)}
 					{@const isLocked = item.restricted && !data.isOnShift}
 					{@const NavIcon = item.icon}
@@ -253,7 +253,10 @@
 
 	<!-- Mobile bottom nav -->
 	{#if navItems.length > 0}
-		<nav class="md:hidden fixed bottom-0 left-0 right-0 border-t bg-card pb-safe z-30">
+		<nav
+			class="md:hidden fixed bottom-0 left-0 right-0 border-t bg-card pb-safe z-30"
+			aria-label={t(locale, 'aria.caretakerNav')}
+		>
 			<div class="relative flex items-end">
 				<!-- Overview tab -->
 				<a
@@ -361,11 +364,31 @@
 				<!-- Settings tab -->
 				<a
 					href="/care/settings"
-					aria-current={$page.url.pathname.startsWith('/care/settings') ? 'page' : undefined}
+					aria-current={page.url.pathname.startsWith('/care/settings') ? 'page' : undefined}
 					class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors min-h-[56px] justify-end pb-2
-						{$page.url.pathname.startsWith('/care/settings') ? 'text-primary' : 'text-muted-foreground'}"
+						{page.url.pathname.startsWith('/care/settings') ? 'text-primary' : 'text-muted-foreground'}"
 				>
 					<Settings class="h-5 w-5 mb-0.5" />
+					{t(locale, 'nav.settings')}
+				</a>
+			</div>
+		</nav>
+	{:else}
+		<nav
+			class="md:hidden fixed bottom-0 left-0 right-0 border-t bg-card pb-safe z-30"
+			aria-label={t(locale, 'aria.caretakerNav')}
+		>
+			<div class="flex">
+				<a
+					href="/care/settings"
+					aria-current={page.url.pathname.startsWith('/care/settings') ? 'page' : undefined}
+					class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors {page.url.pathname.startsWith(
+						'/care/settings'
+					)
+						? 'text-primary'
+						: 'text-muted-foreground'}"
+				>
+					<Settings class="h-5 w-5" />
 					{t(locale, 'nav.settings')}
 				</a>
 			</div>

--- a/src/routes/(caretaker)/+layout.svelte
+++ b/src/routes/(caretaker)/+layout.svelte
@@ -2,14 +2,11 @@
 	import type { LayoutData } from './$types';
 	import type { Snippet } from 'svelte';
 	import { page } from '$app/stores';
-	import { goto } from '$app/navigation';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 	import PawLogo from '$lib/components/PawLogo.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
-	import { Select } from '$lib/components/ui/select/index.js';
 	import {
 		Home,
 		ClipboardList,
@@ -17,12 +14,14 @@
 		Lock,
 		Settings,
 		LogOut,
-		ChevronRight
+		ChevronRight,
+		Plus
 	} from '@lucide/svelte';
-	import { THEME_ICONS, THEMES, applyTheme, saveTheme, type Theme } from '$lib/theme';
 	import AppFooter from '$lib/components/AppFooter.svelte';
 	import { ToastRegion } from '$lib/components/ui/toast';
 	import { t, getLocale } from '$lib/i18n';
+	import CompanionSwitcher from '$lib/components/shell/CompanionSwitcher.svelte';
+	import { currentFabSection, orderFabActions } from '$lib/nav/fabSections';
 
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
 
@@ -33,6 +32,7 @@
 		data.companions.find((c) => c.id === activeCompanionId) ?? data.companions[0] ?? null
 	);
 
+	// Desktop pill nav items (Overview / Journal / Log)
 	let navItems = $derived(
 		activeCompanion
 			? [
@@ -43,30 +43,64 @@
 						restricted: false
 					},
 					{
-						href: `/care/${activeCompanion.id}/log`,
-						label: t(locale, 'nav.caretaker.logActivity'),
-						icon: ClipboardList,
-						restricted: true
-					},
-					{
 						href: `/care/${activeCompanion.id}/journal`,
 						label: t(locale, 'nav.journal'),
 						icon: NotebookPen,
+						restricted: true
+					},
+					{
+						href: `/care/${activeCompanion.id}/log`,
+						label: t(locale, 'nav.caretaker.logActivity'),
+						icon: ClipboardList,
 						restricted: true
 					}
 				]
 			: []
 	);
 
-	// Theme toggle
-	let themeOverride = $state<Theme | null>(null);
-	let currentTheme = $derived<Theme>(themeOverride ?? (data.user?.theme as Theme) ?? 'system');
+	// FAB
+	const CARE_FAB_ICONS = { log: ClipboardList, journal: NotebookPen } as const;
 
-	async function setTheme(theme: Theme) {
-		themeOverride = theme;
-		applyTheme(theme);
-		await saveTheme(theme);
+	let fabOpen = $state(false);
+
+	let fabActions = $derived(
+		activeCompanion && data.isOnShift
+			? orderFabActions(
+					[
+						{
+							key: 'log',
+							href: `/care/${activeCompanion.id}/log`,
+							label: t(locale, 'nav.caretaker.logActivity')
+						},
+						{
+							key: 'journal',
+							href: `/care/${activeCompanion.id}/journal`,
+							label: t(locale, 'nav.caretaker.addJournal')
+						}
+					],
+					currentFabSection($page.url.pathname)
+				)
+			: []
+	);
+
+	function handleFabKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') fabOpen = false;
 	}
+
+	// Mobile nav active states (derived so they update reactively)
+	let overviewHref = $derived(activeCompanion ? `/care/${activeCompanion.id}` : '');
+	let journalHref = $derived(activeCompanion ? `/care/${activeCompanion.id}/journal` : '');
+	let logHref = $derived(activeCompanion ? `/care/${activeCompanion.id}/log` : '');
+	let overviewActive = $derived($page.url.pathname === overviewHref);
+	let journalActive = $derived(
+		$page.url.pathname === journalHref || $page.url.pathname.startsWith(journalHref + '/')
+	);
+	let logActive = $derived(
+		$page.url.pathname === logHref || $page.url.pathname.startsWith(logHref + '/')
+	);
+	let journalLabel = $derived(t(locale, 'nav.journal'));
+	let logLabel = $derived(t(locale, 'nav.caretaker.logActivity'));
+	let overviewLabel = $derived(t(locale, 'nav.caretaker.overview'));
 </script>
 
 <div class="min-h-screen flex flex-col bg-background">
@@ -84,36 +118,17 @@
 						class="logo-paw w-7 h-7 text-muted-foreground transition-[color,transform] duration-200"
 					/>
 					<span class="font-display font-bold text-lg text-primary">EinVault</span>
-					<Badge variant="moss" class="text-xs">{t(locale, 'enum.role.caretaker')}</Badge>
+					<Badge variant="secondary" class="text-xs">{t(locale, 'enum.role.caretaker')}</Badge>
 				</a>
 
-				<!-- Companion name (if single) or switcher (if multiple) -->
-				{#if data.companions.length > 1}
-					<Select
-						id="companion-switcher"
-						name="companionId"
-						aria-label={t(locale, 'layout.switchCompanion')}
-						class="max-w-[160px]"
-						value={activeCompanionId ?? activeCompanion?.id}
-						onchange={(e) => goto(`/care/${e.currentTarget.value}`)}
-					>
-						{#each data.companions as c (c.id)}
-							<option value={c.id}>{c.name}</option>
-						{/each}
-					</Select>
-				{:else if activeCompanion}
-					<div class="flex items-center gap-2">
-						<CompanionAvatar
-							companionId={activeCompanion.id}
-							avatarPath={activeCompanion.avatarPath}
-							name={activeCompanion.name}
-							size="sm"
-						/>
-						<span class="font-medium text-sm text-muted-foreground">{activeCompanion.name}</span>
+				<!-- Companion switcher -->
+				{#if activeCompanion}
+					<div class="min-w-0 flex-1 max-w-[220px]">
+						<CompanionSwitcher companions={data.companions} {activeCompanion} basePath="/care" />
 					</div>
 				{/if}
 
-				<!-- Right: user avatar + theme toggle + settings + sign out -->
+				<!-- Right: user avatar + settings + sign out -->
 				<div class="flex items-center gap-1 shrink-0">
 					{#if data.user}
 						<UserAvatar
@@ -124,22 +139,6 @@
 							class="mr-1"
 						/>
 					{/if}
-					<div class="flex rounded-md border border-border p-0.5 gap-0.5 bg-muted">
-						{#each THEMES as theme (theme)}
-							{@const Icon = THEME_ICONS[theme]}
-							<button
-								type="button"
-								onclick={() => setTheme(theme)}
-								aria-label="{theme.charAt(0).toUpperCase() + theme.slice(1)} mode"
-								aria-pressed={currentTheme === theme}
-								class="rounded px-2 py-1 transition-all {currentTheme === theme
-									? 'bg-background text-foreground shadow-sm'
-									: 'text-muted-foreground hover:text-foreground'}"
-							>
-								<Icon class="h-3.5 w-3.5" />
-							</button>
-						{/each}
-					</div>
 					<Button
 						href="/care/settings"
 						variant="ghost"
@@ -164,20 +163,17 @@
 	{#if data.isOnShift && data.activeShift}
 		<a
 			href="/care/settings#shifts"
-			class="block border-b bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-800 hover:bg-green-100 dark:hover:bg-green-900 transition-colors"
+			class="block border-b border-border bg-teal/10 hover:bg-teal/15 transition-colors"
 		>
-			<div
-				class="mx-auto max-w-3xl px-4 sm:px-6 py-2 flex items-center gap-2 text-sm text-green-700 dark:text-green-300"
-			>
-				<span class="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0" aria-hidden="true"
-				></span>
+			<div class="mx-auto max-w-3xl px-4 sm:px-6 py-2 flex items-center gap-2 text-sm text-teal">
+				<span class="inline-block w-2 h-2 rounded-full bg-teal shrink-0" aria-hidden="true"></span>
 				<span
 					>{t(locale, 'layout.caretaker.onShift')}
 					<LocalTime date={data.activeShift.endAt} format="datetime" /></span
 				>
-				{#if data.activeShift.notes}
-					<span class="text-xs opacity-70">· {data.activeShift.notes}</span>
-				{/if}
+				{#if data.activeShift.notes}<span class="text-xs opacity-70"
+						>· {data.activeShift.notes}</span
+					>{/if}
 				<ChevronRight class="h-3.5 w-3.5 ml-auto shrink-0 opacity-50" />
 			</div>
 		</a>
@@ -258,40 +254,118 @@
 	<!-- Mobile bottom nav -->
 	{#if navItems.length > 0}
 		<nav class="md:hidden fixed bottom-0 left-0 right-0 border-t bg-card pb-safe z-30">
-			<div class="flex">
-				{#each navItems as item (item.href)}
-					{@const isActive =
-						$page.url.pathname === item.href ||
-						($page.url.pathname.startsWith(item.href + '/') &&
-							item.href !== `/care/${activeCompanion?.id}`)}
-					{@const isLocked = item.restricted && !data.isOnShift}
-					{@const NavIcon = item.icon}
-					{#if isLocked}
-						<span
-							aria-label="{item.label} ({t(locale, 'layout.caretaker.requiresActiveShift')})"
-							class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium opacity-40 cursor-not-allowed text-muted-foreground"
+			<div class="relative flex items-end">
+				<!-- Overview tab -->
+				<a
+					href={overviewHref}
+					aria-current={overviewActive ? 'page' : undefined}
+					class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors min-h-[56px] justify-end pb-2
+						{overviewActive ? 'text-primary' : 'text-muted-foreground'}"
+				>
+					<Home class="h-5 w-5 mb-0.5" />
+					{overviewLabel}
+				</a>
+
+				<!-- Journal tab (restricted) -->
+				{#if !data.isOnShift}
+					<span
+						aria-label="{journalLabel} ({t(locale, 'layout.caretaker.requiresActiveShift')})"
+						class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium opacity-40 cursor-not-allowed text-muted-foreground min-h-[56px] justify-end pb-2"
+					>
+						<NotebookPen class="h-5 w-5 mb-0.5" />
+						{journalLabel}
+					</span>
+				{:else}
+					<a
+						href={journalHref}
+						aria-current={journalActive ? 'page' : undefined}
+						class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors min-h-[56px] justify-end pb-2
+							{journalActive ? 'text-primary' : 'text-muted-foreground'}"
+					>
+						<NotebookPen class="h-5 w-5 mb-0.5" />
+						{journalLabel}
+					</a>
+				{/if}
+
+				<!-- Central FAB slot (on shift only) -->
+				{#if data.isOnShift}
+					<div class="flex flex-col items-center flex-1 relative" style="padding-bottom: 8px;">
+						<!-- FAB menu -->
+						{#if fabOpen}
+							<button
+								type="button"
+								class="fixed inset-0 z-40 cursor-default"
+								onclick={() => (fabOpen = false)}
+								aria-label={t(locale, 'aria.closeQuickAdd')}
+								tabindex="-1"
+							></button>
+							<div
+								class="absolute bottom-full mb-3 left-1/2 -translate-x-1/2 z-50 bg-popover border border-border rounded-2xl shadow-xl overflow-hidden min-w-[200px]"
+							>
+								{#each fabActions as action (action.key)}
+									{@const ActionIcon = CARE_FAB_ICONS[action.key as keyof typeof CARE_FAB_ICONS]}
+									<a
+										href={action.href}
+										onclick={() => (fabOpen = false)}
+										class="flex items-center gap-3 px-4 py-3 text-sm transition-colors hover:bg-accent {action.highlight
+											? 'bg-primary/10 text-primary font-medium'
+											: 'text-foreground'}"
+									>
+										<ActionIcon
+											class="h-4 w-4 shrink-0 {action.highlight
+												? 'text-primary'
+												: 'text-muted-foreground'}"
+										/>
+										{action.label}
+									</a>
+								{/each}
+							</div>
+						{/if}
+
+						<!-- FAB button -->
+						<button
+							type="button"
+							onclick={() => (fabOpen = !fabOpen)}
+							onkeydown={handleFabKeydown}
+							aria-label={t(locale, 'nav.fab.quickAdd')}
+							aria-expanded={fabOpen}
+							class="relative -top-3 h-12 w-12 rounded-full flex items-center justify-center text-white shadow-lg transition-transform hover:scale-105 active:scale-95"
+							style="background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary) / 0.7)); box-shadow: 0 8px 20px hsl(var(--primary) / 0.4);"
 						>
-							<NavIcon class="h-5 w-5" />
-							{item.label}
-						</span>
-					{:else}
-						<a
-							href={item.href}
-							aria-current={isActive ? 'page' : undefined}
-							class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors
-								{isActive ? 'text-primary' : 'text-muted-foreground'}"
-						>
-							<NavIcon class="h-5 w-5" />
-							{item.label}
-						</a>
-					{/if}
-				{/each}
+							<Plus class="h-6 w-6 transition-transform {fabOpen ? 'rotate-45' : ''}" />
+						</button>
+					</div>
+				{/if}
+
+				<!-- Log tab (restricted) -->
+				{#if !data.isOnShift}
+					<span
+						aria-label="{logLabel} ({t(locale, 'layout.caretaker.requiresActiveShift')})"
+						class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium opacity-40 cursor-not-allowed text-muted-foreground min-h-[56px] justify-end pb-2"
+					>
+						<ClipboardList class="h-5 w-5 mb-0.5" />
+						{logLabel}
+					</span>
+				{:else}
+					<a
+						href={logHref}
+						aria-current={logActive ? 'page' : undefined}
+						class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors min-h-[56px] justify-end pb-2
+							{logActive ? 'text-primary' : 'text-muted-foreground'}"
+					>
+						<ClipboardList class="h-5 w-5 mb-0.5" />
+						{logLabel}
+					</a>
+				{/if}
+
+				<!-- Settings tab -->
 				<a
 					href="/care/settings"
-					class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors
+					aria-current={$page.url.pathname.startsWith('/care/settings') ? 'page' : undefined}
+					class="flex flex-1 flex-col items-center gap-0.5 py-2 text-xs font-medium transition-colors min-h-[56px] justify-end pb-2
 						{$page.url.pathname.startsWith('/care/settings') ? 'text-primary' : 'text-muted-foreground'}"
 				>
-					<Settings class="h-5 w-5" />
+					<Settings class="h-5 w-5 mb-0.5" />
 					{t(locale, 'nav.settings')}
 				</a>
 			</div>

--- a/src/routes/(caretaker)/care/settings/+page.server.ts
+++ b/src/routes/(caretaker)/care/settings/+page.server.ts
@@ -34,6 +34,31 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 export const actions: Actions = {
+	theme: async ({ request, locals, cookies }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+
+		const data = await request.formData();
+		const theme = String(data.get('theme') ?? 'system');
+		if (!['light', 'dark', 'system'].includes(theme)) {
+			return fail(400, { themeError: t(locals.locale, 'error.invalidTheme') });
+		}
+
+		await db
+			.update(schema.users)
+			.set({ theme: theme as 'light' | 'dark' | 'system' })
+			.where(eq(schema.users.id, locals.user.id));
+
+		cookies.set('einvault_theme', theme, {
+			path: '/',
+			httpOnly: false,
+			secure: isSecureRequest(request),
+			sameSite: 'strict',
+			maxAge: 60 * 60 * 24 * 365
+		});
+
+		return { themeSuccess: true };
+	},
+
 	locale: async ({ request, locals, cookies }) => {
 		if (!locals.user) redirect(302, '/auth/login');
 

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -15,11 +15,21 @@
 	import { Calendar } from '@lucide/svelte';
 	import { SvelteDate } from 'svelte/reactivity';
 	import { t, getLocale, SUPPORTED_LOCALES, LOCALE_LABELS, type MessageKey } from '$lib/i18n';
+	import { applyTheme, saveTheme, THEMES, THEME_ICONS, type Theme } from '$lib/theme';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 
 	const locale = getLocale();
 	let showPasswordFields = $state(false);
+
+	let themeOverride = $state<Theme | null>(null);
+	let currentTheme = $derived<Theme>(themeOverride ?? (data.user?.theme as Theme) ?? 'system');
+
+	async function setTheme(theme: Theme) {
+		themeOverride = theme;
+		applyTheme(theme);
+		await saveTheme(theme, '/care/settings');
+	}
 	let localeForm: HTMLFormElement;
 	let expandedShiftId = $state<string | null>(null);
 
@@ -267,6 +277,32 @@
 					</Select>
 				</div>
 			</form>
+		</CardContent>
+	</Card>
+
+	<Card>
+		<CardHeader>
+			<CardTitle>{t(locale, 'page.settings.appearanceCard')}</CardTitle>
+		</CardHeader>
+		<CardContent>
+			<div class="flex rounded-md border border-border p-0.5 gap-0.5 bg-muted">
+				{#each THEMES as theme (theme)}
+					{@const Icon = THEME_ICONS[theme]}
+					<button
+						type="button"
+						onclick={() => setTheme(theme)}
+						aria-label="{theme.charAt(0).toUpperCase() + theme.slice(1)} mode"
+						aria-pressed={currentTheme === theme}
+						class="flex-1 flex items-center justify-center gap-1.5 rounded px-3 py-2 text-sm transition-all {currentTheme ===
+						theme
+							? 'bg-background text-foreground shadow-sm'
+							: 'text-muted-foreground hover:text-foreground'}"
+					>
+						<Icon class="h-4 w-4 shrink-0" />
+						<span>{theme.charAt(0).toUpperCase() + theme.slice(1)}</span>
+					</button>
+				{/each}
+			</div>
 		</CardContent>
 	</Card>
 

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -366,7 +366,7 @@
 										!isActive && shift.id === data.upcomingShifts.find((s) => s.startAt > now)?.id}
 									<div
 										class="rounded-lg overflow-hidden {isActive
-											? 'bg-green-50 dark:bg-green-950 ring-1 ring-green-200 dark:ring-green-800'
+											? 'bg-teal/10 ring-1 ring-teal/30'
 											: isNext
 												? 'ring-1 ring-primary/20'
 												: ''}"
@@ -381,16 +381,12 @@
 										>
 											{#if isActive}
 												<span
-													class="inline-block w-2 h-2 rounded-full bg-green-500 shrink-0"
+													class="inline-block w-2 h-2 rounded-full bg-teal shrink-0"
 													aria-hidden="true"
 												></span>
 											{/if}
 											<div class="flex-1 min-w-0">
-												<span
-													class={isActive
-														? 'text-green-700 dark:text-green-300 font-medium'
-														: 'text-foreground'}
-												>
+												<span class={isActive ? 'text-teal font-medium' : 'text-foreground'}>
 													<LocalTime date={shift.startAt} format="datetime" />
 												</span>
 												<span class="text-muted-foreground mx-1">–</span>

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,297 @@
+import { test as base, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from '../lib/fixtures';
+import { createSeededDbNoShift, SEED } from '../lib/seed';
+import { startAppServer, type AppServer } from '../lib/app-server';
+import { getFreePort } from '../lib/ports';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+const BISCUIT = SEED.companions.biscuit.id;
+
+// ---------------------------------------------------------------------------
+// A. Owner household tabs + account sheet — mobile-only
+// ---------------------------------------------------------------------------
+
+test('bottom tab bar shows Overview, Search, You but not Members @mobile', async ({
+	asMember
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asMember.goto('/');
+	const nav = asMember.getByRole('navigation', { name: 'Main navigation' });
+	await expect(nav.getByRole('link', { name: 'Overview' })).toBeVisible({ timeout: 8_000 });
+	await expect(nav.getByRole('button', { name: 'Search' })).toBeVisible({ timeout: 8_000 });
+	await expect(nav.getByRole('button', { name: 'You' })).toBeVisible({ timeout: 8_000 });
+	await expect(nav.getByRole('link', { name: 'Members' })).toHaveCount(0);
+});
+
+test('member You tab opens account sheet with Settings + Sign Out only @mobile', async ({
+	asMember
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asMember.goto('/');
+	const nav = asMember.getByRole('navigation', { name: 'Main navigation' });
+	await nav.getByRole('button', { name: 'You' }).click();
+
+	const sheet = asMember.getByRole('dialog', { name: 'Account menu' });
+	await expect(sheet).toBeVisible({ timeout: 8_000 });
+	await expect(sheet.getByRole('link', { name: 'Settings' })).toBeVisible();
+	await expect(sheet.getByRole('button', { name: 'Sign Out' })).toBeVisible();
+	// Admin-only entries must not appear for a member
+	await expect(sheet.getByRole('link', { name: 'Members' })).toHaveCount(0);
+	await expect(sheet.getByRole('link', { name: 'Companions' })).toHaveCount(0);
+});
+
+test('admin You tab account sheet shows Members and Companions @mobile', async ({
+	asAdmin
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asAdmin.goto('/');
+	const nav = asAdmin.getByRole('navigation', { name: 'Main navigation' });
+	await nav.getByRole('button', { name: 'You' }).click();
+
+	const sheet = asAdmin.getByRole('dialog', { name: 'Account menu' });
+	await expect(sheet).toBeVisible({ timeout: 8_000 });
+	await expect(sheet.getByRole('link', { name: 'Members' })).toBeVisible();
+	await expect(sheet.getByRole('link', { name: 'Companions' })).toBeVisible();
+});
+
+test('admin account sheet Members link navigates to /admin/users @mobile', async ({
+	asAdmin
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asAdmin.goto('/');
+	const nav = asAdmin.getByRole('navigation', { name: 'Main navigation' });
+	await nav.getByRole('button', { name: 'You' }).click();
+	const sheet = asAdmin.getByRole('dialog', { name: 'Account menu' });
+	await expect(sheet).toBeVisible({ timeout: 8_000 });
+	await sheet.getByRole('link', { name: 'Members' }).click();
+	await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 8_000 });
+});
+
+test('admin account sheet Companions link navigates to /admin/companions @mobile', async ({
+	asAdmin
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asAdmin.goto('/');
+	const nav = asAdmin.getByRole('navigation', { name: 'Main navigation' });
+	await nav.getByRole('button', { name: 'You' }).click();
+	const sheet = asAdmin.getByRole('dialog', { name: 'Account menu' });
+	await expect(sheet).toBeVisible({ timeout: 8_000 });
+	await sheet.getByRole('link', { name: 'Companions' }).click();
+	await expect(asAdmin).toHaveURL(/\/admin\/companions/, { timeout: 8_000 });
+});
+
+// ---------------------------------------------------------------------------
+// B. Owner account popover — desktop sidebar
+// ---------------------------------------------------------------------------
+
+test('admin sidebar account popover shows Settings + Members + Companions + Sign Out', async ({
+	asAdmin
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'desktop', 'desktop sidebar only');
+	await asAdmin.goto('/');
+	// The account trigger is the button with aria-haspopup="dialog" in the sidebar
+	const trigger = asAdmin.getByRole('button', { name: new RegExp(SEED.admin.displayName, 'i') });
+	await expect(trigger).toBeVisible({ timeout: 8_000 });
+	await trigger.click();
+
+	const popover = asAdmin.getByRole('dialog', { name: 'Account menu' });
+	await expect(popover).toBeVisible({ timeout: 8_000 });
+	await expect(popover.getByRole('link', { name: 'Settings' })).toBeVisible();
+	await expect(popover.getByRole('link', { name: 'Members' })).toBeVisible();
+	await expect(popover.getByRole('link', { name: 'Companions' })).toBeVisible();
+	await expect(popover.getByRole('button', { name: 'Sign Out' })).toBeVisible();
+});
+
+test('member sidebar account popover shows Settings + Sign Out but not Members/Companions', async ({
+	asMember
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'desktop', 'desktop sidebar only');
+	await asMember.goto('/');
+	const trigger = asMember.getByRole('button', {
+		name: new RegExp(SEED.member.displayName, 'i')
+	});
+	await expect(trigger).toBeVisible({ timeout: 8_000 });
+	await trigger.click();
+
+	const popover = asMember.getByRole('dialog', { name: 'Account menu' });
+	await expect(popover).toBeVisible({ timeout: 8_000 });
+	await expect(popover.getByRole('link', { name: 'Settings' })).toBeVisible();
+	await expect(popover.getByRole('button', { name: 'Sign Out' })).toBeVisible();
+	await expect(popover.getByRole('link', { name: 'Members' })).toHaveCount(0);
+	await expect(popover.getByRole('link', { name: 'Companions' })).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// C. Caretaker nav — on shift (seed default)
+// ---------------------------------------------------------------------------
+
+test('caretaker on-shift: Journal and Log tabs are links (not locked) @mobile', async ({
+	asCaretaker
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile bottom nav is mobile-only');
+	await asCaretaker.goto(`/care/${BISCUIT}`);
+	const nav = asCaretaker.getByRole('navigation', { name: 'Caretaker navigation' });
+	await expect(nav.getByRole('link', { name: 'Journal' })).toBeVisible({ timeout: 8_000 });
+	await expect(nav.getByRole('link', { name: 'Log activity' })).toBeVisible({ timeout: 8_000 });
+});
+
+test('caretaker on-shift: Quick add FAB is present and opens Log activity + Add journal entry @mobile', async ({
+	asCaretaker
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asCaretaker.goto(`/care/${BISCUIT}`);
+	// exact: true avoids matching the "Close quick add menu" backdrop button
+	const fab = asCaretaker.getByRole('button', { name: 'Quick add', exact: true });
+	await expect(fab).toBeVisible({ timeout: 8_000 });
+	await fab.click();
+	await expect(fab).toHaveAttribute('aria-expanded', 'true', { timeout: 8_000 });
+	// The caretaker nav holds the FAB popup links alongside the nav tab links.
+	// Both are in the same nav landmark, so scope to the nav and expect at least
+	// one visible instance of each action link (the popup item).
+	const nav = asCaretaker.getByRole('navigation', { name: 'Caretaker navigation' });
+	await expect(nav.getByRole('link', { name: 'Log activity' }).first()).toBeVisible({
+		timeout: 8_000
+	});
+	await expect(nav.getByRole('link', { name: 'Add journal entry' }).first()).toBeVisible({
+		timeout: 8_000
+	});
+});
+
+test('caretaker on-shift desktop: Journal and Log are links (not locked)', async ({
+	asCaretaker
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'desktop', 'desktop only');
+	await asCaretaker.goto(`/care/${BISCUIT}`);
+	const nav = asCaretaker.getByRole('navigation', { name: 'Caretaker navigation' });
+	await expect(nav.getByRole('link', { name: 'Journal' })).toBeVisible({ timeout: 8_000 });
+	await expect(nav.getByRole('link', { name: 'Log activity' })).toBeVisible({ timeout: 8_000 });
+});
+
+test('caretaker has no Open search control on care page', async ({ asCaretaker }) => {
+	await asCaretaker.goto(`/care/${BISCUIT}`);
+	await expect(asCaretaker.getByRole('button', { name: 'Open search' })).toHaveCount(0, {
+		timeout: 8_000
+	});
+});
+
+// ---------------------------------------------------------------------------
+// D. Caretaker nav — off shift (dedicated per-test server, no active shift)
+// ---------------------------------------------------------------------------
+
+interface OffShiftWorld {
+	server: AppServer;
+}
+
+const offShiftTest = base.extend<{ world: OffShiftWorld }>({
+	// eslint-disable-next-line no-empty-pattern
+	world: async ({}, use, testInfo) => {
+		const dir = path.join(
+			REPO_ROOT,
+			'.test-data',
+			`nav-offshift-${testInfo.workerIndex}-${testInfo.testId}`
+		);
+		const appPort = await getFreePort();
+		const dbPath = createSeededDbNoShift(dir);
+		let server: AppServer;
+		try {
+			server = await startAppServer({
+				dbPath,
+				env: { PORT: String(appPort) }
+			});
+		} catch (err) {
+			fs.rmSync(dir, { recursive: true, force: true });
+			throw err;
+		}
+		await use({ server });
+		await server.stop();
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+offShiftTest(
+	'caretaker off-shift: Journal and Log are locked @mobile',
+	async ({ world, browser }, testInfo) => {
+		test.skip(testInfo.project.name !== 'mobile', 'mobile bottom nav is mobile-only');
+
+		// Log in as caretaker against the off-shift server
+		const ctx = await browser.newContext({ baseURL: world.server.baseURL });
+		const page = await ctx.newPage();
+		await page.goto('/auth/login');
+		await page.getByLabel('Username').fill(SEED.caretaker.username);
+		await page.getByLabel('Password').fill(SEED.password);
+		await page.getByRole('button', { name: 'Sign in' }).click();
+		await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
+
+		await page.goto(`/care/${BISCUIT}`);
+
+		// Journal and Log tabs render as <span> (not <a>) with aria-label containing
+		// "requires active shift" text
+		const nav = page.getByRole('navigation', { name: 'Caretaker navigation' });
+		const journalLocked = nav.locator('[aria-label*="requires active shift"]', {
+			hasText: /Journal/i
+		});
+		const logLocked = nav.locator('[aria-label*="requires active shift"]', {
+			hasText: /Log activity/i
+		});
+		await expect(journalLocked).toBeVisible({ timeout: 8_000 });
+		await expect(logLocked).toBeVisible({ timeout: 8_000 });
+
+		// No active-link version of Journal or Log (locked items are spans, not anchors)
+		await expect(nav.getByRole('link', { name: 'Journal' })).toHaveCount(0);
+		await expect(nav.getByRole('link', { name: 'Log activity' })).toHaveCount(0);
+
+		await ctx.close();
+	}
+);
+
+offShiftTest(
+	'caretaker off-shift: no Quick add FAB @mobile',
+	async ({ world, browser }, testInfo) => {
+		test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+
+		const ctx = await browser.newContext({ baseURL: world.server.baseURL });
+		const page = await ctx.newPage();
+		await page.goto('/auth/login');
+		await page.getByLabel('Username').fill(SEED.caretaker.username);
+		await page.getByLabel('Password').fill(SEED.password);
+		await page.getByRole('button', { name: 'Sign in' }).click();
+		await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
+
+		await page.goto(`/care/${BISCUIT}`);
+		await expect(page.getByRole('button', { name: 'Quick add' })).toHaveCount(0, {
+			timeout: 8_000
+		});
+
+		await ctx.close();
+	}
+);
+
+offShiftTest(
+	'caretaker off-shift desktop: Journal and Log are locked spans in pill nav',
+	async ({ world, browser }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop', 'desktop only');
+
+		const ctx = await browser.newContext({ baseURL: world.server.baseURL });
+		const page = await ctx.newPage();
+		await page.goto('/auth/login');
+		await page.getByLabel('Username').fill(SEED.caretaker.username);
+		await page.getByLabel('Password').fill(SEED.password);
+		await page.getByRole('button', { name: 'Sign in' }).click();
+		await expect(page.getByLabel('Username')).toHaveCount(0, { timeout: 10_000 });
+
+		await page.goto(`/care/${BISCUIT}`);
+
+		const nav = page.getByRole('navigation', { name: 'Caretaker navigation' });
+		// Locked items are <span> elements with aria-label containing "requires active shift"
+		await expect(nav.locator('[aria-label*="requires active shift"]').first()).toBeVisible({
+			timeout: 8_000
+		});
+		// No active links for Journal or Log in the pill nav
+		await expect(nav.getByRole('link', { name: 'Journal' })).toHaveCount(0);
+		await expect(nav.getByRole('link', { name: 'Log activity' })).toHaveCount(0);
+
+		await ctx.close();
+	}
+);

--- a/tests/e2e/oidc-variants.spec.ts
+++ b/tests/e2e/oidc-variants.spec.ts
@@ -205,9 +205,10 @@ test('oidc-variants: group absence demotes admin to member', async ({ page }) =>
 		await page.goto(world.server.baseURL + '/admin/users');
 		await expect(page.getByRole('heading', { name: /users/i })).toBeVisible({ timeout: 10_000 });
 
-		// Sign out.
+		// Sign out via the account menu (opened from the sidebar account row).
 		await page.goto(world.server.baseURL + '/settings');
 		await expect(page).toHaveURL(/settings/, { timeout: 10_000 });
+		await page.locator('button[aria-haspopup="dialog"]').click();
 		await page.getByRole('button', { name: /sign out/i }).click();
 		await expect(page).toHaveURL(/auth\/login/, { timeout: 10_000 });
 

--- a/tests/e2e/oidc.spec.ts
+++ b/tests/e2e/oidc.spec.ts
@@ -84,12 +84,12 @@ test('existing OIDC user logs back in with same identity', async ({ world, page 
 	// OAuth round-trip completed and the app accepted the session.
 	await expect(page).not.toHaveURL(/\/auth\//, { timeout: 15_000 });
 
-	// Navigate to settings (always accessible with any number of companions)
-	// so that the Sign Out button is visible in the app nav.
+	// Navigate to settings (always accessible with any number of companions).
 	await page.goto(world.server.baseURL + '/settings');
 	await expect(page).toHaveURL(/settings/, { timeout: 10_000 });
 
-	// Log out via the Sign Out button in the app navigation.
+	// Sign Out lives in the account menu (opened from the sidebar account row).
+	await page.locator('button[aria-haspopup="dialog"]').click();
 	await page.getByRole('button', { name: /sign out/i }).click();
 	await expect(page).toHaveURL(/auth\/login/, { timeout: 10_000 });
 

--- a/tests/lib/seed.ts
+++ b/tests/lib/seed.ts
@@ -106,6 +106,21 @@ export function createSeededDb(dir: string): string {
 	return dbPath;
 }
 
+/**
+ * Like createSeededDb but omits the active caretaker shift.
+ * Use for off-shift caretaker tests that need a dedicated per-test server.
+ */
+export function createSeededDbNoShift(dir: string): string {
+	const dbPath = createSeededDb(dir);
+	// Re-open just to delete the active shift row, then close cleanly.
+	const sqlite = new Database(dbPath);
+	sqlite.pragma('journal_mode = WAL');
+	sqlite.pragma('foreign_keys = ON');
+	sqlite.prepare("DELETE FROM caretaker_shifts WHERE id = 'seed-shift-active'").run();
+	sqlite.close();
+	return dbPath;
+}
+
 /** Migrates an empty DB (pristine instance for the setup wizard project). */
 export function createEmptyDb(dir: string): string {
 	fs.rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
Draft. Stacked on #115 (SP1) — base branch is `redesign-sp1-design-language`, not `main`. Review/merge after SP1. Second sub-project of the phased UI/UX redesign: finalizes the navigation IA on top of SP1's shell.

## What's in it

**Quick-add FAB.** A pure `fabSections` helper (TDD) reorders the FAB menu so the current section's action floats to the top and is highlighted. Same model for owner and caretaker.

**Account sheet.** New `AccountSheet` holds Settings, Sign out, and an admin-only section (Members, Companions). It renders as a bottom sheet on mobile (the "You" tab) and a popover from the desktop sidebar account row, with focus management and Escape/backdrop dismissal.

**Uniform household tabs.** The overview bottom tabs are Overview / Search / You for every role. The admin-only Members tab is gone; admin destinations live in the account sheet, so the bar no longer changes shape by role.

**Shared companion switcher.** Extracted the top-bar avatar switcher into one component used by the owner mobile nav and the caretaker layout.

**Unified caretaker shell.** Avatar switcher in place of the old select, a teal-tokenized shift banner, an on-shift quick-log FAB (Log activity / Add journal entry), the theme control moved to caretaker settings, Settings reachable on mobile even with no assigned companions, and a decluttered mobile header. Off shift, Journal and Log stay locked and the FAB is hidden. Caretakers still have no search.

**i18n.** Every hardcoded nav string moved into the locale files across all six languages.

## Out of scope
Inner-page redesigns, legacy palette-token removal, and caretaker page-body styling land in later sub-projects.

## Tests
`npm run lint`, `npm run check`, and 172 unit tests pass. New `tests/e2e/navigation.spec.ts` covers the account sheet (member vs admin) and caretaker on/off-shift nav, plus a `createSeededDbNoShift` harness helper. E2e green per project on desktop and mobile.