### PR TITLE
Redesign SP3a: Journal

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -262,6 +262,16 @@
 		font-family: var(--font-sans);
 	}
 
+	/* Markdown/code input must keep monospace alignment: disable the mono
+	   font's contextual ligatures (Geist Mono fuses runs like "###" into a
+	   single wider glyph, which breaks per-line left alignment). */
+	textarea {
+		font-variant-ligatures: none;
+		font-feature-settings:
+			'liga' 0,
+			'calt' 0;
+	}
+
 	::-webkit-scrollbar {
 		width: 6px;
 		height: 6px;

--- a/src/lib/components/MarkdownTextarea.svelte
+++ b/src/lib/components/MarkdownTextarea.svelte
@@ -83,7 +83,7 @@
 		</div>
 	{/if}
 
-	<details class="group mt-1.5">
+	<details class="group relative mt-1.5">
 		<summary
 			class="inline-flex cursor-pointer select-none list-none items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors [&::-webkit-details-marker]:hidden"
 		>
@@ -100,7 +100,9 @@
 			>
 			{t(locale, 'component.markdown.markdownSupported')}
 		</summary>
-		<div class="mt-2 rounded-md bg-muted/60 px-3 py-2.5 text-xs space-y-1.5">
+		<div
+			class="absolute left-0 top-full z-20 mt-2 w-72 rounded-md border border-border bg-popover px-3 py-2.5 text-xs space-y-1.5 shadow-lg"
+		>
 			<div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 items-baseline">
 				<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap">**bold**</code>
 				<span><strong>{t(locale, 'component.markdown.cheatsheet.bold')}</strong></span>

--- a/src/lib/components/MediaLightbox.svelte
+++ b/src/lib/components/MediaLightbox.svelte
@@ -141,7 +141,10 @@
 		>
 			<div class="flex items-center justify-between mb-2">
 				{#if items.length > 1}
-					<span class="text-sm text-white/60">{index + 1} / {items.length}</span>
+					<span
+						class="text-xs font-medium text-white bg-black/55 px-2.5 py-1 rounded-full select-none"
+						>{index + 1} / {items.length}</span
+					>
 				{:else}
 					<span></span>
 				{/if}
@@ -149,7 +152,7 @@
 					<a
 						href={mediaUrl(item)}
 						download={item.originalName ?? item.filename}
-						class="text-white/70 hover:text-white p-1 rounded"
+						class="flex items-center justify-center w-9 h-9 rounded-full bg-black/55 text-white hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 transition-colors"
 						aria-label={t(locale, 'aria.downloadMedia')}
 					>
 						<Download class="h-5 w-5" />
@@ -157,7 +160,7 @@
 					<button
 						type="button"
 						onclick={close}
-						class="text-white/70 hover:text-white p-1 rounded"
+						class="flex items-center justify-center w-9 h-9 rounded-full bg-black/55 text-white hover:bg-black/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 transition-colors"
 						aria-label={t(locale, 'aria.close')}
 					>
 						<X class="h-5 w-5" />
@@ -188,10 +191,10 @@
 						type="button"
 						onclick={prev}
 						disabled={index === 0}
-						class="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center text-white transition-opacity bg-black/40 {index ===
+						class="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center text-white bg-black/55 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 {index ===
 						0
-							? 'opacity-20 cursor-default'
-							: 'opacity-70 hover:opacity-100'}"
+							? 'opacity-25 cursor-default'
+							: 'hover:bg-black/70'}"
 						aria-label={t(locale, 'aria.previousMedia')}
 					>
 						<ChevronLeft class="h-5 w-5" />
@@ -200,10 +203,10 @@
 						type="button"
 						onclick={next}
 						disabled={index === items.length - 1}
-						class="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center text-white transition-opacity bg-black/40 {index ===
+						class="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center text-white bg-black/55 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 {index ===
 						items.length - 1
-							? 'opacity-20 cursor-default'
-							: 'opacity-70 hover:opacity-100'}"
+							? 'opacity-25 cursor-default'
+							: 'hover:bg-black/70'}"
 						aria-label={t(locale, 'aria.nextMedia')}
 					>
 						<ChevronRight class="h-5 w-5" />
