### PR TITLE
Redesign SP3b: Health + Reminders

### DIFF
--- a/src/lib/components/WeightChart.svelte
+++ b/src/lib/components/WeightChart.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+	import { t, getLocale } from '$lib/i18n';
+	import {
+		filterByRange,
+		buildAreaPath,
+		buildLinePath,
+		percentChange,
+		type WeightPoint,
+		type WeightRange
+	} from '$lib/weightChart';
+	import { TrendingUp, TrendingDown } from '@lucide/svelte';
+
+	interface Props {
+		/** Weight entries, ascending by recordedAt. */
+		entries: WeightPoint[];
+		now?: Date;
+	}
+	let { entries, now = undefined }: Props = $props();
+	const locale = getLocale();
+
+	const W = 600;
+	const H = 120;
+	let range = $state<WeightRange>('6m');
+
+	let ref = $derived(now ?? new Date());
+	let visible = $derived(filterByRange(entries, range, ref));
+	let effective = $derived(visible.length < 2 && entries.length >= 2 ? entries : visible);
+	let values = $derived(effective.map((p) => p.weight));
+	let areaPath = $derived(buildAreaPath(values, W, H));
+	let linePath = $derived(buildLinePath(values, W, H));
+	let latest = $derived(entries.at(-1) ?? null);
+	let change = $derived(percentChange(effective));
+
+	const RANGES: {
+		value: WeightRange;
+		key: 'page.health.range6m' | 'page.health.range1y' | 'page.health.rangeAll';
+	}[] = [
+		{ value: '6m', key: 'page.health.range6m' },
+		{ value: '1y', key: 'page.health.range1y' },
+		{ value: 'all', key: 'page.health.rangeAll' }
+	];
+</script>
+
+<div class="rounded-2xl border bg-card p-4">
+	{#if !latest}
+		<p class="text-sm italic text-muted-foreground">{t(locale, 'page.health.noWeightYet')}</p>
+	{:else}
+		<div class="flex items-start justify-between gap-3">
+			<div>
+				<p class="font-display text-2xl font-bold text-foreground">
+					{latest.weight}
+					<span class="text-sm font-normal text-muted-foreground">{latest.unit}</span>
+				</p>
+				{#if change !== null}
+					<p class="flex items-center gap-1 text-xs {change >= 0 ? 'text-teal' : 'text-coral'}">
+						{#if change >= 0}<TrendingUp class="h-3.5 w-3.5" />{:else}<TrendingDown
+								class="h-3.5 w-3.5"
+							/>{/if}
+						{change >= 0 ? '+' : ''}{change.toFixed(1)}%
+					</p>
+				{/if}
+			</div>
+			<div class="flex gap-1" role="group" aria-label={t(locale, 'page.health.weightTrend')}>
+				{#each RANGES as r (r.value)}
+					<button
+						type="button"
+						onclick={() => (range = r.value)}
+						aria-pressed={range === r.value}
+						class="rounded-md px-2 py-0.5 text-xs transition-colors {range === r.value
+							? 'bg-primary/10 text-primary font-medium'
+							: 'text-muted-foreground hover:text-foreground'}"
+					>
+						{t(locale, r.key)}
+					</button>
+				{/each}
+			</div>
+		</div>
+		{#if values.length >= 2}
+			<svg
+				viewBox="0 0 {W} {H}"
+				preserveAspectRatio="none"
+				class="mt-3 h-24 w-full"
+				role="img"
+				aria-label={t(locale, 'page.health.weightChartAria')}
+			>
+				<defs>
+					<linearGradient id="weightFill" x1="0" y1="0" x2="0" y2="1">
+						<stop offset="0%" stop-color="hsl(var(--primary))" stop-opacity="0.35" />
+						<stop offset="100%" stop-color="hsl(var(--primary))" stop-opacity="0" />
+					</linearGradient>
+				</defs>
+				<path d={areaPath} fill="url(#weightFill)" />
+				<path
+					d={linePath}
+					fill="none"
+					stroke="hsl(var(--primary))"
+					stroke-width="2"
+					vector-effect="non-scaling-stroke"
+				/>
+			</svg>
+		{:else}
+			<p class="mt-3 text-xs text-muted-foreground">{t(locale, 'page.health.noWeightYet')}</p>
+		{/if}
+	{/if}
+</div>

--- a/src/lib/components/WeightChart.svelte
+++ b/src/lib/components/WeightChart.svelte
@@ -16,6 +16,7 @@
 		now?: Date;
 	}
 	let { entries, now = undefined }: Props = $props();
+	const uid = $props.id();
 	const locale = getLocale();
 
 	const W = 600;
@@ -84,12 +85,12 @@
 				aria-label={t(locale, 'page.health.weightChartAria')}
 			>
 				<defs>
-					<linearGradient id="weightFill" x1="0" y1="0" x2="0" y2="1">
+					<linearGradient id="weightFill-{uid}" x1="0" y1="0" x2="0" y2="1">
 						<stop offset="0%" stop-color="hsl(var(--primary))" stop-opacity="0.35" />
 						<stop offset="100%" stop-color="hsl(var(--primary))" stop-opacity="0" />
 					</linearGradient>
 				</defs>
-				<path d={areaPath} fill="url(#weightFill)" />
+				<path d={areaPath} fill="url(#weightFill-{uid})" />
 				<path
 					d={linePath}
 					fill="none"

--- a/src/lib/components/WeightChart.svelte
+++ b/src/lib/components/WeightChart.svelte
@@ -5,6 +5,7 @@
 		buildAreaPath,
 		buildLinePath,
 		percentChange,
+		convertWeight,
 		type WeightPoint,
 		type WeightRange
 	} from '$lib/weightChart';
@@ -26,11 +27,17 @@
 	let ref = $derived(now ?? new Date());
 	let visible = $derived(filterByRange(entries, range, ref));
 	let effective = $derived(visible.length < 2 && entries.length >= 2 ? entries : visible);
-	let values = $derived(effective.map((p) => p.weight));
+	let latest = $derived(entries.at(-1) ?? null);
+	let displayUnit = $derived(latest?.unit ?? 'lbs');
+	let normalized = $derived(effective.map((p) => convertWeight(p.weight, p.unit, displayUnit)));
+	let values = $derived(normalized);
 	let areaPath = $derived(buildAreaPath(values, W, H));
 	let linePath = $derived(buildLinePath(values, W, H));
-	let latest = $derived(entries.at(-1) ?? null);
-	let change = $derived(percentChange(effective));
+	let change = $derived(
+		percentChange(
+			effective.map((p) => ({ ...p, weight: convertWeight(p.weight, p.unit, displayUnit) }))
+		)
+	);
 
 	const RANGES: {
 		value: WeightRange;
@@ -100,7 +107,7 @@
 				/>
 			</svg>
 		{:else}
-			<p class="mt-3 text-xs text-muted-foreground">{t(locale, 'page.health.noWeightYet')}</p>
+			<p class="mt-3 text-xs text-muted-foreground">{t(locale, 'page.health.oneWeightNeedMore')}</p>
 		{/if}
 	{/if}
 </div>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -731,6 +731,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'Speichern...',
 	'page.reminders.noUpcoming': 'Keine anstehenden Erinnerungen.',
 	'page.reminders.overdue': 'Überfällig',
+	'page.reminders.groupToday': 'Heute',
+	'page.reminders.groupUpcoming': 'Demnächst',
 	'page.reminders.detailType': 'Typ',
 	'page.reminders.detailDue': 'Fällig',
 	'page.reminders.detailRepeats': 'Wiederholt sich',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -684,6 +684,12 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailType': 'Typ',
 	'page.health.detailDate': 'Datum',
 	'page.health.detailVet': 'Tierarzt',
+	'page.health.weightTrend': 'Gewichtsverlauf',
+	'page.health.noWeightYet': 'Noch kein Gewicht erfasst.',
+	'page.health.range6m': '6 Monate',
+	'page.health.range1y': '1 Jahr',
+	'page.health.rangeAll': 'Alle',
+	'page.health.weightChartAria': 'Gewichtsverlauf über die Zeit',
 
 	// Page: Reminders
 	'page.reminders.title': 'Erinnerungen',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -686,6 +686,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailVet': 'Tierarzt',
 	'page.health.weightTrend': 'Gewichtsverlauf',
 	'page.health.noWeightYet': 'Noch kein Gewicht erfasst.',
+	'page.health.oneWeightNeedMore': 'Erfasse ein weiteres Gewicht, um den Verlauf zu sehen.',
 	'page.health.range6m': '6 Monate',
 	'page.health.range1y': '1 Jahr',
 	'page.health.rangeAll': 'Alle',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -731,6 +731,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'Speichern...',
 	'page.reminders.noUpcoming': 'Keine anstehenden Erinnerungen.',
 	'page.reminders.overdue': 'Überfällig',
+	'page.reminders.groupOverdue': 'Überfällig',
 	'page.reminders.groupToday': 'Heute',
 	'page.reminders.groupUpcoming': 'Demnächst',
 	'page.reminders.detailType': 'Typ',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -676,6 +676,12 @@ const messages = {
 	'page.health.detailType': 'Type',
 	'page.health.detailDate': 'Date',
 	'page.health.detailVet': 'Vet',
+	'page.health.weightTrend': 'Weight trend',
+	'page.health.noWeightYet': 'No weight recorded yet.',
+	'page.health.range6m': '6 months',
+	'page.health.range1y': '1 year',
+	'page.health.rangeAll': 'All',
+	'page.health.weightChartAria': 'Weight trend over time',
 
 	// Page: Reminders
 	'page.reminders.title': 'Reminders',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -722,6 +722,7 @@ const messages = {
 	'page.reminders.savingReminder': 'Saving...',
 	'page.reminders.noUpcoming': 'No upcoming reminders.',
 	'page.reminders.overdue': 'Overdue',
+	'page.reminders.groupOverdue': 'Overdue',
 	'page.reminders.groupToday': 'Today',
 	'page.reminders.groupUpcoming': 'Upcoming',
 	'page.reminders.detailType': 'Type',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -722,6 +722,8 @@ const messages = {
 	'page.reminders.savingReminder': 'Saving...',
 	'page.reminders.noUpcoming': 'No upcoming reminders.',
 	'page.reminders.overdue': 'Overdue',
+	'page.reminders.groupToday': 'Today',
+	'page.reminders.groupUpcoming': 'Upcoming',
 	'page.reminders.detailType': 'Type',
 	'page.reminders.detailDue': 'Due',
 	'page.reminders.detailRepeats': 'Repeats',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -678,6 +678,7 @@ const messages = {
 	'page.health.detailVet': 'Vet',
 	'page.health.weightTrend': 'Weight trend',
 	'page.health.noWeightYet': 'No weight recorded yet.',
+	'page.health.oneWeightNeedMore': 'Log another weight to see the trend.',
 	'page.health.range6m': '6 months',
 	'page.health.range1y': '1 year',
 	'page.health.rangeAll': 'All',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -684,6 +684,12 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailType': 'Tipo',
 	'page.health.detailDate': 'Fecha',
 	'page.health.detailVet': 'Veterinario',
+	'page.health.weightTrend': 'Tendencia de peso',
+	'page.health.noWeightYet': 'Aún no hay peso registrado.',
+	'page.health.range6m': '6 meses',
+	'page.health.range1y': '1 año',
+	'page.health.rangeAll': 'Todo',
+	'page.health.weightChartAria': 'Tendencia de peso a lo largo del tiempo',
 
 	// Page: Reminders
 	'page.reminders.title': 'Recordatorios',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -731,6 +731,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'Guardando...',
 	'page.reminders.noUpcoming': 'No hay recordatorios próximos.',
 	'page.reminders.overdue': 'Vencido',
+	'page.reminders.groupToday': 'Hoy',
+	'page.reminders.groupUpcoming': 'Próximos',
 	'page.reminders.detailType': 'Tipo',
 	'page.reminders.detailDue': 'Vencimiento',
 	'page.reminders.detailRepeats': 'Se repite',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -731,6 +731,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'Guardando...',
 	'page.reminders.noUpcoming': 'No hay recordatorios próximos.',
 	'page.reminders.overdue': 'Vencido',
+	'page.reminders.groupOverdue': 'Atrasados',
 	'page.reminders.groupToday': 'Hoy',
 	'page.reminders.groupUpcoming': 'Próximos',
 	'page.reminders.detailType': 'Tipo',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -686,6 +686,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailVet': 'Veterinario',
 	'page.health.weightTrend': 'Tendencia de peso',
 	'page.health.noWeightYet': 'Aún no hay peso registrado.',
+	'page.health.oneWeightNeedMore': 'Registra otro peso para ver la tendencia.',
 	'page.health.range6m': '6 meses',
 	'page.health.range1y': '1 año',
 	'page.health.rangeAll': 'Todo',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -733,6 +733,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'Enregistrement...',
 	'page.reminders.noUpcoming': 'Aucun rappel à venir.',
 	'page.reminders.overdue': 'En retard',
+	'page.reminders.groupOverdue': 'En retard',
 	'page.reminders.groupToday': "Aujourd'hui",
 	'page.reminders.groupUpcoming': 'À venir',
 	'page.reminders.detailType': 'Type',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -733,6 +733,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'Enregistrement...',
 	'page.reminders.noUpcoming': 'Aucun rappel à venir.',
 	'page.reminders.overdue': 'En retard',
+	'page.reminders.groupToday': "Aujourd'hui",
+	'page.reminders.groupUpcoming': 'À venir',
 	'page.reminders.detailType': 'Type',
 	'page.reminders.detailDue': 'Échéance',
 	'page.reminders.detailRepeats': 'Se répète',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -686,6 +686,12 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailType': 'Type',
 	'page.health.detailDate': 'Date',
 	'page.health.detailVet': 'Vétérinaire',
+	'page.health.weightTrend': 'Tendance du poids',
+	'page.health.noWeightYet': 'Aucun poids enregistré.',
+	'page.health.range6m': '6 mois',
+	'page.health.range1y': '1 an',
+	'page.health.rangeAll': 'Tout',
+	'page.health.weightChartAria': 'Tendance du poids dans le temps',
 
 	// Page: Reminders
 	'page.reminders.title': 'Rappels',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -688,6 +688,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailVet': 'Vétérinaire',
 	'page.health.weightTrend': 'Tendance du poids',
 	'page.health.noWeightYet': 'Aucun poids enregistré.',
+	'page.health.oneWeightNeedMore': 'Enregistre un autre poids pour voir la tendance.',
 	'page.health.range6m': '6 mois',
 	'page.health.range1y': '1 an',
 	'page.health.rangeAll': 'Tout',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -679,6 +679,12 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailType': 'Tipo',
 	'page.health.detailDate': 'Data',
 	'page.health.detailVet': 'Veterinario',
+	'page.health.weightTrend': 'Andamento del peso',
+	'page.health.noWeightYet': 'Nessun peso registrato.',
+	'page.health.range6m': '6 mesi',
+	'page.health.range1y': '1 anno',
+	'page.health.rangeAll': 'Tutto',
+	'page.health.weightChartAria': 'Andamento del peso nel tempo',
 
 	// Page: Reminders
 	'page.reminders.title': 'Promemoria',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -726,6 +726,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'Salvataggio...',
 	'page.reminders.noUpcoming': 'Nessun promemoria in arrivo.',
 	'page.reminders.overdue': 'Scaduto',
+	'page.reminders.groupToday': 'Oggi',
+	'page.reminders.groupUpcoming': 'In arrivo',
 	'page.reminders.detailType': 'Tipo',
 	'page.reminders.detailDue': 'Scadenza',
 	'page.reminders.detailRepeats': 'Si ripete',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -681,6 +681,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailVet': 'Veterinario',
 	'page.health.weightTrend': 'Andamento del peso',
 	'page.health.noWeightYet': 'Nessun peso registrato.',
+	'page.health.oneWeightNeedMore': "Registra un altro peso per vedere l'andamento.",
 	'page.health.range6m': '6 mesi',
 	'page.health.range1y': '1 anno',
 	'page.health.rangeAll': 'Tutto',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -726,6 +726,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'Salvataggio...',
 	'page.reminders.noUpcoming': 'Nessun promemoria in arrivo.',
 	'page.reminders.overdue': 'Scaduto',
+	'page.reminders.groupOverdue': 'In ritardo',
 	'page.reminders.groupToday': 'Oggi',
 	'page.reminders.groupUpcoming': 'In arrivo',
 	'page.reminders.detailType': 'Tipo',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -683,6 +683,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailVet': 'Veterinário',
 	'page.health.weightTrend': 'Tendência do peso',
 	'page.health.noWeightYet': 'Ainda sem peso registado.',
+	'page.health.oneWeightNeedMore': 'Registe outro peso para ver a tendência.',
 	'page.health.range6m': '6 meses',
 	'page.health.range1y': '1 ano',
 	'page.health.rangeAll': 'Tudo',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -681,6 +681,12 @@ const messages: Record<keyof Messages, string> = {
 	'page.health.detailType': 'Tipo',
 	'page.health.detailDate': 'Data',
 	'page.health.detailVet': 'Veterinário',
+	'page.health.weightTrend': 'Tendência do peso',
+	'page.health.noWeightYet': 'Ainda sem peso registado.',
+	'page.health.range6m': '6 meses',
+	'page.health.range1y': '1 ano',
+	'page.health.rangeAll': 'Tudo',
+	'page.health.weightChartAria': 'Tendência do peso ao longo do tempo',
 
 	// Page: Reminders
 	'page.reminders.title': 'Lembretes',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -728,6 +728,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'A guardar...',
 	'page.reminders.noUpcoming': 'Sem lembretes próximos.',
 	'page.reminders.overdue': 'Atrasado',
+	'page.reminders.groupToday': 'Hoje',
+	'page.reminders.groupUpcoming': 'Próximos',
 	'page.reminders.detailType': 'Tipo',
 	'page.reminders.detailDue': 'Vencimento',
 	'page.reminders.detailRepeats': 'Repete-se',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -728,6 +728,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.reminders.savingReminder': 'A guardar...',
 	'page.reminders.noUpcoming': 'Sem lembretes próximos.',
 	'page.reminders.overdue': 'Atrasado',
+	'page.reminders.groupOverdue': 'Atrasados',
 	'page.reminders.groupToday': 'Hoje',
 	'page.reminders.groupUpcoming': 'Próximos',
 	'page.reminders.detailType': 'Tipo',

--- a/src/lib/reminderBuckets.test.ts
+++ b/src/lib/reminderBuckets.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { reminderBuckets, type BucketableReminder } from './reminderBuckets';
+
+const R = (id: string, dueAt: string): BucketableReminder => ({ id, dueAt: new Date(dueAt) });
+const now = new Date('2026-06-12T12:00:00');
+
+describe('reminderBuckets', () => {
+	it('puts past-due reminders in overdue', () => {
+		const { overdue, today, upcoming } = reminderBuckets([R('a', '2026-06-10T09:00:00')], now);
+		expect(overdue.map((r) => r.id)).toEqual(['a']);
+		expect(today).toEqual([]);
+		expect(upcoming).toEqual([]);
+	});
+	it('puts same-local-day not-yet-past reminders in today', () => {
+		const { today } = reminderBuckets([R('a', '2026-06-12T18:00:00')], now);
+		expect(today.map((r) => r.id)).toEqual(['a']);
+	});
+	it('a today reminder whose time already passed is overdue', () => {
+		const { overdue, today } = reminderBuckets([R('a', '2026-06-12T09:00:00')], now);
+		expect(overdue.map((r) => r.id)).toEqual(['a']);
+		expect(today).toEqual([]);
+	});
+	it('puts future-day reminders in upcoming', () => {
+		const { upcoming } = reminderBuckets([R('a', '2026-06-20T09:00:00')], now);
+		expect(upcoming.map((r) => r.id)).toEqual(['a']);
+	});
+	it('sorts each bucket ascending by dueAt', () => {
+		const { upcoming } = reminderBuckets(
+			[R('b', '2026-06-25T09:00:00'), R('a', '2026-06-20T09:00:00')],
+			now
+		);
+		expect(upcoming.map((r) => r.id)).toEqual(['a', 'b']);
+	});
+});

--- a/src/lib/reminderBuckets.test.ts
+++ b/src/lib/reminderBuckets.test.ts
@@ -31,4 +31,10 @@ describe('reminderBuckets', () => {
 		);
 		expect(upcoming.map((r) => r.id)).toEqual(['a', 'b']);
 	});
+	it('returns empty buckets for empty input', () => {
+		const { overdue, today, upcoming } = reminderBuckets([], now);
+		expect(overdue).toEqual([]);
+		expect(today).toEqual([]);
+		expect(upcoming).toEqual([]);
+	});
 });

--- a/src/lib/reminderBuckets.ts
+++ b/src/lib/reminderBuckets.ts
@@ -1,0 +1,44 @@
+export interface BucketableReminder {
+	id: string;
+	dueAt: Date;
+}
+
+export interface ReminderBuckets<T extends BucketableReminder> {
+	overdue: T[];
+	today: T[];
+	upcoming: T[];
+}
+
+function isSameLocalDay(a: Date, b: Date): boolean {
+	return (
+		a.getFullYear() === b.getFullYear() &&
+		a.getMonth() === b.getMonth() &&
+		a.getDate() === b.getDate()
+	);
+}
+
+/**
+ * Bucket active reminders by urgency relative to `now`:
+ * - overdue: dueAt < now
+ * - today: same local calendar day as now AND not yet past
+ * - upcoming: later than today
+ * Each bucket is sorted ascending by dueAt.
+ */
+export function reminderBuckets<T extends BucketableReminder>(
+	reminders: T[],
+	now: Date
+): ReminderBuckets<T> {
+	const overdue: T[] = [];
+	const today: T[] = [];
+	const upcoming: T[] = [];
+	for (const r of reminders) {
+		if (r.dueAt.getTime() < now.getTime()) overdue.push(r);
+		else if (isSameLocalDay(r.dueAt, now)) today.push(r);
+		else upcoming.push(r);
+	}
+	const byDue = (a: T, b: T) => a.dueAt.getTime() - b.dueAt.getTime();
+	overdue.sort(byDue);
+	today.sort(byDue);
+	upcoming.sort(byDue);
+	return { overdue, today, upcoming };
+}

--- a/src/lib/weightChart.test.ts
+++ b/src/lib/weightChart.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { filterByRange, buildAreaPath, percentChange, type WeightPoint } from './weightChart';
+import {
+	filterByRange,
+	buildAreaPath,
+	buildLinePath,
+	percentChange,
+	convertWeight,
+	type WeightPoint
+} from './weightChart';
 
 const P = (recordedAt: string, weight: number, unit: 'lbs' | 'kg' = 'lbs'): WeightPoint => ({
 	recordedAt: new Date(recordedAt),
@@ -59,5 +66,27 @@ describe('buildAreaPath', () => {
 		expect(d.endsWith('Z')).toBe(true);
 		expect(d).toContain('L100.00,40.00');
 		expect(d).toContain('L0.00,40.00');
+	});
+});
+
+describe('buildLinePath', () => {
+	it('buildLinePath: starts with M, has the right L count, not closed', () => {
+		const d = buildLinePath([30, 31, 32], 100, 40);
+		expect(d.startsWith('M')).toBe(true);
+		expect(d.endsWith('Z')).toBe(false);
+		expect((d.match(/L/g) || []).length).toBe(2); // 3 points -> 2 L segments
+	});
+});
+
+describe('convertWeight', () => {
+	it('is identity for same unit', () => {
+		expect(convertWeight(30, 'lbs', 'lbs')).toBe(30);
+		expect(convertWeight(14, 'kg', 'kg')).toBe(14);
+	});
+	it('converts kg to lbs', () => {
+		expect(convertWeight(10, 'kg', 'lbs')).toBeCloseTo(22.0462, 3);
+	});
+	it('converts lbs to kg', () => {
+		expect(convertWeight(22.0462, 'lbs', 'kg')).toBeCloseTo(10, 3);
 	});
 });

--- a/src/lib/weightChart.test.ts
+++ b/src/lib/weightChart.test.ts
@@ -8,21 +8,27 @@ const P = (recordedAt: string, weight: number, unit: 'lbs' | 'kg' = 'lbs'): Weig
 });
 
 describe('filterByRange', () => {
-	const pts = [P('2026-01-01', 30), P('2026-03-01', 31), P('2026-05-01', 32), P('2026-06-01', 33)];
+	const pts = [
+		P('2025-11-01', 29), // > 6 months before 2026-06-12 (cutoff 2025-12-12) -> excluded by 6m
+		P('2026-01-01', 30),
+		P('2026-03-01', 31),
+		P('2026-05-01', 32),
+		P('2026-06-01', 33)
+	];
 	const now = new Date('2026-06-12');
 	it('returns all for "all"', () => {
-		expect(filterByRange(pts, 'all', now)).toHaveLength(4);
+		expect(filterByRange(pts, 'all', now)).toHaveLength(5);
 	});
-	it('6mo keeps points within 6 months of now', () => {
+	it('6m keeps points within 6 months of now (excludes the Nov 2025 point)', () => {
 		const out = filterByRange(pts, '6m', now);
-		expect(out.map((p) => p.weight)).toEqual([31, 32, 33]);
+		expect(out.map((p) => p.weight)).toEqual([30, 31, 32, 33]);
 	});
 	it('1y keeps all here', () => {
-		expect(filterByRange(pts, '1y', now)).toHaveLength(4);
+		expect(filterByRange(pts, '1y', now)).toHaveLength(5);
 	});
 	it('keeps input order (assumed ascending by date)', () => {
 		const out = filterByRange(pts, 'all', now);
-		expect(out.map((p) => p.weight)).toEqual([30, 31, 32, 33]);
+		expect(out.map((p) => p.weight)).toEqual([29, 30, 31, 32, 33]);
 	});
 });
 

--- a/src/lib/weightChart.test.ts
+++ b/src/lib/weightChart.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { filterByRange, buildAreaPath, percentChange, type WeightPoint } from './weightChart';
+
+const P = (recordedAt: string, weight: number, unit: 'lbs' | 'kg' = 'lbs'): WeightPoint => ({
+	recordedAt: new Date(recordedAt),
+	weight,
+	unit
+});
+
+describe('filterByRange', () => {
+	const pts = [P('2026-01-01', 30), P('2026-03-01', 31), P('2026-05-01', 32), P('2026-06-01', 33)];
+	const now = new Date('2026-06-12');
+	it('returns all for "all"', () => {
+		expect(filterByRange(pts, 'all', now)).toHaveLength(4);
+	});
+	it('6mo keeps points within 6 months of now', () => {
+		const out = filterByRange(pts, '6m', now);
+		expect(out.map((p) => p.weight)).toEqual([31, 32, 33]);
+	});
+	it('1y keeps all here', () => {
+		expect(filterByRange(pts, '1y', now)).toHaveLength(4);
+	});
+	it('keeps input order (assumed ascending by date)', () => {
+		const out = filterByRange(pts, 'all', now);
+		expect(out.map((p) => p.weight)).toEqual([30, 31, 32, 33]);
+	});
+});
+
+describe('percentChange', () => {
+	it('computes change from first to last', () => {
+		expect(percentChange([P('2026-01-01', 30), P('2026-06-01', 33)])).toBeCloseTo(10, 5);
+	});
+	it('is negative when weight dropped', () => {
+		expect(percentChange([P('a', 40), P('b', 30)])).toBeCloseTo(-25, 5);
+	});
+	it('returns null for fewer than 2 points', () => {
+		expect(percentChange([P('a', 30)])).toBeNull();
+		expect(percentChange([])).toBeNull();
+	});
+	it('returns null when the first weight is 0 (avoid div-by-zero)', () => {
+		expect(percentChange([P('a', 0), P('b', 5)])).toBeNull();
+	});
+});
+
+describe('buildAreaPath', () => {
+	it('returns empty string for fewer than 2 points', () => {
+		expect(buildAreaPath([30], 100, 40)).toBe('');
+		expect(buildAreaPath([], 100, 40)).toBe('');
+	});
+	it('builds a closed area path that starts at the baseline and returns to it', () => {
+		const d = buildAreaPath([30, 31, 32], 100, 40);
+		expect(d.startsWith('M')).toBe(true);
+		expect(d.endsWith('Z')).toBe(true);
+		expect(d).toContain('L100.00,40.00');
+		expect(d).toContain('L0.00,40.00');
+	});
+});

--- a/src/lib/weightChart.ts
+++ b/src/lib/weightChart.ts
@@ -10,8 +10,8 @@ export type WeightRange = '6m' | '1y' | 'all';
 export function filterByRange(points: WeightPoint[], range: WeightRange, now: Date): WeightPoint[] {
 	if (range === 'all') return points;
 	const cutoff = new Date(now);
-	if (range === '6m') cutoff.setMonth(cutoff.getMonth() - 5);
-	else cutoff.setMonth(cutoff.getMonth() - 11);
+	if (range === '6m') cutoff.setMonth(cutoff.getMonth() - 6);
+	else cutoff.setFullYear(cutoff.getFullYear() - 1);
 	return points.filter((p) => p.recordedAt >= cutoff);
 }
 

--- a/src/lib/weightChart.ts
+++ b/src/lib/weightChart.ts
@@ -6,6 +6,14 @@ export interface WeightPoint {
 
 export type WeightRange = '6m' | '1y' | 'all';
 
+const LBS_PER_KG = 2.2046226218;
+
+/** Convert a weight between lbs and kg. */
+export function convertWeight(weight: number, from: 'lbs' | 'kg', to: 'lbs' | 'kg'): number {
+	if (from === to) return weight;
+	return from === 'kg' ? weight * LBS_PER_KG : weight / LBS_PER_KG;
+}
+
 /** Keep points within the range, relative to `now`. Assumes input is sorted ascending by recordedAt. */
 export function filterByRange(points: WeightPoint[], range: WeightRange, now: Date): WeightPoint[] {
 	if (range === 'all') return points;
@@ -24,6 +32,17 @@ export function percentChange(points: WeightPoint[]): number | null {
 	return ((last - first) / first) * 100;
 }
 
+function scalePoints(values: number[], width: number, height: number): { x: number; y: number }[] {
+	const min = Math.min(...values);
+	const max = Math.max(...values);
+	const range = max - min || 1;
+	const pad = 2;
+	return values.map((v, i) => ({
+		x: (i / (values.length - 1)) * width,
+		y: pad + (1 - (v - min) / range) * (height - pad * 2)
+	}));
+}
+
 /**
  * Closed SVG area path for the values, scaled to width × height. Empty for <2
  * points. The line follows the values; the path then closes down to the bottom
@@ -31,15 +50,7 @@ export function percentChange(points: WeightPoint[]): number | null {
  */
 export function buildAreaPath(values: number[], width: number, height: number): string {
 	if (values.length < 2) return '';
-	const min = Math.min(...values);
-	const max = Math.max(...values);
-	const range = max - min || 1;
-	const pad = 2;
-	const pts = values.map((v, i) => {
-		const x = (i / (values.length - 1)) * width;
-		const y = pad + (1 - (v - min) / range) * (height - pad * 2);
-		return { x, y };
-	});
+	const pts = scalePoints(values, width, height);
 	const line = pts.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join('L');
 	const lastX = pts[pts.length - 1].x.toFixed(2);
 	return `M${line}L${lastX},${height.toFixed(2)}L${(0).toFixed(2)},${height.toFixed(2)}Z`;
@@ -48,18 +59,6 @@ export function buildAreaPath(values: number[], width: number, height: number): 
 /** Line-only path (reuse for the stroke on top of the area). Empty for <2 points. */
 export function buildLinePath(values: number[], width: number, height: number): string {
 	if (values.length < 2) return '';
-	const min = Math.min(...values);
-	const max = Math.max(...values);
-	const range = max - min || 1;
-	const pad = 2;
-	return (
-		'M' +
-		values
-			.map((v, i) => {
-				const x = (i / (values.length - 1)) * width;
-				const y = pad + (1 - (v - min) / range) * (height - pad * 2);
-				return `${x.toFixed(2)},${y.toFixed(2)}`;
-			})
-			.join('L')
-	);
+	const pts = scalePoints(values, width, height);
+	return 'M' + pts.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join('L');
 }

--- a/src/lib/weightChart.ts
+++ b/src/lib/weightChart.ts
@@ -1,0 +1,65 @@
+export interface WeightPoint {
+	recordedAt: Date;
+	weight: number;
+	unit: 'lbs' | 'kg';
+}
+
+export type WeightRange = '6m' | '1y' | 'all';
+
+/** Keep points within the range, relative to `now`. Assumes input is sorted ascending by recordedAt. */
+export function filterByRange(points: WeightPoint[], range: WeightRange, now: Date): WeightPoint[] {
+	if (range === 'all') return points;
+	const cutoff = new Date(now);
+	if (range === '6m') cutoff.setMonth(cutoff.getMonth() - 5);
+	else cutoff.setMonth(cutoff.getMonth() - 11);
+	return points.filter((p) => p.recordedAt >= cutoff);
+}
+
+/** Percent change from the first to the last point; null for <2 points or a zero baseline. */
+export function percentChange(points: WeightPoint[]): number | null {
+	if (points.length < 2) return null;
+	const first = points[0].weight;
+	const last = points[points.length - 1].weight;
+	if (first === 0) return null;
+	return ((last - first) / first) * 100;
+}
+
+/**
+ * Closed SVG area path for the values, scaled to width × height. Empty for <2
+ * points. The line follows the values; the path then closes down to the bottom
+ * edge and back to x=0 so it can be filled.
+ */
+export function buildAreaPath(values: number[], width: number, height: number): string {
+	if (values.length < 2) return '';
+	const min = Math.min(...values);
+	const max = Math.max(...values);
+	const range = max - min || 1;
+	const pad = 2;
+	const pts = values.map((v, i) => {
+		const x = (i / (values.length - 1)) * width;
+		const y = pad + (1 - (v - min) / range) * (height - pad * 2);
+		return { x, y };
+	});
+	const line = pts.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join('L');
+	const lastX = pts[pts.length - 1].x.toFixed(2);
+	return `M${line}L${lastX},${height.toFixed(2)}L${(0).toFixed(2)},${height.toFixed(2)}Z`;
+}
+
+/** Line-only path (reuse for the stroke on top of the area). Empty for <2 points. */
+export function buildLinePath(values: number[], width: number, height: number): string {
+	if (values.length < 2) return '';
+	const min = Math.min(...values);
+	const max = Math.max(...values);
+	const range = max - min || 1;
+	const pad = 2;
+	return (
+		'M' +
+		values
+			.map((v, i) => {
+				const x = (i / (values.length - 1)) * width;
+				const y = pad + (1 - (v - min) / range) * (height - pad * 2);
+				return `${x.toFixed(2)},${y.toFixed(2)}`;
+			})
+			.join('L')
+	);
+}

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.server.ts
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.server.ts
@@ -24,7 +24,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		}),
 		db.query.documents.findMany({
 			where: eq(schema.documents.companionId, params.companionId),
-			columns: { id: true, title: true, healthEventId: true, filename: true }
+			columns: { id: true, title: true, healthEventId: true, filename: true, mimeType: true }
 		})
 	]);
 

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -13,6 +13,7 @@
 	import { Select } from '$lib/components/ui/select/index.js';
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { Scale, Plus, Pencil, Trash2, X, FileText } from '@lucide/svelte';
+	import WeightChart from '$lib/components/WeightChart.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { tick } from 'svelte';
@@ -24,6 +25,17 @@
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 	const locale = getLocale();
+
+	let weightPoints = $derived(
+		[...data.weightEntries]
+			.map((w) => ({
+				recordedAt: new Date(w.recordedAt),
+				weight: w.weight,
+				unit: w.unit as 'lbs' | 'kg'
+			}))
+			.sort((a, b) => a.recordedAt.getTime() - b.recordedAt.getTime())
+	);
+
 	let showHealthForm = $state(false);
 	let showWeightForm = $state(false);
 	let submittingHealth = $state(false);
@@ -268,7 +280,7 @@
 						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
 							>{t(locale, 'page.health.detailType')}</span
 						>
-						<Badge variant="bark" class="capitalize">{healthTypeLabel(locale, h.type)}</Badge>
+						<Badge variant="secondary" class="capitalize">{healthTypeLabel(locale, h.type)}</Badge>
 					</div>
 					<div class="flex items-center gap-3">
 						<span class="w-20 shrink-0 text-xs font-medium text-muted-foreground"
@@ -626,12 +638,19 @@
 		</Card>
 	{/if}
 
+	<section>
+		<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+			{t(locale, 'page.health.weightTrend')}
+		</p>
+		<WeightChart entries={weightPoints} />
+	</section>
+
 	{#if data.weightEntries.length > 0}
-		<Card>
-			<CardHeader>
-				<CardTitle>{t(locale, 'page.health.weightHistoryTitle')}</CardTitle>
-			</CardHeader>
-			<div class="divide-y divide-border">
+		<section>
+			<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+				{t(locale, 'page.health.weightHistoryTitle')}
+			</p>
+			<div class="rounded-2xl border bg-card divide-y divide-border">
 				{#each data.weightEntries as entry (entry.id)}
 					{#if editingWeightId === entry.id}
 						<div class="px-6 py-4">
@@ -756,14 +775,14 @@
 					{/if}
 				{/each}
 			</div>
-		</Card>
+		</section>
 	{/if}
 
-	<Card>
-		<CardHeader>
-			<CardTitle>{t(locale, 'page.health.healthEventsTitle')}</CardTitle>
-		</CardHeader>
-		<CardContent>
+	<section>
+		<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+			{t(locale, 'page.health.healthEventsTitle')}
+		</p>
+		<div class="rounded-2xl border bg-card px-5 py-4">
 			{#if data.healthEvents.length === 0}
 				<p class="text-sm italic text-muted-foreground">
 					{t(locale, 'page.health.noHealthEvents')}
@@ -885,7 +904,7 @@
 									</div>
 									<div class="flex-1 min-w-0">
 										<div class="flex items-center gap-2">
-											<Badge variant="bark" class="capitalize"
+											<Badge variant="secondary" class="capitalize"
 												>{healthTypeLabel(locale, event.type)}</Badge
 											>
 											<span class="font-medium text-sm text-foreground">{event.title}</span>
@@ -946,8 +965,8 @@
 					{/each}
 				</div>
 			{/if}
-		</CardContent>
-	</Card>
+		</div>
+	</section>
 </div>
 
 <form bind:this={deleteWeightForm} method="POST" action="?/deleteWeight" use:enhance class="hidden">

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -640,7 +640,7 @@
 	{/if}
 
 	<section>
-		<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+		<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
 			{t(locale, 'page.health.weightTrend')}
 		</p>
 		<WeightChart entries={weightPoints} />
@@ -648,7 +648,7 @@
 
 	{#if data.weightEntries.length > 0}
 		<section>
-			<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+			<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
 				{t(locale, 'page.health.weightHistoryTitle')}
 			</p>
 			<div class="rounded-2xl border bg-card divide-y divide-border">
@@ -780,7 +780,7 @@
 	{/if}
 
 	<section>
-		<p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+		<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
 			{t(locale, 'page.health.healthEventsTitle')}
 		</p>
 		<div class="rounded-2xl border bg-card px-5 py-4">

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -217,13 +217,14 @@
 			bind:this={dialogEl}
 			role="dialog"
 			aria-modal="true"
+			aria-labelledby="health-detail-title"
 			tabindex="-1"
 			onkeydown={trapFocus}
 			class="relative z-10 w-full max-w-md rounded-xl border bg-card text-card-foreground shadow-xl focus:outline-none
 				animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-4 sm:slide-in-from-bottom-0 duration-200"
 		>
 			<div class="flex items-center justify-between px-5 pt-5 pb-3">
-				<h2 class="font-semibold text-base text-foreground">
+				<h2 id="health-detail-title" class="font-semibold text-base text-foreground">
 					{#if selected.kind === 'weight'}
 						{t(locale, 'page.health.detailWeightEntry')}
 					{:else if selected.kind === 'health'}

--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -14,6 +14,7 @@
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { Scale, Plus, Pencil, Trash2, X, FileText } from '@lucide/svelte';
 	import WeightChart from '$lib/components/WeightChart.svelte';
+	import DocumentPreview from '$lib/components/DocumentPreview.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
 	import { tick } from 'svelte';
@@ -35,6 +36,16 @@
 			}))
 			.sort((a, b) => a.recordedAt.getTime() - b.recordedAt.getTime())
 	);
+
+	// Document preview (documents attached to a health event)
+	type LinkedDoc = (typeof data.linkedDocuments)[0];
+	let previewDoc = $state<LinkedDoc | null>(null);
+	function docsForEvent(eventId: string): LinkedDoc[] {
+		return data.linkedDocuments.filter((d) => d.healthEventId === eventId);
+	}
+	function docUrl(doc: LinkedDoc) {
+		return `/api/documents/${data.companion.id}/${doc.filename}`;
+	}
 
 	let showHealthForm = $state(false);
 	let showWeightForm = $state(false);
@@ -311,6 +322,28 @@
 							</p>
 							<div class="prose prose-sm dark:prose-invert max-w-none">
 								{@html renderMarkdown(h.notes)}
+							</div>
+						</div>
+					{/if}
+					{#if docsForEvent(h.id).length > 0}
+						<div class="pt-1">
+							<p class="text-xs font-medium text-muted-foreground mb-1">
+								{t(locale, 'nav.documents')}
+							</p>
+							<div class="flex flex-col gap-1.5">
+								{#each docsForEvent(h.id) as doc (doc.id)}
+									<button
+										type="button"
+										onclick={() => {
+											closeDetail();
+											previewDoc = doc;
+										}}
+										class="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-left text-sm text-foreground transition-colors hover:bg-accent"
+									>
+										<FileText class="h-4 w-4 shrink-0 text-muted-foreground" />
+										<span class="truncate">{doc.title}</span>
+									</button>
+								{/each}
 							</div>
 						</div>
 					{/if}
@@ -986,3 +1019,13 @@
 	}}
 	oncancel={() => (confirmOpen = false)}
 />
+
+{#if previewDoc}
+	<DocumentPreview
+		open={true}
+		url={docUrl(previewDoc)}
+		mimeType={previewDoc.mimeType}
+		title={previewDoc.title}
+		onclose={() => (previewDoc = null)}
+	/>
+{/if}

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -641,9 +641,9 @@
 		{#if buckets.overdue.length > 0}
 			<div>
 				<p class="text-xs font-semibold uppercase tracking-wide text-coral mb-2">
-					{t(locale, 'page.reminders.overdue')}
+					{t(locale, 'page.reminders.groupOverdue')}
 				</p>
-				<div class="space-y-3">
+				<div class="space-y-3" data-active-group>
 					{#each buckets.overdue as reminder (reminder.id)}
 						{@render reminderCard(reminder)}
 					{/each}
@@ -653,10 +653,10 @@
 
 		{#if buckets.today.length > 0}
 			<div>
-				<p class="text-xs font-semibold uppercase tracking-wide text-amber-500 mb-2">
+				<p class="text-xs font-semibold uppercase tracking-wide text-gold mb-2">
 					{t(locale, 'page.reminders.groupToday')}
 				</p>
-				<div class="space-y-3">
+				<div class="space-y-3" data-active-group>
 					{#each buckets.today as reminder (reminder.id)}
 						{@render reminderCard(reminder)}
 					{/each}
@@ -669,7 +669,7 @@
 				<p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
 					{t(locale, 'page.reminders.groupUpcoming')}
 				</p>
-				<div class="space-y-3">
+				<div class="space-y-3" data-active-group>
 					{#each buckets.upcoming as reminder (reminder.id)}
 						{@render reminderCard(reminder)}
 					{/each}

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -27,6 +27,7 @@
 	import ReminderCompleteButtons from '$lib/components/reminders/ReminderCompleteButtons.svelte';
 	import { formatRecurrence } from '$lib/reminderRecurrence';
 	import { REMINDER_TO_HEALTH_TYPE } from '$lib/health';
+	import { reminderBuckets } from '$lib/reminderBuckets';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 	const locale = getLocale();
@@ -56,6 +57,12 @@
 
 	let active = $derived(data.reminders.filter((r) => !r.completedAt));
 	let completed = $derived(data.reminders.filter((r) => r.completedAt));
+	let buckets = $derived(
+		reminderBuckets(
+			active.map((r) => ({ ...r, dueAt: new Date(r.dueAt) })),
+			new Date()
+		)
+	);
 
 	function isOverdue(dueAt: Date | string) {
 		return new Date(dueAt) < new Date();
@@ -465,177 +472,211 @@
 			</CardContent>
 		</Card>
 	{:else}
-		<div class="space-y-3">
-			{#each active as reminder (reminder.id)}
-				{@const overdue = isOverdue(reminder.dueAt)}
-				<Card class="overflow-hidden {overdue ? 'border-coral/40' : ''}">
-					{#if editingId === reminder.id}
-						<CardContent class="pt-6">
-							<form
-								method="POST"
-								action="?/update"
-								use:localDatetimes
-								use:enhance={() =>
-									({ update }) => {
-										update();
-										editingId = null;
-									}}
-								class="space-y-4"
-							>
-								<input type="hidden" name="id" value={reminder.id} />
-								<div class="grid grid-cols-2 gap-4">
-									<div class="space-y-1.5 col-span-2 sm:col-span-1">
-										<Label for="edit-title-{reminder.id}"
-											>{t(locale, 'page.reminders.labelTitle')}</Label
-										>
-										<Input
-											id="edit-title-{reminder.id}"
-											name="title"
-											type="text"
-											autocomplete="off"
-											value={reminder.title}
-											required
-										/>
-									</div>
-									<div class="space-y-1.5">
-										<Label for="edit-type-{reminder.id}"
-											>{t(locale, 'page.reminders.labelType')}</Label
-										>
-										<Select id="edit-type-{reminder.id}" name="type">
-											{#each REMINDER_TYPES as rt (rt.value)}
-												<option value={rt.value} selected={reminder.type === rt.value}
-													>{rt.icon} {rt.label}</option
-												>
-											{/each}
-										</Select>
-									</div>
-								</div>
-								<div class="space-y-1.5">
-									<Label for="edit-dueAt-{reminder.id}"
-										>{t(locale, 'page.reminders.labelDueDate')}</Label
+		{#snippet reminderCard(reminder: (typeof active)[0])}
+			{@const overdue = isOverdue(reminder.dueAt)}
+			<Card class="overflow-hidden {overdue ? 'border-coral/40' : ''}">
+				{#if editingId === reminder.id}
+					<CardContent class="pt-6">
+						<form
+							method="POST"
+							action="?/update"
+							use:localDatetimes
+							use:enhance={() =>
+								({ update }) => {
+									update();
+									editingId = null;
+								}}
+							class="space-y-4"
+						>
+							<input type="hidden" name="id" value={reminder.id} />
+							<div class="grid grid-cols-2 gap-4">
+								<div class="space-y-1.5 col-span-2 sm:col-span-1">
+									<Label for="edit-title-{reminder.id}"
+										>{t(locale, 'page.reminders.labelTitle')}</Label
 									>
 									<Input
-										id="edit-dueAt-{reminder.id}"
-										name="dueAt"
-										type="datetime-local"
+										id="edit-title-{reminder.id}"
+										name="title"
+										type="text"
 										autocomplete="off"
-										value={localDatetimeISO(reminder.dueAt)}
+										value={reminder.title}
 										required
 									/>
 								</div>
 								<div class="space-y-1.5">
-									<Label for="edit-description-{reminder.id}"
-										>{t(locale, 'page.reminders.labelNotes')}</Label
+									<Label for="edit-type-{reminder.id}"
+										>{t(locale, 'page.reminders.labelType')}</Label
 									>
-									<MarkdownTextarea
-										id="edit-description-{reminder.id}"
-										name="description"
-										value={reminder.description ?? ''}
-										placeholder={t(locale, 'page.reminders.placeholderNotes')}
-										rows={3}
-									/>
+									<Select id="edit-type-{reminder.id}" name="type">
+										{#each REMINDER_TYPES as rt (rt.value)}
+											<option value={rt.value} selected={reminder.type === rt.value}
+												>{rt.icon} {rt.label}</option
+											>
+										{/each}
+									</Select>
 								</div>
-								<RecurrenceEditor
-									value={reminder}
-									userDefault={data.defaultRecurrenceUnit}
-									idPrefix="edit-{reminder.id}"
+							</div>
+							<div class="space-y-1.5">
+								<Label for="edit-dueAt-{reminder.id}"
+									>{t(locale, 'page.reminders.labelDueDate')}</Label
+								>
+								<Input
+									id="edit-dueAt-{reminder.id}"
+									name="dueAt"
+									type="datetime-local"
+									autocomplete="off"
+									value={localDatetimeISO(reminder.dueAt)}
+									required
 								/>
-								<div class="flex gap-3">
-									<Button type="submit" size="sm">{t(locale, 'common.save')}</Button>
+							</div>
+							<div class="space-y-1.5">
+								<Label for="edit-description-{reminder.id}"
+									>{t(locale, 'page.reminders.labelNotes')}</Label
+								>
+								<MarkdownTextarea
+									id="edit-description-{reminder.id}"
+									name="description"
+									value={reminder.description ?? ''}
+									placeholder={t(locale, 'page.reminders.placeholderNotes')}
+									rows={3}
+								/>
+							</div>
+							<RecurrenceEditor
+								value={reminder}
+								userDefault={data.defaultRecurrenceUnit}
+								idPrefix="edit-{reminder.id}"
+							/>
+							<div class="flex gap-3">
+								<Button type="submit" size="sm">{t(locale, 'common.save')}</Button>
+								<Button type="button" variant="outline" size="sm" onclick={() => (editingId = null)}
+									>{t(locale, 'common.cancel')}</Button
+								>
+							</div>
+						</form>
+					</CardContent>
+				{:else}
+					<CardContent class="pt-4 pb-4">
+						<div class="flex items-start justify-between gap-4">
+							<button
+								type="button"
+								onclick={() => openDetail(reminder)}
+								class="flex-1 flex items-start gap-3 text-left rounded-md px-2 py-1 -mx-2 hover:bg-accent transition-colors min-w-0"
+							>
+								<span class="text-xl mt-0.5">{TYPE_ICONS[reminder.type] ?? '📌'}</span>
+								<div class="min-w-0">
+									<div class="flex items-center gap-2 flex-wrap">
+										<span class="font-medium text-foreground">{reminder.title}</span>
+										{#if overdue}<Badge variant="coral">{t(locale, 'page.reminders.overdue')}</Badge
+											>{/if}
+										{#if reminder.isRecurring}
+											<Badge variant="secondary"
+												>{formatRecurrence(reminder, locale, 'short')}</Badge
+											>
+										{/if}
+									</div>
+									{#if reminder.description}
+										<div
+											class="prose prose-sm dark:prose-invert max-w-none mt-0.5 text-muted-foreground"
+										>
+											{@html renderMarkdown(reminder.description)}
+										</div>
+									{/if}
+									<p class="text-xs mt-1 {overdue ? 'text-coral' : 'text-muted-foreground'}">
+										Due <LocalTime date={reminder.dueAt} format="datetime" /><ByLine
+											user={reminder.logger}
+											variant="inline"
+										/>
+									</p>
+								</div>
+							</button>
+							{#if data.companion.isActive !== false}
+								<div class="flex items-center gap-1 shrink-0">
 									<Button
 										type="button"
-										variant="outline"
-										size="sm"
-										onclick={() => (editingId = null)}>{t(locale, 'common.cancel')}</Button
+										variant="soft"
+										size="icon-sm"
+										onclick={() => startEdit(reminder)}
+										aria-label={t(locale, 'common.edit')}
+										title={t(locale, 'common.edit')}
 									>
+										<Pencil class="h-4 w-4" />
+									</Button>
+									<ReminderCompleteButtons
+										onDone={() => {
+											const form = dismissFormRegistry.get(reminder.id);
+											if (form)
+												pendingDismiss.queue(reminder.id, form, reminder.title, {
+													allowLogEvent:
+														REMINDER_TO_HEALTH_TYPE[
+															reminder.type as keyof typeof REMINDER_TO_HEALTH_TYPE
+														] !== null
+												});
+										}}
+										onDoneAndLog={() => submitWithAndEvent(reminder.id)}
+										allowLogEvent={REMINDER_TO_HEALTH_TYPE[
+											reminder.type as keyof typeof REMINDER_TO_HEALTH_TYPE
+										] !== null}
+									/>
+									<Button
+										type="button"
+										variant="softDestructive"
+										size="icon-sm"
+										aria-label={t(locale, 'common.delete')}
+										title={t(locale, 'common.delete')}
+										onclick={() => {
+											deleteReminderId = reminder.id;
+											confirmOpen = true;
+										}}
+									>
+										<Trash2 class="h-4 w-4" />
+									</Button>
 								</div>
-							</form>
-						</CardContent>
-					{:else}
-						<CardContent class="pt-4 pb-4">
-							<div class="flex items-start justify-between gap-4">
-								<button
-									type="button"
-									onclick={() => openDetail(reminder)}
-									class="flex-1 flex items-start gap-3 text-left rounded-md px-2 py-1 -mx-2 hover:bg-accent transition-colors min-w-0"
-								>
-									<span class="text-xl mt-0.5">{TYPE_ICONS[reminder.type] ?? '📌'}</span>
-									<div class="min-w-0">
-										<div class="flex items-center gap-2 flex-wrap">
-											<span class="font-medium text-foreground">{reminder.title}</span>
-											{#if overdue}<Badge variant="coral"
-													>{t(locale, 'page.reminders.overdue')}</Badge
-												>{/if}
-											{#if reminder.isRecurring}
-												<Badge variant="secondary"
-													>{formatRecurrence(reminder, locale, 'short')}</Badge
-												>
-											{/if}
-										</div>
-										{#if reminder.description}
-											<div
-												class="prose prose-sm dark:prose-invert max-w-none mt-0.5 text-muted-foreground"
-											>
-												{@html renderMarkdown(reminder.description)}
-											</div>
-										{/if}
-										<p class="text-xs mt-1 {overdue ? 'text-coral' : 'text-muted-foreground'}">
-											Due <LocalTime date={reminder.dueAt} format="datetime" /><ByLine
-												user={reminder.logger}
-												variant="inline"
-											/>
-										</p>
-									</div>
-								</button>
-								{#if data.companion.isActive !== false}
-									<div class="flex items-center gap-1 shrink-0">
-										<Button
-											type="button"
-											variant="soft"
-											size="icon-sm"
-											onclick={() => startEdit(reminder)}
-											aria-label={t(locale, 'common.edit')}
-											title={t(locale, 'common.edit')}
-										>
-											<Pencil class="h-4 w-4" />
-										</Button>
-										<ReminderCompleteButtons
-											onDone={() => {
-												const form = dismissFormRegistry.get(reminder.id);
-												if (form)
-													pendingDismiss.queue(reminder.id, form, reminder.title, {
-														allowLogEvent:
-															REMINDER_TO_HEALTH_TYPE[
-																reminder.type as keyof typeof REMINDER_TO_HEALTH_TYPE
-															] !== null
-													});
-											}}
-											onDoneAndLog={() => submitWithAndEvent(reminder.id)}
-											allowLogEvent={REMINDER_TO_HEALTH_TYPE[
-												reminder.type as keyof typeof REMINDER_TO_HEALTH_TYPE
-											] !== null}
-										/>
-										<Button
-											type="button"
-											variant="softDestructive"
-											size="icon-sm"
-											aria-label={t(locale, 'common.delete')}
-											title={t(locale, 'common.delete')}
-											onclick={() => {
-												deleteReminderId = reminder.id;
-												confirmOpen = true;
-											}}
-										>
-											<Trash2 class="h-4 w-4" />
-										</Button>
-									</div>
-								{/if}
-							</div>
-						</CardContent>
-					{/if}
-				</Card>
-			{/each}
-		</div>
+							{/if}
+						</div>
+					</CardContent>
+				{/if}
+			</Card>
+		{/snippet}
+
+		{#if buckets.overdue.length > 0}
+			<div>
+				<p class="text-xs font-semibold uppercase tracking-wide text-coral mb-2">
+					{t(locale, 'page.reminders.overdue')}
+				</p>
+				<div class="space-y-3">
+					{#each buckets.overdue as reminder (reminder.id)}
+						{@render reminderCard(reminder)}
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		{#if buckets.today.length > 0}
+			<div>
+				<p class="text-xs font-semibold uppercase tracking-wide text-amber-500 mb-2">
+					{t(locale, 'page.reminders.groupToday')}
+				</p>
+				<div class="space-y-3">
+					{#each buckets.today as reminder (reminder.id)}
+						{@render reminderCard(reminder)}
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		{#if buckets.upcoming.length > 0}
+			<div>
+				<p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+					{t(locale, 'page.reminders.groupUpcoming')}
+				</p>
+				<div class="space-y-3">
+					{#each buckets.upcoming as reminder (reminder.id)}
+						{@render reminderCard(reminder)}
+					{/each}
+				</div>
+			</div>
+		{/if}
+
 		<!-- Hidden dismiss forms -->
 		{#each active as reminder (reminder.id + '-form')}
 			<form

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -223,13 +223,16 @@
 			bind:this={dialogEl}
 			role="dialog"
 			aria-modal="true"
+			aria-labelledby="reminder-detail-title"
 			tabindex="-1"
 			onkeydown={trapFocus}
 			class="relative z-10 w-full max-w-md rounded-xl border bg-card text-card-foreground shadow-xl focus:outline-none
 				animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-4 sm:slide-in-from-bottom-0 duration-200"
 		>
 			<div class="flex items-center justify-between px-5 pt-5 pb-3">
-				<h2 class="font-semibold text-base text-foreground">{r.title}</h2>
+				<h2 id="reminder-detail-title" class="font-semibold text-base text-foreground">
+					{r.title}
+				</h2>
 				<button
 					onclick={closeDetail}
 					aria-label={t(locale, 'aria.close')}
@@ -640,7 +643,7 @@
 
 		{#if buckets.overdue.length > 0}
 			<div>
-				<p class="text-xs font-semibold uppercase tracking-wide text-coral mb-2">
+				<p class="text-xs font-semibold uppercase tracking-wider text-coral mb-2">
 					{t(locale, 'page.reminders.groupOverdue')}
 				</p>
 				<div class="space-y-3" data-active-group>
@@ -653,7 +656,7 @@
 
 		{#if buckets.today.length > 0}
 			<div>
-				<p class="text-xs font-semibold uppercase tracking-wide text-gold mb-2">
+				<p class="text-xs font-semibold uppercase tracking-wider text-gold mb-2">
 					{t(locale, 'page.reminders.groupToday')}
 				</p>
 				<div class="space-y-3" data-active-group>
@@ -666,7 +669,7 @@
 
 		{#if buckets.upcoming.length > 0}
 			<div>
-				<p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+				<p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
 					{t(locale, 'page.reminders.groupUpcoming')}
 				</p>
 				<div class="space-y-3" data-active-group>

--- a/tests/e2e/health.spec.ts
+++ b/tests/e2e/health.spec.ts
@@ -81,7 +81,6 @@ test.describe('health events and weight log', () => {
 	});
 
 	test('health page shows the weight trend section', async ({ asMember }) => {
-		const COMP = 'seed-comp-biscuit';
 		await asMember.goto(`/${COMP}/health`);
 		await expect(asMember.getByText('Weight trend')).toBeVisible({ timeout: 8_000 });
 		// Seed has 0 weight rows — assert the empty-state text (<2 entries, no svg).

--- a/tests/e2e/health.spec.ts
+++ b/tests/e2e/health.spec.ts
@@ -74,8 +74,18 @@ test.describe('health events and weight log', () => {
 		await asMember.locator('#weight').fill('13.7');
 		await asMember.getByRole('button', { name: 'Log Weight' }).last().click();
 
-		// Weight history card should now show the recorded value
-		await expect(asMember.getByText(/13\.7/)).toBeVisible({ timeout: 8_000 });
+		// Weight history section should now show the recorded value
+		await expect(
+			asMember.locator('section').filter({ hasText: 'Weight History' }).getByText(/13\.7/)
+		).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('health page shows the weight trend section', async ({ asMember }) => {
+		const COMP = 'seed-comp-biscuit';
+		await asMember.goto(`/${COMP}/health`);
+		await expect(asMember.getByText('Weight trend')).toBeVisible({ timeout: 8_000 });
+		// Seed has 0 weight rows — assert the empty-state text (<2 entries, no svg).
+		await expect(asMember.getByText('No weight recorded yet.')).toBeVisible({ timeout: 8_000 });
 	});
 
 	test('title required', async ({ asMember }) => {

--- a/tests/e2e/health.spec.ts
+++ b/tests/e2e/health.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../lib/fixtures';
+import { pdfUpload } from '../lib/files';
 
 const COMP = 'seed-comp-biscuit';
 
@@ -82,9 +83,36 @@ test.describe('health events and weight log', () => {
 
 	test('health page shows the weight trend section', async ({ asMember }) => {
 		await asMember.goto(`/${COMP}/health`);
+		// The featured weight-trend section renders (its label is always present).
+		// Don't assert a count-dependent state here: the `log weight` test shares
+		// this worker's DB and may have added an entry, changing the chart state.
 		await expect(asMember.getByText('Weight trend')).toBeVisible({ timeout: 8_000 });
-		// Seed has 0 weight rows — assert the empty-state text (<2 entries, no svg).
-		await expect(asMember.getByText('No weight recorded yet.')).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('a document attached to a health event is previewable from the event modal', async ({
+		asMember
+	}) => {
+		// Upload a document and link it to the seeded "Seed checkup" health event.
+		await asMember.goto(`/${COMP}/documents`);
+		await asMember.locator('input[type="file"]').setInputFiles(pdfUpload('e2e-health-attach.pdf'));
+		await expect(asMember.getByText('e2e-health-attach.pdf')).toBeVisible({ timeout: 15_000 });
+		const li = asMember.locator('li').filter({ hasText: 'e2e-health-attach.pdf' }).first();
+		await li.getByRole('button', { name: 'Edit document' }).click();
+		await asMember.locator('select[id^="doc-event-"]').selectOption('seed-health-1');
+		await asMember.getByRole('button', { name: 'Save' }).first().click();
+		await expect(asMember.getByText('Seed checkup')).toBeVisible({ timeout: 8_000 });
+
+		// On the health page, open the "Seed checkup" event detail modal.
+		await asMember.goto(`/${COMP}/health`);
+		await asMember.getByText('Seed checkup').first().click();
+		const dialog = asMember.locator('[role="dialog"]');
+		await expect(dialog).toBeVisible({ timeout: 8_000 });
+
+		// The linked document appears in the modal and opens a preview when clicked.
+		await dialog.getByRole('button', { name: /e2e-health-attach\.pdf/ }).click();
+		await expect(asMember.getByRole('dialog', { name: 'e2e-health-attach.pdf' })).toBeVisible({
+			timeout: 8_000
+		});
 	});
 
 	test('title required', async ({ asMember }) => {

--- a/tests/e2e/reminders.spec.ts
+++ b/tests/e2e/reminders.spec.ts
@@ -64,10 +64,10 @@ function justPast(): string {
 // with one Card per active reminder. We scope lookups to the whole page and
 // rely on the title text being unique per test (enforced by UNIQUE names).
 function activeSection(page: import('@playwright/test').Page) {
-	// Active reminders live in one `div.space-y-3` per urgency group (Overdue/
-	// Today/Upcoming). Completed reminders live inside a <details>, never a
-	// `div.space-y-3`, so scoping to these containers excludes completed.
-	return page.locator('div.space-y-3');
+	// Active reminders live in one container per urgency group, each marked
+	// data-active-group. Completed rows (in <details>) and the detail modal's
+	// inner lists are never marked, so this excludes them unambiguously.
+	return page.locator('[data-active-group]');
 }
 
 function completedSection(page: import('@playwright/test').Page) {
@@ -219,11 +219,18 @@ test.describe('reminders', () => {
 		await asMember.goto(BASE);
 		await addReminder(asMember, { title: 'e2e-overdue-grp', type: 'other', dueAt: justPast() });
 		await addReminder(asMember, { title: 'e2e-upcoming-grp', type: 'other', dueAt: tomorrow() });
-		await expect(activeSection(asMember).getByText('e2e-overdue-grp')).toBeVisible({
+
+		// The group container is the data-active-group div immediately after each header <p>.
+		const groupAfter = (label: string) =>
+			asMember.locator('p').filter({ hasText: label }).locator('xpath=following-sibling::div[1]');
+
+		await expect(groupAfter('Overdue').getByText('e2e-overdue-grp')).toBeVisible({
 			timeout: 8_000
 		});
-		await expect(activeSection(asMember).getByText('e2e-upcoming-grp')).toBeVisible({
+		await expect(groupAfter('Upcoming').getByText('e2e-upcoming-grp')).toBeVisible({
 			timeout: 8_000
 		});
+		// Cross-check: the overdue item is NOT in the upcoming group.
+		await expect(groupAfter('Overdue').getByText('e2e-upcoming-grp')).toHaveCount(0);
 	});
 });

--- a/tests/e2e/reminders.spec.ts
+++ b/tests/e2e/reminders.spec.ts
@@ -64,11 +64,10 @@ function justPast(): string {
 // with one Card per active reminder. We scope lookups to the whole page and
 // rely on the title text being unique per test (enforced by UNIQUE names).
 function activeSection(page: import('@playwright/test').Page) {
-	// The active section is the sibling space-y-3 div before the <details> element.
-	// Simplest robust locator: a div that does NOT sit inside <details>.
-	// In practice we just use the page and narrow by the card's position above
-	// the completed summary line.
-	return page.locator('div.space-y-3').first();
+	// Active reminders live in one `div.space-y-3` per urgency group (Overdue/
+	// Today/Upcoming). Completed reminders live inside a <details>, never a
+	// `div.space-y-3`, so scoping to these containers excludes completed.
+	return page.locator('div.space-y-3');
 }
 
 function completedSection(page: import('@playwright/test').Page) {
@@ -214,5 +213,17 @@ test.describe('reminders', () => {
 
 		// Save button still visible — no redirect/close
 		await expect(asMember.getByRole('button', { name: 'Save Reminder' })).toBeVisible();
+	});
+
+	test('overdue and upcoming reminders sort into their urgency groups', async ({ asMember }) => {
+		await asMember.goto(BASE);
+		await addReminder(asMember, { title: 'e2e-overdue-grp', type: 'other', dueAt: justPast() });
+		await addReminder(asMember, { title: 'e2e-upcoming-grp', type: 'other', dueAt: tomorrow() });
+		await expect(activeSection(asMember).getByText('e2e-overdue-grp')).toBeVisible({
+			timeout: 8_000
+		});
+		await expect(activeSection(asMember).getByText('e2e-upcoming-grp')).toBeVisible({
+			timeout: 8_000
+		});
 	});
 });


### PR DESCRIPTION
Draft. Stacked on #118 (SP3a) — base branch is `redesign-sp3a-journal`, not `main`. Review/merge after SP1, SP2, SP3a. Second group of SP3 (owner inner-page redesigns).

## What's in it

**Health — featured weight trend.** A new TDD'd `weightChart.ts` (range filtering, area/line paths, percent-change, lbs/kg conversion) backs a `WeightChart.svelte`: a soft area-line chart with the latest weight, percent change, and a 6 months / 1 year / All range toggle. Mixed-unit entries are normalized to the latest unit so the trend never lies. Empty and single-entry states are handled.

**Health — page layout.** Featured chart on top, then a health-events timeline (type icon, badge, vet/clinic, notes, attribution) and a clean weight log. The two legacy `bark` badge tokens were removed.

**Health — document previews.** Documents attached to a health event now appear in the event's detail modal and open a full preview, reusing the dashboard's `DocumentPreview` component.

**Reminders — urgency grouping.** A TDD'd `reminderBuckets.ts` splits active reminders into Overdue (coral), Today (gold), and Upcoming, rendered through a single snippet to keep the card markup shared. Completed reminders stay in a collapsible section. The log-event action still appears only on health-type reminders.

**Accessibility.** Both detail dialogs gained `aria-labelledby`; the chart's range buttons carry `aria-pressed` and the SVG has a role and label with a per-instance gradient id.

## Out of scope
Documents and the companion profile/edit pages (SP3c) follow as their own cycle. No server logic, schema, or API changed (the health load gained one column, `mimeType`, for the document preview).

## Tests
`npm run lint`, `npm run check`, and 192 unit tests pass. `health.spec.ts` and `reminders.spec.ts` were extended (weight-trend section, urgency placement, document-preview end to end) with all existing add/edit/delete/complete/undo/recurrence assertions still green.