@@ -212,7 +215,7 @@
 			</div>
 
 			{#if item.notes}
-				<div class="prose prose-sm prose-invert max-w-none mt-3 text-center text-sm">
+				<div class="prose prose-sm prose-invert max-w-none mt-3 text-center text-sm text-white/90">
 					{@html renderMarkdown(item.notes)}
 				</div>
 			{/if}

--- a/src/lib/components/journal/JournalTimelineEntry.svelte
+++ b/src/lib/components/journal/JournalTimelineEntry.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import { renderMarkdown } from '$lib/markdown';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import ByLine from '$lib/components/ByLine.svelte';
+	import { Pencil, NotebookPen, Play } from '@lucide/svelte';
+	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
+	import { t, getLocale } from '$lib/i18n';
+	import type { JournalPhoto, DailyEvent } from '$server/db/schema';
+	import type { UserRef } from '$lib/types';
+
+	type Photo = JournalPhoto & { logger: UserRef };
+	type Activity = DailyEvent & { logger: UserRef };
+
+	type Entry = {
+		date: string;
+		mood: string | null;
+		body: string | null;
+		loggedBy: string | null;
+		updatedBy: string | null;
+		logger: UserRef;
+		updater: { displayName: string } | null;
+		photos: Photo[];
+		events: Activity[];
+	};
+
+	interface Props {
+		entry: Entry;
+		companionId: string;
+		today: string;
+		canEdit: boolean;
+		onOpenLightbox: (photos: Photo[], date: string, index: number) => void;
+		onOpenActivity: (event: Activity) => void;
+	}
+
+	let { entry, companionId, today, canEdit, onOpenLightbox, onOpenActivity }: Props = $props();
+
+	const locale = getLocale();
+	const EVENT_ICONS = ACTIVITY_ICONS;
+	let isToday = $derived(entry.date === today);
+
+	const MAX_THUMBS = 4;
+	let visiblePhotos = $derived(entry.photos.slice(0, MAX_THUMBS));
+	let overflow = $derived(Math.max(0, entry.photos.length - MAX_THUMBS));
+
+	function dayNum(d: string) {
+		return new Date(d + 'T00:00:00').toLocaleDateString(undefined, { day: 'numeric' });
+	}
+	function weekday(d: string) {
+		return new Date(d + 'T00:00:00').toLocaleDateString(undefined, { weekday: 'short' });
+	}
+	function mediaUrl(item: Entry['photos'][number]) {
+		return `/api/photos/journal/${companionId}/${entry.date}/${item.filename}`;
+	}
+	function posterUrl(item: Entry['photos'][number]) {
+		return item.posterKey ? `${mediaUrl(item)}?poster` : null;
+	}
+</script>
+
+<div class="flex gap-3">
+	<div class="relative w-12 shrink-0 text-center">
+		<div
+			class="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border"
+			aria-hidden="true"
+		></div>
+		<div
+			class="relative z-10 mx-auto mt-1 h-2.5 w-2.5 rounded-full ring-4 ring-background {isToday
+				? 'bg-primary'
+				: 'bg-muted-foreground/40'}"
+			aria-hidden="true"
+		></div>
+		<div
+			class="mt-1.5 font-display text-xl font-bold leading-none {isToday
+				? 'text-primary'
+				: 'text-foreground'}"
+		>
+			{dayNum(entry.date)}
+		</div>
+		<div class="text-[10px] uppercase tracking-wide text-muted-foreground">
+			{weekday(entry.date)}
+		</div>
+	</div>
+
+	<div class="min-w-0 flex-1 rounded-2xl border bg-card p-4">
+		<div class="flex items-start justify-between gap-3">
+			<div class="flex min-w-0 items-center gap-2">
+				{#if entry.mood && MOOD_ICONS[entry.mood]}
+					<span class="text-xl shrink-0" title={entry.mood}>{MOOD_ICONS[entry.mood]}</span>
+				{:else}
+					<NotebookPen class="h-5 w-5 shrink-0 text-muted-foreground/40" />
+				{/if}
+				<div class="min-w-0 text-xs">
+					{#if isToday}<span class="font-medium text-primary"
+							>{t(locale, 'page.journal.today')}</span
+						>{/if}
+					<ByLine user={entry.logger} variant="inline" class="ml-0" />
+					{#if entry.updatedBy && entry.updatedBy !== entry.loggedBy && entry.updater}
+						<span class="text-muted-foreground"
+							>· {t(locale, 'common.updatedBy', { name: entry.updater.displayName })}</span
+						>
+					{/if}
+				</div>
+			</div>
+			{#if canEdit}
+				<Button
+					href="/{companionId}/journal/{entry.date}"
+					variant="soft"
+					size="sm"
+					class="h-7 shrink-0 gap-1 px-2 text-xs"
+				>
+					<Pencil class="h-3 w-3" />
+					{t(locale, 'page.journal.edit')}
+				</Button>
+			{/if}
+		</div>
+
+		{#if entry.photos.length > 0}
+			<div class="mt-3 flex gap-1.5">
+				{#each visiblePhotos as item, i (item.id)}
+					<button
+						type="button"
+						onclick={() => onOpenLightbox(entry.photos, entry.date, i)}
+						class="relative h-16 w-16 overflow-hidden rounded-lg transition-opacity hover:opacity-90"
+						title={item.originalName ??
+							t(
+								locale,
+								item.mediaType === 'video' ? 'page.journal.videoAlt' : 'page.journal.photoAlt'
+							)}
+					>
+						{#if item.mediaType === 'video' && item.posterKey}
+							<img
+								src={posterUrl(item)}
+								alt={item.originalName ?? ''}
+								class="h-full w-full object-cover"
+								loading="lazy"
+							/>
+						{:else if item.mediaType === 'video'}
+							<video
+								src={mediaUrl(item)}
+								preload="metadata"
+								muted
+								playsinline
+								class="h-full w-full object-cover"
+							></video>
+						{:else}
+							<img
+								src={mediaUrl(item)}
+								alt={item.originalName ?? ''}
+								class="h-full w-full object-cover"
+								loading="lazy"
+							/>
+						{/if}
+						{#if item.mediaType === 'video'}
+							<span
+								class="absolute inset-0 flex items-center justify-center bg-black/20"
+								aria-hidden="true"
+								><span class="rounded-full bg-black/55 p-1.5"
+									><Play class="h-4 w-4 text-white" /></span
+								></span
+							>
+						{/if}
+						{#if i === MAX_THUMBS - 1 && overflow > 0}
+							<span
+								class="absolute inset-0 flex items-center justify-center bg-black/60 text-sm font-semibold text-white"
+								>+{overflow}</span
+							>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		{/if}
+
+		{#if entry.body?.trim()}
+			<div
+				class="prose prose-sm dark:prose-invert mt-3 max-w-none leading-relaxed overflow-hidden"
+				style="display:-webkit-box;-webkit-line-clamp:4;-webkit-box-orient:vertical"
+			>
+				{@html renderMarkdown(entry.body)}
+			</div>
+		{:else if !entry.photos.length && !entry.events.length}
+			<p class="mt-3 text-sm italic text-muted-foreground">{t(locale, 'page.journal.noNotes')}</p>
+		{/if}
+
+		{#if entry.events.length > 0}
+			<div class="mt-3 flex flex-wrap gap-1.5">
+				{#each entry.events as event (event.id)}
+					<button
+						type="button"
+						onclick={() => onOpenActivity(event)}
+						class="inline-flex items-center gap-1 rounded-full bg-secondary px-2.5 py-0.5 text-xs font-semibold text-secondary-foreground transition-colors hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					>
+						{EVENT_ICONS[event.type] ?? '📝'}
+						<span class="capitalize">{event.type}</span>
+						{#if event.durationMinutes}<span class="text-muted-foreground"
+								>· {event.durationMinutes}m</span
+							>{/if}
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/journal/JournalTimelineEntry.svelte
+++ b/src/lib/components/journal/JournalTimelineEntry.svelte
@@ -124,6 +124,11 @@
 								locale,
 								item.mediaType === 'video' ? 'page.journal.videoAlt' : 'page.journal.photoAlt'
 							)}
+						aria-label={item.originalName ??
+							t(
+								locale,
+								item.mediaType === 'video' ? 'page.journal.videoAlt' : 'page.journal.photoAlt'
+							)}
 					>
 						{#if item.mediaType === 'video' && item.posterKey}
 							<img
@@ -171,7 +176,7 @@
 
 		{#if entry.body?.trim()}
 			<div
-				class="prose prose-sm dark:prose-invert mt-3 max-w-none leading-relaxed overflow-hidden max-h-[6rem]"
+				class="prose prose-sm dark:prose-invert mt-3 max-w-none leading-relaxed overflow-hidden max-h-[6rem] [mask-image:linear-gradient(to_bottom,black_60%,transparent_100%)]"
 			>
 				{@html renderMarkdown(entry.body)}
 			</div>

--- a/src/lib/components/journal/JournalTimelineEntry.svelte
+++ b/src/lib/components/journal/JournalTimelineEntry.svelte
@@ -51,19 +51,9 @@
 </script>
 
 <div class="flex gap-3">
-	<div class="relative w-12 shrink-0 text-center">
+	<div class="relative flex w-12 shrink-0 flex-col items-center">
 		<div
-			class="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border"
-			aria-hidden="true"
-		></div>
-		<div
-			class="relative z-10 mx-auto mt-1 h-2.5 w-2.5 rounded-full ring-4 ring-background {isToday
-				? 'bg-primary'
-				: 'bg-muted-foreground/40'}"
-			aria-hidden="true"
-		></div>
-		<div
-			class="mt-1.5 font-display text-xl font-bold leading-none {isToday
+			class="font-display text-xl font-bold leading-none {isToday
 				? 'text-primary'
 				: 'text-foreground'}"
 		>
@@ -72,6 +62,17 @@
 		<div class="text-[10px] uppercase tracking-wide text-muted-foreground">
 			{weekday(entry.date)}
 		</div>
+		<div
+			class="mt-1.5 h-2.5 w-2.5 rounded-full ring-4 ring-background {isToday
+				? 'bg-primary'
+				: 'bg-muted-foreground/40'}"
+			aria-hidden="true"
+		></div>
+		<div
+			class="absolute left-1/2 w-px -translate-x-1/2 bg-border"
+			style="top: calc(100% - 0.125rem); bottom: -0.75rem;"
+			aria-hidden="true"
+		></div>
 	</div>
 
 	<div class="min-w-0 flex-1 rounded-2xl border bg-card p-4">
@@ -175,9 +176,7 @@
 		{/if}
 
 		{#if entry.body?.trim()}
-			<div
-				class="prose prose-sm dark:prose-invert mt-3 max-w-none leading-relaxed overflow-hidden max-h-[6rem] [mask-image:linear-gradient(to_bottom,black_60%,transparent_100%)]"
-			>
+			<div class="prose prose-sm dark:prose-invert mt-3 max-w-none leading-relaxed">
 				{@html renderMarkdown(entry.body)}
 			</div>
 		{:else if !entry.photos.length && !entry.events.length}

--- a/src/lib/components/journal/JournalTimelineEntry.svelte
+++ b/src/lib/components/journal/JournalTimelineEntry.svelte
@@ -5,19 +5,14 @@
 	import { Pencil, NotebookPen, Play } from '@lucide/svelte';
 	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { t, getLocale } from '$lib/i18n';
-	import type { JournalPhoto, DailyEvent } from '$server/db/schema';
+	import type { JournalEntry, JournalPhoto, DailyEvent } from '$server/db/schema';
 	import type { UserRef } from '$lib/types';
 
 	type Photo = JournalPhoto & { logger: UserRef };
 	type Activity = DailyEvent & { logger: UserRef };
 
-	type Entry = {
-		date: string;
-		mood: string | null;
-		body: string | null;
-		loggedBy: string | null;
-		updatedBy: string | null;
-		logger: UserRef;
+	type Entry = Pick<JournalEntry, 'date' | 'mood' | 'body' | 'loggedBy' | 'updatedBy'> & {
+		logger: UserRef | null;
 		updater: { displayName: string } | null;
 		photos: Photo[];
 		events: Activity[];
@@ -35,7 +30,6 @@
 	let { entry, companionId, today, canEdit, onOpenLightbox, onOpenActivity }: Props = $props();
 
 	const locale = getLocale();
-	const EVENT_ICONS = ACTIVITY_ICONS;
 	let isToday = $derived(entry.date === today);
 
 	const MAX_THUMBS = 4;
@@ -118,7 +112,12 @@
 				{#each visiblePhotos as item, i (item.id)}
 					<button
 						type="button"
-						onclick={() => onOpenLightbox(entry.photos, entry.date, i)}
+						onclick={() =>
+							onOpenLightbox(
+								entry.photos,
+								entry.date,
+								i === MAX_THUMBS - 1 && overflow > 0 ? MAX_THUMBS : i
+							)}
 						class="relative h-16 w-16 overflow-hidden rounded-lg transition-opacity hover:opacity-90"
 						title={item.originalName ??
 							t(
@@ -139,6 +138,7 @@
 								preload="metadata"
 								muted
 								playsinline
+								aria-hidden="true"
 								class="h-full w-full object-cover"
 							></video>
 						{:else}
@@ -171,8 +171,7 @@
 
 		{#if entry.body?.trim()}
 			<div
-				class="prose prose-sm dark:prose-invert mt-3 max-w-none leading-relaxed overflow-hidden"
-				style="display:-webkit-box;-webkit-line-clamp:4;-webkit-box-orient:vertical"
+				class="prose prose-sm dark:prose-invert mt-3 max-w-none leading-relaxed overflow-hidden max-h-[6rem]"
 			>
 				{@html renderMarkdown(entry.body)}
 			</div>
@@ -188,7 +187,7 @@
 						onclick={() => onOpenActivity(event)}
 						class="inline-flex items-center gap-1 rounded-full bg-secondary px-2.5 py-0.5 text-xs font-semibold text-secondary-foreground transition-colors hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
 					>
-						{EVENT_ICONS[event.type] ?? '📝'}
+						{ACTIVITY_ICONS[event.type] ?? '📝'}
 						<span class="capitalize">{event.type}</span>
 						{#if event.durationMinutes}<span class="text-muted-foreground"
 								>· {event.durationMinutes}m</span

--- a/src/lib/components/journal/JournalTimelineEntry.svelte
+++ b/src/lib/components/journal/JournalTimelineEntry.svelte
@@ -63,16 +63,13 @@
 			{weekday(entry.date)}
 		</div>
 		<div
-			class="mt-1.5 h-2.5 w-2.5 rounded-full ring-4 ring-background {isToday
+			class="mt-1.5 h-3 w-3 rounded-full ring-4 ring-background {isToday
 				? 'bg-primary'
-				: 'bg-muted-foreground/40'}"
+				: 'bg-muted-foreground/50'}"
 			aria-hidden="true"
 		></div>
-		<div
-			class="absolute left-1/2 w-px -translate-x-1/2 bg-border"
-			style="top: calc(100% - 0.125rem); bottom: -0.75rem;"
-			aria-hidden="true"
-		></div>
+		<!-- Connector: fills the rest of the row height and bridges the gap to the next entry. -->
+		<div class="mt-1.5 -mb-3 w-0.5 flex-1 rounded-full bg-border" aria-hidden="true"></div>
 	</div>
 
 	<div class="min-w-0 flex-1 rounded-2xl border bg-card p-4">

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -216,7 +216,6 @@
 							.slice(0, 10)}"
 						variant="soft"
 						size="sm"
-						onclick={closeDetail}
 					>
 						<Pencil class="h-3.5 w-3.5 mr-1.5" />
 						{t(locale, 'page.journal.activityDetailOpenInJournal')}

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -49,8 +49,6 @@
 		}
 	}
 
-	const EVENT_ICONS = ACTIVITY_ICONS;
-
 	function formatMonth(d: string) {
 		return new Date(d + 'T00:00:00').toLocaleDateString(undefined, {
 			month: 'long',
@@ -157,7 +155,7 @@
 		>
 			<div class="flex items-center justify-between px-5 pt-5 pb-3">
 				<h2 class="font-semibold text-base text-foreground">
-					{EVENT_ICONS[detailEvent.type] ?? '📝'}
+					{ACTIVITY_ICONS[detailEvent.type] ?? '📝'}
 					{detailEvent.type.charAt(0).toUpperCase() + detailEvent.type.slice(1)}
 				</h2>
 				<button

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -227,7 +227,7 @@
 	</div>
 {/if}
 
-<div class="space-y-6 pb-24 md:pb-0">
+<div class="space-y-6 pb-24 md:pb-0 mx-auto max-w-2xl">
 	{#if !companion.isActive}
 		<div class="rounded-lg bg-muted/50 px-4 py-2.5 text-sm text-muted-foreground mb-4">
 			{t(locale, 'page.journal.archivedNotice', { name: companion.name })}

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -227,7 +227,7 @@
 	</div>
 {/if}
 
-<div class="space-y-6 pb-24 md:pb-0 mx-auto max-w-2xl">
+<div class="space-y-6 pb-24 md:pb-0 mx-auto max-w-3xl">
 	{#if !companion.isActive}
 		<div class="rounded-lg bg-muted/50 px-4 py-2.5 text-sm text-muted-foreground mb-4">
 			{t(locale, 'page.journal.archivedNotice', { name: companion.name })}

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -226,7 +226,7 @@
 	</div>
 {/if}
 
-<div class="space-y-6 pb-24 md:pb-0 mx-auto max-w-3xl">
+<div class="space-y-6 pb-24 md:pb-0">
 	{#if !companion.isActive}
 		<div class="rounded-lg bg-muted/50 px-4 py-2.5 text-sm text-muted-foreground mb-4">
 			{t(locale, 'page.journal.archivedNotice', { name: companion.name })}

--- a/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/+page.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { renderMarkdown } from '$lib/markdown';
-	import { Card, CardHeader, CardContent } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Separator } from '$lib/components/ui/separator/index.js';
-	import { X, Pencil, NotebookPen, ArrowRight, Play } from '@lucide/svelte';
+	import { X, Pencil, NotebookPen, ArrowRight } from '@lucide/svelte';
+	import JournalTimelineEntry from '$lib/components/journal/JournalTimelineEntry.svelte';
 	import { tick } from 'svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
 	import MediaLightbox from '$lib/components/MediaLightbox.svelte';
-	import { MOOD_ICONS, ACTIVITY_ICONS } from '$lib/i18n/labels';
+	import { ACTIVITY_ICONS } from '$lib/i18n/labels';
 	import { t, getLocale } from '$lib/i18n';
 
 	const locale = getLocale();
@@ -51,28 +51,11 @@
 
 	const EVENT_ICONS = ACTIVITY_ICONS;
 
-	function formatDate(d: string) {
-		return new Date(d + 'T00:00:00').toLocaleDateString(undefined, {
-			weekday: 'long',
-			month: 'long',
-			day: 'numeric',
-			year: 'numeric'
-		});
-	}
-
 	function formatMonth(d: string) {
 		return new Date(d + 'T00:00:00').toLocaleDateString(undefined, {
 			month: 'long',
 			year: 'numeric'
 		});
-	}
-
-	function mediaUrl(item: Entry['photos'][0], date: string) {
-		return `/api/photos/journal/${companion.id}/${date}/${item.filename}`;
-	}
-
-	function posterUrl(item: Entry['photos'][0], date: string) {
-		return item.posterKey ? `${mediaUrl(item, date)}?poster` : null;
 	}
 
 	function monthKey(date: string) {
@@ -267,20 +250,18 @@
 	</div>
 
 	{#if entries.length === 0}
-		<Card>
-			<CardContent class="text-center py-12">
-				<NotebookPen class="h-10 w-10 mb-3 mx-auto text-muted-foreground" />
-				<p class="font-medium mb-1 text-foreground">{t(locale, 'page.journal.emptyTitle')}</p>
-				<p class="text-sm mb-4 text-muted-foreground">
-					{t(locale, 'page.journal.emptyBody', { name: companion.name })}
-				</p>
-				{#if companion.isActive !== false}
-					<Button href="/{companion.id}/journal/{data.today}"
-						>{t(locale, 'page.journal.writeFirstEntry')}</Button
-					>
-				{/if}
-			</CardContent>
-		</Card>
+		<div class="rounded-xl border bg-card text-center py-12 px-6">
+			<NotebookPen class="h-10 w-10 mb-3 mx-auto text-muted-foreground" />
+			<p class="font-medium mb-1 text-foreground">{t(locale, 'page.journal.emptyTitle')}</p>
+			<p class="text-sm mb-4 text-muted-foreground">
+				{t(locale, 'page.journal.emptyBody', { name: companion.name })}
+			</p>
+			{#if companion.isActive !== false}
+				<Button href="/{companion.id}/journal/{data.today}"
+					>{t(locale, 'page.journal.writeFirstEntry')}</Button
+				>
+			{/if}
+		</div>
 	{:else}
 		{@const grouped = entries.reduce<{ month: string; items: Entry[] }[]>((acc, entry) => {
 			const mk = monthKey(entry.date);
@@ -298,142 +279,18 @@
 				<Separator class="flex-1" />
 			</div>
 
-			{#each group.items as entry (entry.date)}
-				<Card class="overflow-hidden">
-					<CardHeader class="py-3 px-5">
-						<div class="flex items-center justify-between gap-3">
-							<div class="flex items-center gap-2 min-w-0">
-								{#if entry.mood && MOOD_ICONS[entry.mood]}
-									<span class="text-xl shrink-0" title={entry.mood}>{MOOD_ICONS[entry.mood]}</span>
-								{:else}
-									<NotebookPen class="h-5 w-5 shrink-0 opacity-30 text-foreground" />
-								{/if}
-								<div class="min-w-0">
-									<h2 class="font-semibold text-sm leading-snug truncate text-foreground">
-										{formatDate(entry.date)}
-									</h2>
-									{#if entry.date === data.today}
-										<span class="text-xs font-medium text-primary"
-											>{t(locale, 'page.journal.today')}</span
-										>
-									{/if}
-									<ByLine user={entry.logger} variant="inline" class="ml-0" />
-									{#if entry.updatedBy && entry.updatedBy !== entry.loggedBy && entry.updater}
-										<span class="text-xs text-muted-foreground">
-											· {t(locale, 'common.updatedBy', { name: entry.updater.displayName })}
-										</span>
-									{/if}
-								</div>
-							</div>
-							{#if companion.isActive !== false}
-								<Button
-									href="/{companion.id}/journal/{entry.date}"
-									variant="soft"
-									size="sm"
-									class="h-7 text-xs shrink-0 gap-1"
-								>
-									<Pencil class="h-3 w-3" />
-									{t(locale, 'page.journal.edit')}
-								</Button>
-							{/if}
-						</div>
-					</CardHeader>
-
-					<!-- Media -->
-					{#if entry.photos.length > 0}
-						<div
-							class="grid gap-0.5 {entry.photos.length === 1
-								? 'grid-cols-1'
-								: entry.photos.length === 2
-									? 'grid-cols-2'
-									: 'grid-cols-3'}"
-						>
-							{#each entry.photos as item, i (item.id)}
-								<button
-									type="button"
-									onclick={() => openLightbox(entry.photos, entry.date, i)}
-									class="relative block overflow-hidden {entry.photos.length === 1
-										? 'aspect-video'
-										: 'aspect-square'} hover:opacity-95 transition-opacity"
-									title={item.originalName ??
-										t(
-											locale,
-											item.mediaType === 'video' ? 'page.journal.videoAlt' : 'page.journal.photoAlt'
-										)}
-								>
-									{#if item.mediaType === 'video'}
-										{#if item.posterKey}
-											<img
-												src={posterUrl(item, entry.date)}
-												alt={item.originalName ?? ''}
-												class="w-full h-full object-cover pointer-events-none"
-												loading="lazy"
-											/>
-										{:else}
-											<video
-												src={mediaUrl(item, entry.date)}
-												preload="metadata"
-												muted
-												playsinline
-												class="w-full h-full object-cover pointer-events-none"
-											></video>
-										{/if}
-										<span
-											class="absolute inset-0 flex items-center justify-center bg-black/20"
-											aria-hidden="true"
-										>
-											<span class="rounded-full bg-black/55 p-2">
-												<Play class="h-5 w-5 text-white" />
-											</span>
-										</span>
-									{:else}
-										<img
-											src={mediaUrl(item, entry.date)}
-											alt={item.originalName ?? ''}
-											class="w-full h-full object-cover"
-											loading="lazy"
-										/>
-									{/if}
-								</button>
-							{/each}
-						</div>
-					{/if}
-
-					<!-- Markdown body -->
-					{#if entry.body?.trim()}
-						<CardContent class="py-4">
-							<div class="prose prose-sm dark:prose-invert max-w-none leading-relaxed">
-								{@html renderMarkdown(entry.body)}
-							</div>
-						</CardContent>
-					{:else if !entry.photos.length && !entry.events.length}
-						<CardContent class="py-4">
-							<p class="text-sm italic text-muted-foreground">
-								{t(locale, 'page.journal.noNotes')}
-							</p>
-						</CardContent>
-					{/if}
-
-					<!-- Activities -->
-					{#if entry.events.length > 0}
-						<div class="px-5 pt-3 pb-4 flex flex-wrap gap-1.5">
-							{#each entry.events as event (event.id)}
-								<button
-									type="button"
-									onclick={() => openDetail(event)}
-									class="inline-flex items-center gap-1 rounded-full border border-transparent bg-secondary text-secondary-foreground px-2.5 py-0.5 text-xs font-semibold transition-colors hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-								>
-									{EVENT_ICONS[event.type] ?? '📝'}
-									<span class="capitalize">{event.type}</span>
-									{#if event.durationMinutes}
-										<span class="text-muted-foreground">· {event.durationMinutes}m</span>
-									{/if}
-								</button>
-							{/each}
-						</div>
-					{/if}
-				</Card>
-			{/each}
+			<div class="space-y-3">
+				{#each group.items as entry (entry.date)}
+					<JournalTimelineEntry
+						{entry}
+						companionId={companion.id}
+						today={data.today}
+						canEdit={companion.isActive !== false}
+						onOpenLightbox={openLightbox}
+						onOpenActivity={openDetail}
+					/>
+				{/each}
+			</div>
 		{/each}
 
 		{#if hasMore}

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -526,7 +526,7 @@
 {/if}
 
 <div class="pb-24 md:pb-0">
-	<div class="mx-auto max-w-3xl space-y-6">
+	<div class="space-y-6">
 		<!-- Back to journal -->
 		<div>
 			<a

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -527,6 +527,16 @@
 {/if}
 
 <div class="space-y-4 pb-24 md:pb-0">
+	<!-- Back to journal -->
+	<div>
+		<a
+			href="/{companion.id}/journal"
+			class="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+		>
+			<ChevronLeft class="h-3.5 w-3.5" />
+			{t(locale, 'page.journal.title')}
+		</a>
+	</div>
 	<!-- Date nav -->
 	<div class="flex items-center justify-between">
 		<div class="flex items-center gap-2">
@@ -616,9 +626,7 @@
 						title={m.label}
 						aria-pressed={mood === m.value}
 						class="text-xl leading-none p-1.5 rounded-lg transition-all
-						{mood === m.value
-							? 'bg-bark-100 dark:bg-bark-900 ring-1 ring-bark-300 dark:ring-bark-700'
-							: 'opacity-40 hover:opacity-80'}"
+						{mood === m.value ? 'bg-primary/10 ring-1 ring-primary/30' : 'opacity-40 hover:opacity-80'}"
 					>
 						{m.icon}
 					</button>

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -21,9 +21,7 @@
 		ChevronLeft,
 		ChevronRight,
 		Calendar,
-		Camera,
 		ImageIcon,
-		ClipboardList,
 		Plus,
 		Pencil,
 		NotebookPen,
@@ -526,294 +524,306 @@
 	</div>
 {/if}
 
-<div class="space-y-4 pb-24 md:pb-0">
-	<!-- Back to journal -->
-	<div>
-		<a
-			href="/{companion.id}/journal"
-			class="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-		>
-			<ChevronLeft class="h-3.5 w-3.5" />
-			{t(locale, 'page.journal.title')}
-		</a>
-	</div>
-	<!-- Date nav -->
-	<div class="flex items-center justify-between">
-		<div class="flex items-center gap-2">
+<div class="pb-24 md:pb-0">
+	<div class="mx-auto max-w-3xl space-y-6">
+		<!-- Back to journal -->
+		<div>
 			<a
-				href="/{companion.id}/journal/{prevDate(data.date)}"
-				class="inline-flex items-center justify-center rounded-md h-8 w-8 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-				><ChevronLeft class="h-4 w-4" /></a
+				href="/{companion.id}/journal"
+				class="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
 			>
-			<div>
-				<h1 class="font-display font-semibold text-foreground">{formatDisplayDate(data.date)}</h1>
-			</div>
-			<a
-				href="/{companion.id}/journal/{nextDate(data.date)}"
-				class="inline-flex items-center justify-center rounded-md h-8 w-8 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring {isNextDisabled
-					? 'opacity-30 pointer-events-none'
-					: ''}"><ChevronRight class="h-4 w-4" /></a
-			>
-			<!-- Calendar picker -->
-			<div class="relative">
-				<button
-					type="button"
-					onclick={() => datePickerEl?.showPicker()}
-					class="inline-flex items-center justify-center rounded-md h-8 w-8 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-					title="Go to date"><Calendar class="h-4 w-4" /></button
-				>
-				<input
-					bind:this={datePickerEl}
-					id="datePicker"
-					type="date"
-					value={data.date}
-					max={data.today}
-					onchange={(e) => {
-						const v = (e.target as HTMLInputElement).value;
-						if (v) goto(`/${companion.id}/journal/${v}`);
-					}}
-					class="sr-only"
-				/>
-			</div>
-			{#if data.isToday}
-				<span class="text-xs font-medium px-2 py-1 text-primary"
-					>{t(locale, 'page.journal.today')}</span
-				>
-			{:else}
-				<a
-					href="/{companion.id}/journal/{data.today}"
-					class="inline-flex items-center gap-0.5 rounded-md px-2 py-1 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-					>{t(locale, 'page.journal.today')} <ChevronRight class="h-3.5 w-3.5" /></a
-				>
-			{/if}
+				<ChevronLeft class="h-3.5 w-3.5" />
+				{t(locale, 'page.journal.title')}
+			</a>
 		</div>
-		<span class="hidden items-center gap-1 sm:flex">
+
+		<!-- Date nav + autosave -->
+		<div class="flex items-center justify-between">
+			<div class="flex items-center gap-2">
+				<a
+					href="/{companion.id}/journal/{prevDate(data.date)}"
+					class="inline-flex items-center justify-center rounded-md h-8 w-8 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+					><ChevronLeft class="h-4 w-4" /></a
+				>
+				<div>
+					<h1 class="font-display font-semibold text-foreground">{formatDisplayDate(data.date)}</h1>
+				</div>
+				<a
+					href="/{companion.id}/journal/{nextDate(data.date)}"
+					class="inline-flex items-center justify-center rounded-md h-8 w-8 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring {isNextDisabled
+						? 'opacity-30 pointer-events-none'
+						: ''}"><ChevronRight class="h-4 w-4" /></a
+				>
+				<!-- Calendar picker -->
+				<div class="relative">
+					<button
+						type="button"
+						onclick={() => datePickerEl?.showPicker()}
+						class="inline-flex items-center justify-center rounded-md h-8 w-8 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+						title="Go to date"><Calendar class="h-4 w-4" /></button
+					>
+					<input
+						bind:this={datePickerEl}
+						id="datePicker"
+						type="date"
+						value={data.date}
+						max={data.today}
+						onchange={(e) => {
+							const v = (e.target as HTMLInputElement).value;
+							if (v) goto(`/${companion.id}/journal/${v}`);
+						}}
+						class="sr-only"
+					/>
+				</div>
+				{#if data.isToday}
+					<span class="text-xs font-medium px-2 py-1 text-primary"
+						>{t(locale, 'page.journal.today')}</span
+					>
+				{:else}
+					<a
+						href="/{companion.id}/journal/{data.today}"
+						class="inline-flex items-center gap-0.5 rounded-md px-2 py-1 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+						>{t(locale, 'page.journal.today')} <ChevronRight class="h-3.5 w-3.5" /></a
+					>
+				{/if}
+			</div>
+			<div class="flex items-center gap-3">
+				<!-- Save status (inline, right of date nav) -->
+				<div class="flex items-center gap-2 text-sm shrink-0">
+					{#if saveStatus === 'saving'}
+						<span class="animate-pulse text-muted-foreground"
+							>{t(locale, 'page.journal.day.savingStatus')}</span
+						>
+					{:else if saveStatus === 'saved'}
+						<span class="text-green-600 dark:text-green-400"
+							>{t(locale, 'page.journal.day.savedStatus')}</span
+						>
+					{:else if saveStatus === 'error'}
+						<span class="text-red-500">{t(locale, 'page.journal.day.saveFailedStatus')}</span>
+						<button
+							type="button"
+							onclick={saveNow}
+							class="text-xs text-red-500 underline hover:no-underline"
+							>{t(locale, 'page.journal.day.saveFailedRetry')}</button
+						>
+					{/if}
+				</div>
+				<span class="hidden items-center gap-1 sm:flex">
+					<ByLine user={data.entry?.logger} variant="inline" class="ml-0" />
+					{#if data.entry?.updatedBy && data.entry.updatedBy !== data.entry.loggedBy && data.entry.updater}
+						<span class="text-xs text-muted-foreground">
+							· {t(locale, 'common.updatedBy', { name: data.entry.updater.displayName })}
+						</span>
+					{/if}
+				</span>
+			</div>
+		</div>
+		<div class="flex items-center gap-1 sm:hidden">
 			<ByLine user={data.entry?.logger} variant="inline" class="ml-0" />
 			{#if data.entry?.updatedBy && data.entry.updatedBy !== data.entry.loggedBy && data.entry.updater}
 				<span class="text-xs text-muted-foreground">
 					· {t(locale, 'common.updatedBy', { name: data.entry.updater.displayName })}
 				</span>
 			{/if}
-		</span>
-	</div>
-	<div class="flex items-center gap-1 sm:hidden">
-		<ByLine user={data.entry?.logger} variant="inline" class="ml-0" />
-		{#if data.entry?.updatedBy && data.entry.updatedBy !== data.entry.loggedBy && data.entry.updater}
-			<span class="text-xs text-muted-foreground">
-				· {t(locale, 'common.updatedBy', { name: data.entry.updater.displayName })}
-			</span>
-		{/if}
-	</div>
-
-	<!-- Mood -->
-	<div class="flex items-center justify-between">
-		<div class="flex items-center gap-2">
-			<span class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
-				>{t(locale, 'page.journal.day.mood')}</span
-			>
-			<div
-				role="group"
-				aria-label={t(locale, 'page.journal.day.moodQuestion', { name: companion.name })}
-				class="flex gap-1"
-			>
-				{#each MOODS as m (m.value)}
-					<button
-						type="button"
-						onclick={() => {
-							mood = mood === m.value ? '' : m.value;
-							triggerSave();
-						}}
-						title={m.label}
-						aria-pressed={mood === m.value}
-						class="text-xl leading-none p-1.5 rounded-lg transition-all
-						{mood === m.value ? 'bg-primary/10 ring-1 ring-primary/30' : 'opacity-40 hover:opacity-80'}"
-					>
-						{m.icon}
-					</button>
-				{/each}
-			</div>
-		</div>
-		<!-- Save status -->
-		<div class="flex items-center gap-2 text-sm shrink-0">
-			{#if saveStatus === 'saving'}
-				<span class="animate-pulse text-muted-foreground"
-					>{t(locale, 'page.journal.day.savingStatus')}</span
-				>
-			{:else if saveStatus === 'saved'}
-				<span class="text-green-600 dark:text-green-400"
-					>{t(locale, 'page.journal.day.savedStatus')}</span
-				>
-			{:else if saveStatus === 'error'}
-				<span class="text-red-500">{t(locale, 'page.journal.day.saveFailedStatus')}</span>
-				<button
-					type="button"
-					onclick={saveNow}
-					class="text-xs text-red-500 underline hover:no-underline"
-					>{t(locale, 'page.journal.day.saveFailedRetry')}</button
-				>
-			{/if}
-		</div>
-	</div>
-
-	<!-- Editor -->
-	<div class="rounded-lg border border-border bg-card overflow-hidden">
-		<div class="flex items-center justify-between px-4 py-2 border-b border-border">
-			<div class="flex gap-0.5">
-				<button
-					type="button"
-					onclick={() => {
-						viewMode = 'write';
-						tick().then(() => textareaEl?.focus());
-					}}
-					class="px-3 py-1 rounded-md text-sm font-medium transition-colors {viewMode === 'write'
-						? 'bg-accent text-foreground'
-						: 'text-muted-foreground hover:text-foreground'}"
-				>
-					{t(locale, 'page.journal.day.write')}
-				</button>
-				<button
-					type="button"
-					onclick={() => (viewMode = 'preview')}
-					class="px-3 py-1 rounded-md text-sm font-medium transition-colors {viewMode === 'preview'
-						? 'bg-accent text-foreground'
-						: 'text-muted-foreground hover:text-foreground'}"
-				>
-					{t(locale, 'page.journal.day.preview')}
-				</button>
-			</div>
-			<div class="hidden sm:flex items-center gap-3">
-				<span class="text-xs text-muted-foreground">{t(locale, 'page.journal.day.toggleHint')}</span
-				>
-				<details class="group">
-					<summary
-						class="inline-flex cursor-pointer select-none list-none items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors [&::-webkit-details-marker]:hidden"
-					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							class="h-3 w-3 transition-transform group-open:rotate-90"
-							aria-hidden="true"><path d="m9 18 6-6-6-6" /></svg
-						>
-						Markdown supported
-					</summary>
-					<div class="mt-2 rounded-md bg-muted/60 px-3 py-2.5 text-xs space-y-1.5">
-						<div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 items-baseline">
-							<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
-								>**bold**</code
-							>
-							<span><strong>bold</strong></span>
-
-							<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
-								>_italic_</code
-							>
-							<span><em>italic</em></span>
-
-							<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
-								>## Heading</code
-							>
-							<span class="font-semibold text-sm">Heading</span>
-
-							<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap">- item</code>
-							<span>bullet list item</span>
-
-							<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap">1. item</code
-							>
-							<span>numbered list item</span>
-
-							<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
-								>&gt; note</code
-							>
-							<span class="border-l-2 border-border pl-2 text-muted-foreground">note</span>
-
-							<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
-								>[text](url)</code
-							>
-							<span class="text-primary underline">link text</span>
-						</div>
-					</div>
-				</details>
-			</div>
 		</div>
 
-		{#if viewMode === 'write'}
-			<textarea
-				bind:this={textareaEl}
-				bind:value={body}
-				oninput={triggerSave}
-				placeholder={t(locale, 'page.journal.day.writePlaceholder', { name: companion.name })}
-				class="w-full min-h-[360px] resize-none p-4 text-sm font-mono leading-relaxed bg-card text-foreground placeholder:text-muted-foreground focus:outline-none"
-				spellcheck="true"
-			></textarea>
-		{:else}
-			<div
-				class="prose prose-sm dark:prose-invert max-w-none p-4 min-h-[360px] bg-card text-foreground"
-			>
-				{@html renderedMarkdown}
-			</div>
-		{/if}
-	</div>
-
-	<!-- Media -->
-	<div class="rounded-lg border border-border bg-card overflow-hidden">
-		<div
-			class="flex flex-col gap-3 px-5 py-3 border-b border-border sm:flex-row sm:items-center sm:justify-between"
-		>
-			<h2 class="font-semibold flex items-center gap-2 text-foreground">
-				<Camera class="h-4 w-4" />
-				{t(locale, 'page.journal.day.mediaTitle')}
-				<span class="text-xs font-normal text-muted-foreground"
-					>{media.length}/{data.maxDailyMedia}</span
+		<!-- Mood -->
+		<div>
+			<div class="flex items-center gap-2">
+				<span class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground"
+					>{t(locale, 'page.journal.day.mood')}</span
 				>
-			</h2>
-			{#if media.length < data.maxDailyMedia}
-				<div class="flex flex-wrap items-center gap-2">
-					{#if data.immichEnabled}
+				<div
+					role="group"
+					aria-label={t(locale, 'page.journal.day.moodQuestion', { name: companion.name })}
+					class="flex gap-1"
+				>
+					{#each MOODS as m (m.value)}
 						<button
 							type="button"
-							class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
-							onclick={() => (immichPickerOpen = true)}
+							onclick={() => {
+								mood = mood === m.value ? '' : m.value;
+								triggerSave();
+							}}
+							title={m.label}
+							aria-pressed={mood === m.value}
+							class="text-xl leading-none p-1.5 rounded-lg transition-all
+							{mood === m.value ? 'bg-primary/10 ring-1 ring-primary/30' : 'opacity-40 hover:opacity-80'}"
 						>
-							<ImageIcon class="h-3.5 w-3.5" />
-							{t(locale, 'immich.picker.button')}
+							{m.icon}
 						</button>
-					{/if}
-					<label
-						class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent cursor-pointer"
-					>
-						{#if uploading}{t(locale, 'page.journal.day.uploading')}{:else}<Plus
-								class="h-3.5 w-3.5"
-							/>
-							{t(locale, 'page.journal.day.addMedia')}{/if}
-						<input
-							bind:this={fileInputEl}
-							type="file"
-							name="photos"
-							accept={MEDIA_ACCEPT}
-							multiple
-							class="sr-only"
-							onchange={handleFileInput}
-							disabled={uploading}
-						/>
-					</label>
+					{/each}
 				</div>
-			{/if}
+			</div>
 		</div>
 
-		{#if uploadError}
-			<div
-				role="alert"
-				class="mx-4 my-3 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
-			>
-				{uploadError}
-			</div>
-		{/if}
+		<!-- Note editor -->
+		<div class="space-y-2">
+			<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+				{t(locale, 'page.journal.day.write')}
+			</p>
+			<div class="rounded-lg border border-input overflow-hidden">
+				<div class="flex items-center justify-between px-3 py-1.5 border-b border-border">
+					<div class="flex gap-0.5">
+						<button
+							type="button"
+							onclick={() => {
+								viewMode = 'write';
+								tick().then(() => textareaEl?.focus());
+							}}
+							class="px-3 py-1 rounded-md text-sm font-medium transition-colors {viewMode ===
+							'write'
+								? 'bg-accent text-foreground'
+								: 'text-muted-foreground hover:text-foreground'}"
+						>
+							{t(locale, 'page.journal.day.write')}
+						</button>
+						<button
+							type="button"
+							onclick={() => (viewMode = 'preview')}
+							class="px-3 py-1 rounded-md text-sm font-medium transition-colors {viewMode ===
+							'preview'
+								? 'bg-accent text-foreground'
+								: 'text-muted-foreground hover:text-foreground'}"
+						>
+							{t(locale, 'page.journal.day.preview')}
+						</button>
+					</div>
+					<div class="hidden sm:flex items-center gap-3">
+						<span class="text-xs text-muted-foreground"
+							>{t(locale, 'page.journal.day.toggleHint')}</span
+						>
+						<details class="group">
+							<summary
+								class="inline-flex cursor-pointer select-none list-none items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors [&::-webkit-details-marker]:hidden"
+							>
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									class="h-3 w-3 transition-transform group-open:rotate-90"
+									aria-hidden="true"><path d="m9 18 6-6-6-6" /></svg
+								>
+								Markdown supported
+							</summary>
+							<div class="mt-2 rounded-md bg-muted/60 px-3 py-2.5 text-xs space-y-1.5">
+								<div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 items-baseline">
+									<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
+										>**bold**</code
+									>
+									<span><strong>bold</strong></span>
 
-		<div class="p-4">
+									<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
+										>_italic_</code
+									>
+									<span><em>italic</em></span>
+
+									<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
+										>## Heading</code
+									>
+									<span class="font-semibold text-sm">Heading</span>
+
+									<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
+										>- item</code
+									>
+									<span>bullet list item</span>
+
+									<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
+										>1. item</code
+									>
+									<span>numbered list item</span>
+
+									<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
+										>&gt; note</code
+									>
+									<span class="border-l-2 border-border pl-2 text-muted-foreground">note</span>
+
+									<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
+										>[text](url)</code
+									>
+									<span class="text-primary underline">link text</span>
+								</div>
+							</div>
+						</details>
+					</div>
+				</div>
+
+				{#if viewMode === 'write'}
+					<textarea
+						bind:this={textareaEl}
+						bind:value={body}
+						oninput={triggerSave}
+						placeholder={t(locale, 'page.journal.day.writePlaceholder', { name: companion.name })}
+						dir="ltr"
+						class="w-full min-h-[360px] resize-none p-4 text-sm font-mono leading-relaxed bg-background text-foreground placeholder:text-muted-foreground focus:outline-none"
+						spellcheck="true"
+					></textarea>
+				{:else}
+					<div
+						class="prose prose-sm dark:prose-invert max-w-none p-4 min-h-[360px] text-foreground"
+					>
+						{@html renderedMarkdown}
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Photos & Videos -->
+		<div class="space-y-2">
+			<div class="flex items-center justify-between">
+				<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+					{t(locale, 'page.journal.day.mediaTitle')}
+					<span class="ml-1 normal-case font-normal text-muted-foreground/70"
+						>{media.length}/{data.maxDailyMedia}</span
+					>
+				</p>
+				{#if media.length < data.maxDailyMedia}
+					<div class="flex flex-wrap items-center gap-2">
+						{#if data.immichEnabled}
+							<button
+								type="button"
+								class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
+								onclick={() => (immichPickerOpen = true)}
+							>
+								<ImageIcon class="h-3.5 w-3.5" />
+								{t(locale, 'immich.picker.button')}
+							</button>
+						{/if}
+						<label
+							class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent cursor-pointer"
+						>
+							{#if uploading}{t(locale, 'page.journal.day.uploading')}{:else}<Plus
+									class="h-3.5 w-3.5"
+								/>
+								{t(locale, 'page.journal.day.addMedia')}{/if}
+							<input
+								bind:this={fileInputEl}
+								type="file"
+								name="photos"
+								accept={MEDIA_ACCEPT}
+								multiple
+								class="sr-only"
+								onchange={handleFileInput}
+								disabled={uploading}
+							/>
+						</label>
+					</div>
+				{/if}
+			</div>
+
+			{#if uploadError}
+				<div
+					role="alert"
+					class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
+				>
+					{uploadError}
+				</div>
+			{/if}
+
 			{#if media.length === 0}
 				<label
 					class="flex flex-col items-center justify-center border-2 border-dashed border-border rounded-lg py-8 cursor-pointer transition-colors hover:opacity-80"
@@ -935,340 +945,337 @@
 				</div>
 			{/if}
 		</div>
-	</div>
 
-	<!-- Activity log -->
-	<div class="rounded-lg border border-border bg-card overflow-hidden">
-		<div class="flex items-center justify-between px-5 py-3 border-b border-border">
-			<h2 class="font-semibold flex items-center gap-2 text-foreground">
-				<ClipboardList class="h-4 w-4" />
-				{t(locale, 'page.journal.day.activitiesTitle')}
-			</h2>
-			<button
-				onclick={() => (showActivityForm = !showActivityForm)}
-				class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
-			>
-				{#if showActivityForm}{t(locale, 'common.cancel')}{:else}<Plus class="h-3.5 w-3.5" />
-					{t(locale, 'page.journal.day.logActivity')}{/if}
-			</button>
-		</div>
-
-		{#if showActivityForm}
-			<div class="px-6 py-4 border-b border-border animate-slide-up">
-				<form
-					method="POST"
-					action="?/addActivity"
-					use:localDatetimes
-					use:enhance={() =>
-						({ update }) => {
-							update();
-							showActivityForm = false;
-							selectedType = 'walk';
-							selectedAdditionalIds = [];
-						}}
-					class="space-y-4"
+		<!-- Activities -->
+		<div class="space-y-2">
+			<div class="flex items-center justify-between">
+				<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+					{t(locale, 'page.journal.day.activitiesTitle')}
+				</p>
+				<button
+					onclick={() => (showActivityForm = !showActivityForm)}
+					class="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent"
 				>
-					<div class="space-y-1.5">
-						<span class="text-sm font-medium text-foreground"
-							>{t(locale, 'page.journal.day.activityType')}</span
-						>
-						<div class="flex flex-wrap gap-2">
-							{#each EVENT_TYPES as evtType (evtType.value)}
-								<label class="cursor-pointer">
-									<input
-										type="radio"
-										name="type"
-										value={evtType.value}
-										bind:group={selectedType}
-										class="sr-only"
-									/>
-									<span
-										class="inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors cursor-pointer border-border text-muted-foreground {selectedType ===
-										evtType.value
-											? 'bg-primary/10 border-primary/30 text-primary'
-											: 'hover:text-foreground'}"
-									>
-										{evtType.icon}
-										{evtType.label}
-									</span>
-								</label>
-							{/each}
-						</div>
-					</div>
-					{#if siblingCompanions.length > 0}
-						<fieldset class="space-y-1.5">
-							<legend class="text-sm font-medium text-foreground">
-								{t(locale, 'page.journal.day.alsoLogFor')}
-							</legend>
-							<p class="text-xs text-muted-foreground">
-								{t(locale, 'page.journal.day.alsoLogForHint')}
-							</p>
+					{#if showActivityForm}{t(locale, 'common.cancel')}{:else}<Plus class="h-3.5 w-3.5" />
+						{t(locale, 'page.journal.day.logActivity')}{/if}
+				</button>
+			</div>
+
+			{#if showActivityForm}
+				<div class="rounded-lg border border-border px-5 py-4 animate-slide-up">
+					<form
+						method="POST"
+						action="?/addActivity"
+						use:localDatetimes
+						use:enhance={() =>
+							({ update }) => {
+								update();
+								showActivityForm = false;
+								selectedType = 'walk';
+								selectedAdditionalIds = [];
+							}}
+						class="space-y-4"
+					>
+						<div class="space-y-1.5">
+							<span class="text-sm font-medium text-foreground"
+								>{t(locale, 'page.journal.day.activityType')}</span
+							>
 							<div class="flex flex-wrap gap-2">
-								{#each siblingCompanions as sibling (sibling.id)}
-									{@const checked = selectedAdditionalIds.includes(sibling.id)}
+								{#each EVENT_TYPES as evtType (evtType.value)}
 									<label class="cursor-pointer">
 										<input
-											type="checkbox"
-											name="additionalCompanionIds"
-											value={sibling.id}
-											bind:group={selectedAdditionalIds}
+											type="radio"
+											name="type"
+											value={evtType.value}
+											bind:group={selectedType}
 											class="sr-only"
 										/>
 										<span
-											class="inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors cursor-pointer {checked
+											class="inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors cursor-pointer border-border text-muted-foreground {selectedType ===
+											evtType.value
 												? 'bg-primary/10 border-primary/30 text-primary'
-												: 'border-border text-muted-foreground hover:text-foreground'}"
+												: 'hover:text-foreground'}"
 										>
-											{sibling.name}
+											{evtType.icon}
+											{evtType.label}
 										</span>
 									</label>
 								{/each}
 							</div>
-						</fieldset>
-					{/if}
-					<div class="grid grid-cols-2 gap-4">
-						<div class="space-y-1.5">
-							<label for="act-loggedAt" class="text-sm font-medium text-foreground"
-								>{t(locale, 'page.journal.day.activityTime')}</label
-							>
-							<input
-								id="act-loggedAt"
-								name="loggedAt"
-								type="datetime-local"
-								autocomplete="off"
-								class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground placeholder:text-muted-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-								value={defaultLoggedAt()}
-							/>
 						</div>
-						{#if hasDuration}
+						{#if siblingCompanions.length > 0}
+							<fieldset class="space-y-1.5">
+								<legend class="text-sm font-medium text-foreground">
+									{t(locale, 'page.journal.day.alsoLogFor')}
+								</legend>
+								<p class="text-xs text-muted-foreground">
+									{t(locale, 'page.journal.day.alsoLogForHint')}
+								</p>
+								<div class="flex flex-wrap gap-2">
+									{#each siblingCompanions as sibling (sibling.id)}
+										{@const checked = selectedAdditionalIds.includes(sibling.id)}
+										<label class="cursor-pointer">
+											<input
+												type="checkbox"
+												name="additionalCompanionIds"
+												value={sibling.id}
+												bind:group={selectedAdditionalIds}
+												class="sr-only"
+											/>
+											<span
+												class="inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors cursor-pointer {checked
+													? 'bg-primary/10 border-primary/30 text-primary'
+													: 'border-border text-muted-foreground hover:text-foreground'}"
+											>
+												{sibling.name}
+											</span>
+										</label>
+									{/each}
+								</div>
+							</fieldset>
+						{/if}
+						<div class="grid grid-cols-2 gap-4">
 							<div class="space-y-1.5">
-								<label for="act-duration" class="text-sm font-medium text-foreground"
-									>{t(locale, 'page.journal.day.activityDuration')}</label
+								<label for="act-loggedAt" class="text-sm font-medium text-foreground"
+									>{t(locale, 'page.journal.day.activityTime')}</label
 								>
 								<input
-									id="act-duration"
-									name="durationMinutes"
-									type="number"
-									min="1"
+									id="act-loggedAt"
+									name="loggedAt"
+									type="datetime-local"
 									autocomplete="off"
 									class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground placeholder:text-muted-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-									placeholder="30"
+									value={defaultLoggedAt()}
 								/>
 							</div>
-						{/if}
-					</div>
-					<div class="space-y-1.5">
-						<label for="act-notes" class="text-sm font-medium text-foreground"
-							>{t(locale, 'page.journal.day.activityNotes')}</label
-						>
-						<MarkdownTextarea
-							id="act-notes"
-							name="notes"
-							placeholder={t(locale, 'page.journal.day.activityNotes')}
-							rows={3}
-						/>
-					</div>
-					<div class="flex gap-3">
-						<button
-							type="submit"
-							class="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-sm font-medium shadow hover:bg-primary/90 transition-colors"
-							>{t(locale, 'page.journal.day.logIt')}</button
-						>
-						<button
-							type="button"
-							onclick={() => (showActivityForm = false)}
-							class="inline-flex items-center justify-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-accent transition-colors"
-							>{t(locale, 'common.cancel')}</button
-						>
-					</div>
-				</form>
-			</div>
-		{/if}
-
-		{#if data.dailyEvents.length === 0 && !showActivityForm}
-			<div class="text-center py-8 px-6">
-				<p class="text-sm italic text-muted-foreground">
-					{t(locale, 'page.journal.day.noActivities')}
-				</p>
-			</div>
-		{:else if data.dailyEvents.length > 0}
-			<div class="divide-y divide-border">
-				{#each data.dailyEvents as event (event.id)}
-					{#if editingActivityId === event.id}
-						<div class="px-6 py-4">
-							<form
-								method="POST"
-								action="?/updateActivity"
-								use:localDatetimes
-								use:enhance={() =>
-									({ update }) => {
-										update();
-										editingActivityId = null;
-									}}
-								class="space-y-4"
-							>
-								<input type="hidden" name="id" value={event.id} />
+							{#if hasDuration}
 								<div class="space-y-1.5">
-									<span class="text-sm font-medium text-foreground"
-										>{t(locale, 'page.journal.day.activityType')}</span
+									<label for="act-duration" class="text-sm font-medium text-foreground"
+										>{t(locale, 'page.journal.day.activityDuration')}</label
 									>
-									<div class="flex flex-wrap gap-2">
-										{#each EVENT_TYPES as evtType (evtType.value)}
-											<label class="cursor-pointer">
-												<input
-													type="radio"
-													name="type"
-													value={evtType.value}
-													bind:group={editActivityType}
-													class="sr-only"
-												/>
-												<span
-													class="inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors cursor-pointer border-border text-muted-foreground {editActivityType ===
-													evtType.value
-														? 'bg-primary/10 border-primary/30 text-primary'
-														: 'hover:text-foreground'}"
-												>
-													{evtType.icon}
-													{evtType.label}
-												</span>
-											</label>
-										{/each}
-									</div>
-								</div>
-								<div class="grid grid-cols-2 gap-4">
-									<div class="space-y-1.5">
-										<label
-											for="edit-act-loggedAt-{event.id}"
-											class="text-sm font-medium text-foreground"
-											>{t(locale, 'page.journal.day.activityTime')}</label
-										>
-										<input
-											id="edit-act-loggedAt-{event.id}"
-											name="loggedAt"
-											autocomplete="off"
-											type="datetime-local"
-											class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground placeholder:text-muted-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-											value={localDatetimeISO(new Date(event.loggedAt))}
-										/>
-									</div>
-									{#if editActivityHasDuration}
-										<div class="space-y-1.5">
-											<label
-												for="edit-act-duration-{event.id}"
-												class="text-sm font-medium text-foreground"
-												>{t(locale, 'page.journal.day.activityDuration')}</label
-											>
-											<input
-												id="edit-act-duration-{event.id}"
-												name="durationMinutes"
-												autocomplete="off"
-												type="number"
-												min="1"
-												class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground placeholder:text-muted-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-												value={event.durationMinutes ?? ''}
-												placeholder="30"
-											/>
-										</div>
-									{/if}
-								</div>
-								<div class="space-y-1.5">
-									<label for="edit-act-notes-{event.id}" class="text-sm font-medium text-foreground"
-										>{t(locale, 'page.journal.day.activityNotes')}</label
-									>
-									<MarkdownTextarea
-										id="edit-act-notes-{event.id}"
-										name="notes"
-										value={event.notes ?? ''}
-										placeholder={t(locale, 'page.journal.day.activityNotes')}
-										rows={3}
+									<input
+										id="act-duration"
+										name="durationMinutes"
+										type="number"
+										min="1"
+										autocomplete="off"
+										class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground placeholder:text-muted-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+										placeholder="30"
 									/>
 								</div>
-								<div class="flex gap-3">
-									<button
-										type="submit"
-										class="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-sm font-medium shadow hover:bg-primary/90 transition-colors"
-										>{t(locale, 'common.save')}</button
-									>
-									<button
-										type="button"
-										onclick={() => (editingActivityId = null)}
-										class="inline-flex items-center justify-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-accent transition-colors"
-										>{t(locale, 'common.cancel')}</button
-									>
-								</div>
-							</form>
+							{/if}
 						</div>
-					{:else}
-						<div class="flex items-center gap-2 pl-6 pr-3 py-3">
+						<div class="space-y-1.5">
+							<label for="act-notes" class="text-sm font-medium text-foreground"
+								>{t(locale, 'page.journal.day.activityNotes')}</label
+							>
+							<MarkdownTextarea
+								id="act-notes"
+								name="notes"
+								placeholder={t(locale, 'page.journal.day.activityNotes')}
+								rows={3}
+							/>
+						</div>
+						<div class="flex gap-3">
+							<button
+								type="submit"
+								class="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-sm font-medium shadow hover:bg-primary/90 transition-colors"
+								>{t(locale, 'page.journal.day.logIt')}</button
+							>
 							<button
 								type="button"
-								onclick={() => openActivityDetail(event)}
-								class="flex items-center gap-3 flex-1 min-w-0 text-left hover:bg-accent rounded-lg px-2 py-1 transition-colors -mx-2"
+								onclick={() => (showActivityForm = false)}
+								class="inline-flex items-center justify-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-accent transition-colors"
+								>{t(locale, 'common.cancel')}</button
 							>
-								<span class="text-xl shrink-0">{EVENT_ICONS[event.type] ?? '📝'}</span>
-								<div class="flex-1 min-w-0">
-									<div class="flex items-center gap-2">
-										<Badge variant="secondary" class="capitalize">{event.type}</Badge>
-										{#if event.durationMinutes}
-											<span class="text-xs text-muted-foreground">{event.durationMinutes} min</span>
+						</div>
+					</form>
+				</div>
+			{/if}
+
+			{#if data.dailyEvents.length === 0 && !showActivityForm}
+				<p class="text-sm italic text-muted-foreground py-4">
+					{t(locale, 'page.journal.day.noActivities')}
+				</p>
+			{:else if data.dailyEvents.length > 0}
+				<div class="divide-y divide-border rounded-lg border border-border overflow-hidden">
+					{#each data.dailyEvents as event (event.id)}
+						{#if editingActivityId === event.id}
+							<div class="px-5 py-4">
+								<form
+									method="POST"
+									action="?/updateActivity"
+									use:localDatetimes
+									use:enhance={() =>
+										({ update }) => {
+											update();
+											editingActivityId = null;
+										}}
+									class="space-y-4"
+								>
+									<input type="hidden" name="id" value={event.id} />
+									<div class="space-y-1.5">
+										<span class="text-sm font-medium text-foreground"
+											>{t(locale, 'page.journal.day.activityType')}</span
+										>
+										<div class="flex flex-wrap gap-2">
+											{#each EVENT_TYPES as evtType (evtType.value)}
+												<label class="cursor-pointer">
+													<input
+														type="radio"
+														name="type"
+														value={evtType.value}
+														bind:group={editActivityType}
+														class="sr-only"
+													/>
+													<span
+														class="inline-flex items-center rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors cursor-pointer border-border text-muted-foreground {editActivityType ===
+														evtType.value
+															? 'bg-primary/10 border-primary/30 text-primary'
+															: 'hover:text-foreground'}"
+													>
+														{evtType.icon}
+														{evtType.label}
+													</span>
+												</label>
+											{/each}
+										</div>
+									</div>
+									<div class="grid grid-cols-2 gap-4">
+										<div class="space-y-1.5">
+											<label
+												for="edit-act-loggedAt-{event.id}"
+												class="text-sm font-medium text-foreground"
+												>{t(locale, 'page.journal.day.activityTime')}</label
+											>
+											<input
+												id="edit-act-loggedAt-{event.id}"
+												name="loggedAt"
+												autocomplete="off"
+												type="datetime-local"
+												class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground placeholder:text-muted-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+												value={localDatetimeISO(new Date(event.loggedAt))}
+											/>
+										</div>
+										{#if editActivityHasDuration}
+											<div class="space-y-1.5">
+												<label
+													for="edit-act-duration-{event.id}"
+													class="text-sm font-medium text-foreground"
+													>{t(locale, 'page.journal.day.activityDuration')}</label
+												>
+												<input
+													id="edit-act-duration-{event.id}"
+													name="durationMinutes"
+													autocomplete="off"
+													type="number"
+													min="1"
+													class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground placeholder:text-muted-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+													value={event.durationMinutes ?? ''}
+													placeholder="30"
+												/>
+											</div>
 										{/if}
 									</div>
-									{#if event.notes}
-										<p class="text-sm mt-0.5 text-muted-foreground">
-											{stripMarkdown(event.notes)}
-										</p>
-									{/if}
-								</div>
-								<div class="text-xs shrink-0 text-muted-foreground text-right">
-									<span
-										>{new Date(event.loggedAt).toLocaleTimeString(undefined, {
-											hour: 'numeric',
-											minute: '2-digit',
-											...(serverTimezone ? { timeZone: serverTimezone } : {})
-										})}</span
+									<div class="space-y-1.5">
+										<label
+											for="edit-act-notes-{event.id}"
+											class="text-sm font-medium text-foreground"
+											>{t(locale, 'page.journal.day.activityNotes')}</label
+										>
+										<MarkdownTextarea
+											id="edit-act-notes-{event.id}"
+											name="notes"
+											value={event.notes ?? ''}
+											placeholder={t(locale, 'page.journal.day.activityNotes')}
+											rows={3}
+										/>
+									</div>
+									<div class="flex gap-3">
+										<button
+											type="submit"
+											class="inline-flex items-center justify-center rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-sm font-medium shadow hover:bg-primary/90 transition-colors"
+											>{t(locale, 'common.save')}</button
+										>
+										<button
+											type="button"
+											onclick={() => (editingActivityId = null)}
+											class="inline-flex items-center justify-center rounded-md border border-input bg-background px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-accent transition-colors"
+											>{t(locale, 'common.cancel')}</button
+										>
+									</div>
+								</form>
+							</div>
+						{:else}
+							<div class="flex items-center gap-2 pl-5 pr-3 py-3">
+								<button
+									type="button"
+									onclick={() => openActivityDetail(event)}
+									class="flex items-center gap-3 flex-1 min-w-0 text-left hover:bg-accent rounded-lg px-2 py-1 transition-colors -mx-2"
+								>
+									<span class="text-xl shrink-0">{EVENT_ICONS[event.type] ?? '📝'}</span>
+									<div class="flex-1 min-w-0">
+										<div class="flex items-center gap-2">
+											<Badge variant="secondary" class="capitalize">{event.type}</Badge>
+											{#if event.durationMinutes}
+												<span class="text-xs text-muted-foreground"
+													>{event.durationMinutes} min</span
+												>
+											{/if}
+										</div>
+										{#if event.notes}
+											<p class="text-sm mt-0.5 text-muted-foreground">
+												{stripMarkdown(event.notes)}
+											</p>
+										{/if}
+									</div>
+									<div class="text-xs shrink-0 text-muted-foreground text-right">
+										<span
+											>{new Date(event.loggedAt).toLocaleTimeString(undefined, {
+												hour: 'numeric',
+												minute: '2-digit',
+												...(serverTimezone ? { timeZone: serverTimezone } : {})
+											})}</span
+										>
+										<ByLine user={event.logger} />
+									</div>
+								</button>
+								<Button
+									variant="soft"
+									size="sm"
+									class="h-7 px-2 text-xs gap-1.5 shrink-0"
+									onclick={() => startEditActivity(event)}
+								>
+									<Pencil class="h-3.5 w-3.5" /><span class="hidden sm:inline"
+										>{t(locale, 'common.edit')}</span
 									>
-									<ByLine user={event.logger} />
-								</div>
-							</button>
-							<Button
-								variant="soft"
-								size="sm"
-								class="h-7 px-2 text-xs gap-1.5 shrink-0"
-								onclick={() => startEditActivity(event)}
-							>
-								<Pencil class="h-3.5 w-3.5" /><span class="hidden sm:inline"
-									>{t(locale, 'common.edit')}</span
+								</Button>
+								<Button
+									variant="softDestructive"
+									size="sm"
+									class="h-7 px-2 text-xs gap-1.5 shrink-0"
+									onclick={() => {
+										deleteActivityId = event.id;
+										openConfirm(() => deleteActivityForm?.requestSubmit());
+									}}
 								>
-							</Button>
-							<Button
-								variant="softDestructive"
-								size="sm"
-								class="h-7 px-2 text-xs gap-1.5 shrink-0"
-								onclick={() => {
-									deleteActivityId = event.id;
-									openConfirm(() => deleteActivityForm?.requestSubmit());
-								}}
-							>
-								<Trash2 class="h-3.5 w-3.5" /><span class="hidden sm:inline"
-									>{t(locale, 'common.delete')}</span
-								>
-							</Button>
-						</div>
-					{/if}
-				{/each}
-			</div>
-		{/if}
-	</div>
+									<Trash2 class="h-3.5 w-3.5" /><span class="hidden sm:inline"
+										>{t(locale, 'common.delete')}</span
+									>
+								</Button>
+							</div>
+						{/if}
+					{/each}
+				</div>
+			{/if}
+		</div>
 
-	<!-- Recent entries strip -->
-	{#if data.recentEntries.length > 0}
-		<div class="rounded-lg border border-border bg-card">
-			<div class="px-5 py-3 border-b border-border">
-				<h2 class="text-sm font-medium text-muted-foreground">
+		<!-- Recent entries -->
+		{#if data.recentEntries.length > 0}
+			<div class="space-y-2 pt-2 border-t border-border">
+				<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
 					{t(locale, 'page.journal.day.recentEntries')}
-				</h2>
-			</div>
-			<div class="p-4">
+				</p>
 				<div class="flex flex-wrap gap-2">
 					{#each data.recentEntries as e (e.date)}
 						{@const entryMood = e.date === data.date ? mood : (e.mood ?? '')}
@@ -1287,8 +1294,8 @@
 					{/each}
 				</div>
 			</div>
-		</div>
-	{/if}
+		{/if}
+	</div>
 </div>
 
 <form

--- a/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/journal/[date]/+page.svelte
@@ -512,8 +512,9 @@
 					variant="soft"
 					size="sm"
 					onclick={() => {
+						const ev = detailEvent;
 						closeActivityDetail();
-						startEditActivity(detailEvent!);
+						if (ev) startEditActivity(ev);
 					}}
 				>
 					<Pencil class="h-3.5 w-3.5 mr-1.5" />
@@ -693,7 +694,7 @@
 						<span class="text-xs text-muted-foreground"
 							>{t(locale, 'page.journal.day.toggleHint')}</span
 						>
-						<details class="group">
+						<details class="group relative">
 							<summary
 								class="inline-flex cursor-pointer select-none list-none items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors [&::-webkit-details-marker]:hidden"
 							>
@@ -710,7 +711,9 @@
 								>
 								Markdown supported
 							</summary>
-							<div class="mt-2 rounded-md bg-muted/60 px-3 py-2.5 text-xs space-y-1.5">
+							<div
+								class="absolute right-0 top-full z-20 mt-2 w-72 rounded-md border border-border bg-popover px-3 py-2.5 text-xs space-y-1.5 shadow-lg"
+							>
 								<div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 items-baseline">
 									<code class="font-mono text-[11px] text-foreground/70 whitespace-nowrap"
 										>**bold**</code

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -63,7 +63,9 @@
 			onOpenSearch={() => (searchOpen = true)}
 		/>
 
-		<main class="flex-1 min-w-0 animate-fade-in pb-24 md:pb-0 px-4 sm:px-6 lg:px-8 py-6">
+		<main
+			class="flex-1 min-w-0 animate-fade-in pb-24 md:pb-0 px-4 sm:px-6 lg:px-8 py-6 mx-auto w-full max-w-6xl"
+		>
 			{@render children()}
 		</main>
 

--- a/tests/e2e/journal.spec.ts
+++ b/tests/e2e/journal.spec.ts
@@ -119,6 +119,33 @@ test.describe('journal day editor', () => {
 		});
 	});
 
+	test('journal timeline marks today and opens media in the lightbox', async ({ asMember }) => {
+		const today = (() => {
+			const n = new Date();
+			const p = (x: number) => String(x).padStart(2, '0');
+			return `${n.getUTCFullYear()}-${p(n.getUTCMonth() + 1)}-${p(n.getUTCDate())}`;
+		})();
+
+		// Create today's entry with a photo.
+		await asMember.goto(`/${COMP}/journal/${today}`);
+		await asMember.locator('textarea').first().fill('timeline e2e body');
+		await asMember.locator('h1').first().click();
+		await expect(asMember.getByText('✓ Saved')).toBeVisible({ timeout: 8_000 });
+		const fileInput = asMember.locator('input[type="file"][name="photos"]').first();
+		await fileInput.setInputFiles(pngUpload());
+		await expect(asMember.locator('img[src*="/api/photos/journal/"]').first()).toBeVisible({
+			timeout: 15_000
+		});
+
+		// On the list, today's row shows the "Today" marker and the thumbnail opens the lightbox.
+		await asMember.goto(`/${COMP}/journal`);
+		await expect(asMember.getByText('Today', { exact: true }).first()).toBeVisible({
+			timeout: 8_000
+		});
+		await asMember.locator('img[src*="/api/photos/journal/"]').first().click();
+		await expect(asMember.locator('[role="dialog"]')).toBeVisible({ timeout: 5_000 });
+	});
+
 	test('journal list shows entries', async ({ asMember }) => {
 		await asMember.goto(`/${COMP}/journal`);
 


### PR DESCRIPTION
Draft. Stacked on #117 (SP2) — base branch is `redesign-sp2-ia-nav`, not `main`. Review/merge after SP1 and SP2. First group of SP3 (owner inner-page redesigns).

## What's in it

**Date-rail keepsake timeline list.** The journal list is now a vertical timeline: a day-number rail with a connecting line and dots (Today highlighted), each entry showing mood, byline, media thumbnails, the full entry body, and activity chips. New focused `JournalTimelineEntry` component.

**Clean single-column day editor.** De-carded from heavy bordered sections into a flowing layout with light uppercase labels: date nav + inline autosave status, mood, note, photos, activities. The Markdown-help cheatsheet now opens as a floating popover instead of growing the row.

**Media lightbox.** Chrome retokenized to the Companion language with consistent overlay controls and focus rings. Behaviour unchanged.

**Content width.** The app shell now centers page content in a `max-w-6xl` column on wide screens, and the journal fills it like every other page. (Other owner pages still carry their own inner widths and need a later consistency pass.)

**Fixes found in review.** Disabled mono-font ligatures so markdown headings stay left-aligned in the textarea; fixed an activity-detail modal crash where the edit button read the event after it was cleared; thumbnail aria-labels; legacy `bark` token removed from the journal pages.

## Out of scope
Health + Reminders (SP3b) and Documents + Companion profile/edit (SP3c) follow as their own cycles. Journal server logic, API, and data shape are unchanged.

## Tests
`npm run lint`, `npm run check`, and 172 unit tests pass. `tests/e2e/journal.spec.ts` extended (timeline Today marker, thumbnail opens the lightbox, autosave status) with all existing autosave/upload/caption/pagination assertions still green.