### PR TITLE
Redesign SP3c: Documents + Companion profile/edit

### DIFF
--- a/src/lib/components/MarkdownTextarea.svelte
+++ b/src/lib/components/MarkdownTextarea.svelte
@@ -29,6 +29,9 @@
 
 	const fieldClass =
 		'flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
+	// The preview renders block-level prose (paragraphs, <br>); `flex` would lay
+	// those out as flex items (paragraphs pushed side by side / right-aligned).
+	const previewClass = fieldClass.replace('flex ', 'block ');
 </script>
 
 <div class="space-y-1">
@@ -69,7 +72,7 @@
 
 	{#if mode === 'preview'}
 		<div
-			class="{fieldClass} prose prose-sm dark:prose-invert max-w-none"
+			class="{previewClass} prose prose-sm dark:prose-invert max-w-none"
 			style="min-height: {rows * 1.5}rem"
 		>
 			{#if value}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -454,6 +454,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Archivieren',
 	'page.companion.edit.labelArchiveDate': 'Datum',
 	'page.companion.edit.labelArchiveNote': 'Notiz',
+	'page.companion.edit.tabsAria': 'Bearbeitungsbereiche',
+	'page.companion.edit.sectionBasics': 'Grunddaten',
+	'page.companion.edit.sectionAbout': 'Über',
 
 	// Page: overview (multi-companion landing)
 	'overview.title': 'Übersicht',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -406,10 +406,8 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: companion new
 	'page.companion.new.pageTitle': 'Begleiter hinzufügen | EinVault',
-	'page.companion.new.backToSettings': 'Zurück zu Einstellungen',
 	'page.companion.new.heading': 'Begleiter hinzufügen',
 	'page.companion.new.subheading': 'Fülle aus, was du weißt. Du kannst später immer noch ändern.',
-	'page.companion.new.cardTitle': 'Begleiterdetails',
 	'page.companion.new.submit': 'Begleiter hinzufügen',
 
 	// Page: companion edit

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -447,6 +447,9 @@ const messages = {
 	'page.companion.edit.archive': 'Archive',
 	'page.companion.edit.labelArchiveDate': 'Date',
 	'page.companion.edit.labelArchiveNote': 'Note',
+	'page.companion.edit.tabsAria': 'Edit sections',
+	'page.companion.edit.sectionBasics': 'Basics',
+	'page.companion.edit.sectionAbout': 'About',
 
 	// Page: overview (multi-companion landing)
 	'overview.title': 'Overview',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -399,10 +399,8 @@ const messages = {
 
 	// Page: companion new
 	'page.companion.new.pageTitle': 'Add companion | EinVault',
-	'page.companion.new.backToSettings': 'Back to Settings',
 	'page.companion.new.heading': 'Add a companion',
 	'page.companion.new.subheading': 'Fill in what you know. You can always edit later.',
-	'page.companion.new.cardTitle': 'Companion Details',
 	'page.companion.new.submit': 'Add Companion',
 
 	// Page: companion edit

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -406,10 +406,8 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: companion new
 	'page.companion.new.pageTitle': 'Añadir compañero | EinVault',
-	'page.companion.new.backToSettings': 'Volver a Ajustes',
 	'page.companion.new.heading': 'Añadir un compañero',
 	'page.companion.new.subheading': 'Completa lo que sepas. Siempre puedes editarlo después.',
-	'page.companion.new.cardTitle': 'Detalles del compañero',
 	'page.companion.new.submit': 'Añadir compañero',
 
 	// Page: companion edit

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -454,6 +454,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Archivar',
 	'page.companion.edit.labelArchiveDate': 'Fecha',
 	'page.companion.edit.labelArchiveNote': 'Nota',
+	'page.companion.edit.tabsAria': 'Secciones de edición',
+	'page.companion.edit.sectionBasics': 'Básicos',
+	'page.companion.edit.sectionAbout': 'Acerca de',
 
 	// Page: overview (multi-companion landing)
 	'overview.title': 'Resumen',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -454,6 +454,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Archiver',
 	'page.companion.edit.labelArchiveDate': 'Date',
 	'page.companion.edit.labelArchiveNote': 'Note',
+	'page.companion.edit.tabsAria': "Sections d'édition",
+	'page.companion.edit.sectionBasics': 'Bases',
+	'page.companion.edit.sectionAbout': 'À propos',
 
 	// Page: overview (multi-companion landing)
 	'overview.title': 'Aperçu',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -405,11 +405,9 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: companion new
 	'page.companion.new.pageTitle': 'Ajouter un compagnon | EinVault',
-	'page.companion.new.backToSettings': 'Retour aux paramètres',
 	'page.companion.new.heading': 'Ajouter un compagnon',
 	'page.companion.new.subheading':
 		'Remplissez ce que vous savez. Vous pourrez toujours modifier plus tard.',
-	'page.companion.new.cardTitle': 'Détails du compagnon',
 	'page.companion.new.submit': 'Ajouter le compagnon',
 
 	// Page: companion edit

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -402,10 +402,8 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: companion new
 	'page.companion.new.pageTitle': 'Aggiungi compagno | EinVault',
-	'page.companion.new.backToSettings': 'Torna alle impostazioni',
 	'page.companion.new.heading': 'Aggiungi un compagno',
 	'page.companion.new.subheading': 'Compila quello che sai. Puoi sempre modificare dopo.',
-	'page.companion.new.cardTitle': 'Dettagli compagno',
 	'page.companion.new.submit': 'Aggiungi compagno',
 
 	// Page: companion edit

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -450,6 +450,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Archivia',
 	'page.companion.edit.labelArchiveDate': 'Data',
 	'page.companion.edit.labelArchiveNote': 'Nota',
+	'page.companion.edit.tabsAria': 'Sezioni di modifica',
+	'page.companion.edit.sectionBasics': 'Base',
+	'page.companion.edit.sectionAbout': 'Informazioni',
 
 	// Page: overview (multi-companion landing)
 	'overview.title': 'Panoramica',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -451,6 +451,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.archive': 'Arquivar',
 	'page.companion.edit.labelArchiveDate': 'Data',
 	'page.companion.edit.labelArchiveNote': 'Nota',
+	'page.companion.edit.tabsAria': 'Secções de edição',
+	'page.companion.edit.sectionBasics': 'Básico',
+	'page.companion.edit.sectionAbout': 'Sobre',
 
 	// Page: overview (multi-companion landing)
 	'overview.title': 'Resumo',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -403,10 +403,8 @@ const messages: Record<keyof Messages, string> = {
 
 	// Page: companion new
 	'page.companion.new.pageTitle': 'Adicionar companheiro | EinVault',
-	'page.companion.new.backToSettings': 'Voltar às definições',
 	'page.companion.new.heading': 'Adicionar um companheiro',
 	'page.companion.new.subheading': 'Preencha o que souber. Pode sempre editar depois.',
-	'page.companion.new.cardTitle': 'Detalhes do companheiro',
 	'page.companion.new.submit': 'Adicionar companheiro',
 
 	// Page: companion edit

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -9,6 +9,13 @@ describe('renderMarkdown', () => {
 		expect(html).toContain('<code>code</code>');
 	});
 
+	it('turns a single newline into a line break', () => {
+		const html = renderMarkdown('line one\nline two');
+		expect(html).toContain('<br');
+		expect(html).toContain('line one');
+		expect(html).toContain('line two');
+	});
+
 	it('strips raw HTML blocks entirely', () => {
 		const html = renderMarkdown('before\n\n<script>alert(1)</script>\n\nafter');
 		expect(html).not.toContain('<script');

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -39,7 +39,9 @@ export function stripMarkdown(text: string): string {
 }
 
 export function renderMarkdown(text: string): string {
-	const raw = marked.parse(text, { async: false }) as string;
+	// `breaks: true` turns single newlines into <br> so users' line breaks in
+	// journal/notes show up as written (CommonMark would otherwise collapse them).
+	const raw = marked.parse(text, { async: false, gfm: true, breaks: true }) as string;
 	return DOMPurify.sanitize(raw, {
 		ALLOWED_TAGS,
 		ALLOWED_ATTR: ['href', 'rel'],

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
@@ -5,7 +5,6 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import { Card, CardContent } from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
@@ -197,155 +196,167 @@
 		</Alert>
 	{/if}
 
-	<Card>
-		<CardContent class="space-y-3 pt-6">
-			{#if data.companion.isActive !== false}
-				<p class="text-xs text-muted-foreground">
-					{t(locale, 'page.documents.dropHint', { max: data.uploadMaxMb })}
-				</p>
-			{/if}
+	<div class="space-y-3">
+		{#if data.companion.isActive !== false}
+			<p class="text-xs text-muted-foreground">
+				{t(locale, 'page.documents.dropHint', { max: data.uploadMaxMb })}
+			</p>
+		{/if}
 
-			<select
-				class="h-9 rounded-md border border-input bg-background px-3 text-sm"
-				bind:value={filter}
-				aria-label={t(locale, 'page.documents.filterAll')}
+		<div
+			class="flex flex-wrap gap-2"
+			role="group"
+			aria-label={t(locale, 'page.documents.filterAll')}
+		>
+			<button
+				type="button"
+				onclick={() => (filter = 'all')}
+				aria-pressed={filter === 'all'}
+				class="rounded-full border px-3 py-1 text-xs transition-colors {filter === 'all'
+					? 'border-primary/40 bg-primary/10 text-primary font-medium'
+					: 'border-border bg-card text-muted-foreground hover:bg-accent'}"
 			>
-				<option value="all">{t(locale, 'page.documents.filterAll')}</option>
-				{#each CATEGORIES as c (c)}
-					<option value={c}>{categoryLabel(c)}</option>
-				{/each}
-			</select>
+				{t(locale, 'page.documents.filterAll')}
+			</button>
+			{#each CATEGORIES as c (c)}
+				<button
+					type="button"
+					onclick={() => (filter = c)}
+					aria-pressed={filter === c}
+					class="rounded-full border px-3 py-1 text-xs transition-colors {filter === c
+						? 'border-primary/40 bg-primary/10 text-primary font-medium'
+						: 'border-border bg-card text-muted-foreground hover:bg-accent'}"
+				>
+					{categoryLabel(c)}
+				</button>
+			{/each}
+		</div>
 
-			{#if filtered.length === 0}
-				<p class="text-sm text-muted-foreground py-8 text-center">
-					{t(locale, 'page.documents.empty')}
-				</p>
-			{:else}
-				<ul class="divide-y divide-border">
-					{#each filtered as doc (doc.id)}
-						<li class="py-3">
-							{#if editingId === doc.id}
-								<div class="space-y-2">
+		{#if filtered.length === 0}
+			<p class="text-sm text-muted-foreground py-8 text-center">
+				{t(locale, 'page.documents.empty')}
+			</p>
+		{:else}
+			<ul class="divide-y divide-border">
+				{#each filtered as doc (doc.id)}
+					<li class="py-3">
+						{#if editingId === doc.id}
+							<div class="space-y-2">
+								<div>
+									<Label for="doc-title-{doc.id}">{t(locale, 'page.documents.labelTitle')}</Label>
+									<Input
+										id="doc-title-{doc.id}"
+										value={editTitle}
+										oninput={(e) => (editTitle = e.currentTarget.value)}
+										maxlength={255}
+									/>
+								</div>
+								<div class="flex gap-2">
 									<div>
-										<Label for="doc-title-{doc.id}">{t(locale, 'page.documents.labelTitle')}</Label>
-										<Input
-											id="doc-title-{doc.id}"
-											value={editTitle}
-											oninput={(e) => (editTitle = e.currentTarget.value)}
-											maxlength={255}
-										/>
-									</div>
-									<div class="flex gap-2">
-										<div>
-											<Label for="doc-cat-{doc.id}"
-												>{t(locale, 'page.documents.labelCategory')}</Label
-											>
-											<select
-												id="doc-cat-{doc.id}"
-												class="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-												bind:value={editCategory}
-											>
-												{#each CATEGORIES as c (c)}
-													<option value={c}>{categoryLabel(c)}</option>
-												{/each}
-											</select>
-										</div>
-										<div>
-											<Label for="doc-date-{doc.id}">{t(locale, 'page.documents.labelDate')}</Label>
-											<Input
-												id="doc-date-{doc.id}"
-												type="date"
-												value={editDate}
-												oninput={(e) => (editDate = e.currentTarget.value)}
-											/>
-										</div>
-									</div>
-									<div>
-										<Label for="doc-event-{doc.id}">{t(locale, 'page.documents.linkedEvent')}</Label
+										<Label for="doc-cat-{doc.id}">{t(locale, 'page.documents.labelCategory')}</Label
 										>
 										<select
-											id="doc-event-{doc.id}"
+											id="doc-cat-{doc.id}"
 											class="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
-											bind:value={editHealthEventId}
+											bind:value={editCategory}
 										>
-											<option value="">{t(locale, 'page.documents.noLinkedEvent')}</option>
-											{#each data.healthEvents as event (event.id)}
-												<option value={event.id}>{healthEventLabel(event)}</option>
+											{#each CATEGORIES as c (c)}
+												<option value={c}>{categoryLabel(c)}</option>
 											{/each}
 										</select>
 									</div>
-									{#if saveError}
-										<p class="text-sm text-red-600 dark:text-red-400">{saveError}</p>
-									{/if}
-									<div class="flex gap-2">
-										<Button size="sm" onclick={saveEdit}>{t(locale, 'page.documents.save')}</Button>
-										<Button variant="outline" size="sm" onclick={() => (editingId = null)}>
-											{t(locale, 'common.cancel')}
-										</Button>
+									<div>
+										<Label for="doc-date-{doc.id}">{t(locale, 'page.documents.labelDate')}</Label>
+										<Input
+											id="doc-date-{doc.id}"
+											type="date"
+											value={editDate}
+											oninput={(e) => (editDate = e.currentTarget.value)}
+										/>
 									</div>
 								</div>
-							{:else}
-								<div class="flex items-center gap-3">
-									<button
-										type="button"
-										class="flex items-center gap-3 flex-1 min-w-0 text-left rounded-md px-2 py-1 -mx-2 hover:bg-accent transition-colors"
-										onclick={() => (preview = doc)}
-										aria-label={t(locale, 'page.documents.view')}
+								<div>
+									<Label for="doc-event-{doc.id}">{t(locale, 'page.documents.linkedEvent')}</Label>
+									<select
+										id="doc-event-{doc.id}"
+										class="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+										bind:value={editHealthEventId}
 									>
-										<FileText class="h-5 w-5 shrink-0 text-muted-foreground" />
-										<div class="min-w-0">
-											<p class="text-sm font-medium text-foreground truncate">{doc.title}</p>
-											<p
-												class="text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap mt-0.5"
-											>
-												<Badge variant="secondary">{categoryLabel(doc.category)}</Badge>
-												{#if doc.provider === 'paperless'}
-													<Badge variant="outline"
-														>{t(locale, 'page.documents.fromPaperless')}</Badge
-													>
-												{/if}
-												{#if doc.documentDate}<span>{doc.documentDate}</span>{/if}
-												{#if doc.sizeBytes}<span>{formatSize(doc.sizeBytes)}</span>{/if}
-												{#if doc.healthEvent}<span>· {doc.healthEvent.title}</span>{/if}
-											</p>
-										</div>
-									</button>
-									<div class="flex items-center gap-1 shrink-0">
-										<Button
-											href={`${docUrl(doc)}?download`}
-											variant="soft"
-											size="icon-sm"
-											aria-label={t(locale, 'page.documents.download')}
-										>
-											<Download class="h-4 w-4" />
-										</Button>
-										<Button
-											type="button"
-											variant="soft"
-											size="icon-sm"
-											aria-label={t(locale, 'page.documents.editTitle')}
-											onclick={() => startEdit(doc)}
-										>
-											<Pencil class="h-4 w-4" />
-										</Button>
-										<Button
-											type="button"
-											variant="softDestructive"
-											size="icon-sm"
-											aria-label={t(locale, 'page.documents.delete')}
-											onclick={() => (deleteTarget = doc)}
-										>
-											<Trash2 class="h-4 w-4" />
-										</Button>
-									</div>
+										<option value="">{t(locale, 'page.documents.noLinkedEvent')}</option>
+										{#each data.healthEvents as event (event.id)}
+											<option value={event.id}>{healthEventLabel(event)}</option>
+										{/each}
+									</select>
 								</div>
-							{/if}
-						</li>
-					{/each}
-				</ul>
-			{/if}
-		</CardContent>
-	</Card>
+								{#if saveError}
+									<p class="text-sm text-red-600 dark:text-red-400">{saveError}</p>
+								{/if}
+								<div class="flex gap-2">
+									<Button size="sm" onclick={saveEdit}>{t(locale, 'page.documents.save')}</Button>
+									<Button variant="outline" size="sm" onclick={() => (editingId = null)}>
+										{t(locale, 'common.cancel')}
+									</Button>
+								</div>
+							</div>
+						{:else}
+							<div class="flex items-center gap-3">
+								<button
+									type="button"
+									class="flex items-center gap-3 flex-1 min-w-0 text-left rounded-md px-2 py-1 -mx-2 hover:bg-accent transition-colors"
+									onclick={() => (preview = doc)}
+									aria-label={t(locale, 'page.documents.view')}
+								>
+									<FileText class="h-5 w-5 shrink-0 text-muted-foreground" />
+									<div class="min-w-0">
+										<p class="text-sm font-medium text-foreground truncate">{doc.title}</p>
+										<p
+											class="text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap mt-0.5"
+										>
+											<Badge variant="secondary">{categoryLabel(doc.category)}</Badge>
+											{#if doc.provider === 'paperless'}
+												<Badge variant="outline">{t(locale, 'page.documents.fromPaperless')}</Badge>
+											{/if}
+											{#if doc.documentDate}<span>{doc.documentDate}</span>{/if}
+											{#if doc.sizeBytes}<span>{formatSize(doc.sizeBytes)}</span>{/if}
+											{#if doc.healthEvent}<span>· {doc.healthEvent.title}</span>{/if}
+										</p>
+									</div>
+								</button>
+								<div class="flex items-center gap-1 shrink-0">
+									<Button
+										href={`${docUrl(doc)}?download`}
+										variant="soft"
+										size="icon-sm"
+										aria-label={t(locale, 'page.documents.download')}
+									>
+										<Download class="h-4 w-4" />
+									</Button>
+									<Button
+										type="button"
+										variant="soft"
+										size="icon-sm"
+										aria-label={t(locale, 'page.documents.editTitle')}
+										onclick={() => startEdit(doc)}
+									>
+										<Pencil class="h-4 w-4" />
+									</Button>
+									<Button
+										type="button"
+										variant="softDestructive"
+										size="icon-sm"
+										aria-label={t(locale, 'page.documents.delete')}
+										onclick={() => (deleteTarget = doc)}
+									>
+										<Trash2 class="h-4 w-4" />
+									</Button>
+								</div>
+							</div>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
 </div>
 
 {#if data.paperlessEnabled}

--- a/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/documents/+page.svelte
@@ -289,7 +289,7 @@
 									</select>
 								</div>
 								{#if saveError}
-									<p class="text-sm text-red-600 dark:text-red-400">{saveError}</p>
+									<p class="text-sm text-destructive">{saveError}</p>
 								{/if}
 								<div class="flex gap-2">
 									<Button size="sm" onclick={saveEdit}>{t(locale, 'page.documents.save')}</Button>

--- a/src/routes/(app)/companions/[id]/edit/+page.svelte
+++ b/src/routes/(app)/companions/[id]/edit/+page.svelte
@@ -6,7 +6,6 @@
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import ImmichPicker from '$lib/components/ImmichPicker.svelte';
 	import { bustAvatarCache } from '$lib/avatarCache.svelte';
-	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -95,24 +94,32 @@
 		</Alert>
 	{/if}
 
-	<!-- Tab switcher -->
-	<div class="flex gap-1 rounded-xl border border-border bg-muted p-1">
-		<Button
+	<!-- Segmented tab control -->
+	<div class="inline-flex w-full rounded-lg border border-border bg-muted p-0.5">
+		<button
 			type="button"
 			onclick={() => (activeTab = 'profile')}
-			variant={activeTab === 'profile' ? 'default' : 'ghost'}
-			class="flex-1 rounded-lg"
+			class={[
+				'flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-all',
+				activeTab === 'profile'
+					? 'bg-background text-foreground shadow-sm'
+					: 'text-muted-foreground hover:text-foreground'
+			].join(' ')}
 		>
 			{t(locale, 'page.companion.edit.tabProfile')}
-		</Button>
-		<Button
+		</button>
+		<button
 			type="button"
 			onclick={() => (activeTab = 'caretaker')}
-			variant={activeTab === 'caretaker' ? 'default' : 'ghost'}
-			class="flex-1 rounded-lg"
+			class={[
+				'flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-all',
+				activeTab === 'caretaker'
+					? 'bg-background text-foreground shadow-sm'
+					: 'text-muted-foreground hover:text-foreground'
+			].join(' ')}
 		>
 			{t(locale, 'page.companion.edit.tabCaretaker')}
-		</Button>
+		</button>
 	</div>
 
 	<form
@@ -128,244 +135,245 @@
 		}}
 	>
 		<!-- Profile tab: always in DOM, hidden when not active -->
-		<div class:hidden={activeTab !== 'profile'}>
-			<Card class="animate-fade-in">
-				<CardHeader>
-					<CardTitle>{t(locale, 'page.companion.edit.cardProfile')}</CardTitle>
-				</CardHeader>
-				<CardContent class="space-y-5">
-					<!-- Profile photo -->
-					<div class="flex flex-col items-center gap-2 pb-2">
-						<CompanionAvatar
-							companionId={companion.id}
-							avatarPath={companion.avatarPath}
-							name={companion.name}
-							size="xl"
-							editable
-							immichEnabled={data.immichEnabled}
-							onpickImmich={() => (immichAvatarPickerOpen = true)}
-						/>
-						<p class="text-xs text-muted-foreground">
-							{t(locale, 'page.companion.edit.profilePhoto')}
-						</p>
-					</div>
+		<div class:hidden={activeTab !== 'profile'} class="space-y-6 animate-fade-in">
+			<!-- Avatar hero -->
+			<div class="flex flex-col items-center gap-3 py-4">
+				<CompanionAvatar
+					companionId={companion.id}
+					avatarPath={companion.avatarPath}
+					name={companion.name}
+					size="xl"
+					editable
+					immichEnabled={data.immichEnabled}
+					onpickImmich={() => (immichAvatarPickerOpen = true)}
+				/>
+				<p class="text-xs text-muted-foreground">
+					{t(locale, 'page.companion.edit.profilePhoto')}
+				</p>
+			</div>
 
-					<Separator />
+			<!-- BASICS section -->
+			<section class="space-y-4">
+				<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+					Basics
+				</p>
 
+				<div class="space-y-1.5">
+					<Label for="name"
+						>{t(locale, 'page.companion.labelName')}
+						<span class="text-destructive">*</span></Label
+					>
+					<Input
+						id="name"
+						name="name"
+						type="text"
+						autocomplete="off"
+						value={companion.name}
+						required
+					/>
+				</div>
+
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 					<div class="space-y-1.5">
-						<Label for="name"
-							>{t(locale, 'page.companion.labelName')}
-							<span class="text-destructive">*</span></Label
-						>
+						<Label for="breed">{t(locale, 'page.companion.labelBreed')}</Label>
 						<Input
-							id="name"
-							name="name"
+							id="breed"
+							name="breed"
 							type="text"
 							autocomplete="off"
-							value={companion.name}
-							required
+							value={companion.breed ?? ''}
 						/>
 					</div>
-
-					<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-						<div class="space-y-1.5">
-							<Label for="breed">{t(locale, 'page.companion.labelBreed')}</Label>
-							<Input
-								id="breed"
-								name="breed"
-								type="text"
-								autocomplete="off"
-								value={companion.breed ?? ''}
-							/>
-						</div>
-						<div class="space-y-1.5">
-							<Label for="sex">{t(locale, 'page.companion.labelSex')}</Label>
-							<Select id="sex" name="sex">
-								<option value="">{t(locale, 'page.companion.sexUnknown')}</option>
-								<option value="male" selected={companion.sex === 'male'}
-									>{t(locale, 'enum.sex.male')}</option
-								>
-								<option value="female" selected={companion.sex === 'female'}
-									>{t(locale, 'enum.sex.female')}</option
-								>
-							</Select>
-						</div>
-					</div>
-
-					<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-						<div class="space-y-1.5">
-							<Label for="dob">{t(locale, 'page.companion.labelDob')}</Label>
-							<Input
-								id="dob"
-								name="dob"
-								type="date"
-								autocomplete="off"
-								value={companion.dob ?? ''}
-							/>
-						</div>
-						<div class="space-y-1.5">
-							<Label for="weightUnit">{t(locale, 'page.companion.labelWeightUnit')}</Label>
-							<Select id="weightUnit" name="weightUnit">
-								<option value="lbs" selected={companion.weightUnit === 'lbs'}>lbs</option>
-								<option value="kg" selected={companion.weightUnit === 'kg'}>kg</option>
-							</Select>
-						</div>
-					</div>
-
 					<div class="space-y-1.5">
-						<Label for="microchip">{t(locale, 'page.companion.labelMicrochip')}</Label>
-						<Input
-							id="microchip"
-							name="microchip"
-							type="text"
-							autocomplete="off"
-							value={companion.microchip ?? ''}
-							placeholder={t(locale, 'page.companion.edit.placeholderMicrochip')}
-						/>
+						<Label for="sex">{t(locale, 'page.companion.labelSex')}</Label>
+						<Select id="sex" name="sex">
+							<option value="">{t(locale, 'page.companion.sexUnknown')}</option>
+							<option value="male" selected={companion.sex === 'male'}
+								>{t(locale, 'enum.sex.male')}</option
+							>
+							<option value="female" selected={companion.sex === 'female'}
+								>{t(locale, 'enum.sex.female')}</option
+							>
+						</Select>
 					</div>
+				</div>
 
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 					<div class="space-y-1.5">
-						<Label for="bio">{t(locale, 'page.companion.labelBio')}</Label>
-						<MarkdownTextarea
-							id="bio"
-							name="bio"
-							value={companion.bio ?? ''}
-							placeholder={t(locale, 'page.companion.placeholderBio')}
-							rows={4}
-						/>
+						<Label for="dob">{t(locale, 'page.companion.labelDob')}</Label>
+						<Input id="dob" name="dob" type="date" autocomplete="off" value={companion.dob ?? ''} />
 					</div>
-				</CardContent>
-			</Card>
+					<div class="space-y-1.5">
+						<Label for="weightUnit">{t(locale, 'page.companion.labelWeightUnit')}</Label>
+						<Select id="weightUnit" name="weightUnit">
+							<option value="lbs" selected={companion.weightUnit === 'lbs'}>lbs</option>
+							<option value="kg" selected={companion.weightUnit === 'kg'}>kg</option>
+						</Select>
+					</div>
+				</div>
+
+				<div class="space-y-1.5">
+					<Label for="microchip">{t(locale, 'page.companion.labelMicrochip')}</Label>
+					<Input
+						id="microchip"
+						name="microchip"
+						type="text"
+						autocomplete="off"
+						value={companion.microchip ?? ''}
+						placeholder={t(locale, 'page.companion.edit.placeholderMicrochip')}
+					/>
+				</div>
+			</section>
+
+			<Separator />
+
+			<!-- ABOUT section -->
+			<section class="space-y-4">
+				<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+					About
+				</p>
+				<div class="space-y-1.5">
+					<Label for="bio">{t(locale, 'page.companion.labelBio')}</Label>
+					<MarkdownTextarea
+						id="bio"
+						name="bio"
+						value={companion.bio ?? ''}
+						placeholder={t(locale, 'page.companion.placeholderBio')}
+						rows={4}
+					/>
+				</div>
+			</section>
 		</div>
 
 		<!-- Caretaker tab: always in DOM, hidden when not active -->
-		<div class:hidden={activeTab !== 'caretaker'} class="space-y-4 animate-fade-in">
-			<Card>
-				<CardHeader>
-					<CardTitle>{t(locale, 'page.companion.edit.cardSchedules')}</CardTitle>
-					<p class="text-xs text-muted-foreground mt-1">
+		<div class:hidden={activeTab !== 'caretaker'} class="space-y-6 animate-fade-in">
+			<!-- SCHEDULES section -->
+			<section class="space-y-4">
+				<div>
+					<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+						{t(locale, 'page.companion.edit.cardSchedules')}
+					</p>
+					<p class="text-xs text-muted-foreground mt-0.5">
 						{t(locale, 'page.companion.edit.schedulesHint')}
 					</p>
-				</CardHeader>
-				<CardContent class="space-y-4">
-					<div class="space-y-1.5">
-						<Label for="feedingSchedule"
-							>{t(locale, 'page.companion.edit.labelFeedingSchedule')}</Label
-						>
-						<MarkdownTextarea
-							id="feedingSchedule"
-							name="feedingSchedule"
-							value={companion.feedingSchedule ?? ''}
-							placeholder={t(locale, 'page.companion.edit.placeholderFeedingSchedule')}
-							rows={4}
-						/>
-					</div>
-					<div class="space-y-1.5">
-						<Label for="walkSchedule">{t(locale, 'page.companion.edit.labelWalkSchedule')}</Label>
-						<MarkdownTextarea
-							id="walkSchedule"
-							name="walkSchedule"
-							value={companion.walkSchedule ?? ''}
-							placeholder={t(locale, 'page.companion.edit.placeholderWalkSchedule')}
-							rows={4}
-						/>
-					</div>
-				</CardContent>
-			</Card>
+				</div>
+				<div class="space-y-1.5">
+					<Label for="feedingSchedule"
+						>{t(locale, 'page.companion.edit.labelFeedingSchedule')}</Label
+					>
+					<MarkdownTextarea
+						id="feedingSchedule"
+						name="feedingSchedule"
+						value={companion.feedingSchedule ?? ''}
+						placeholder={t(locale, 'page.companion.edit.placeholderFeedingSchedule')}
+						rows={4}
+					/>
+				</div>
+				<div class="space-y-1.5">
+					<Label for="walkSchedule">{t(locale, 'page.companion.edit.labelWalkSchedule')}</Label>
+					<MarkdownTextarea
+						id="walkSchedule"
+						name="walkSchedule"
+						value={companion.walkSchedule ?? ''}
+						placeholder={t(locale, 'page.companion.edit.placeholderWalkSchedule')}
+						rows={4}
+					/>
+				</div>
+			</section>
 
-			<Card>
-				<CardHeader>
-					<CardTitle>{t(locale, 'page.companion.edit.cardContacts')}</CardTitle>
-				</CardHeader>
-				<CardContent class="space-y-4">
-					<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-						<div class="space-y-1.5">
-							<Label for="vetName">{t(locale, 'page.companion.edit.labelVetName')}</Label>
-							<Input
-								id="vetName"
-								name="vetName"
-								type="text"
-								autocomplete="off"
-								value={companion.vetName ?? ''}
-								placeholder={t(locale, 'page.companion.edit.placeholderVetName')}
-							/>
-						</div>
-						<div class="space-y-1.5">
-							<Label for="vetPhone">{t(locale, 'page.companion.edit.labelVetPhone')}</Label>
-							<Input
-								id="vetPhone"
-								name="vetPhone"
-								type="tel"
-								autocomplete="off"
-								value={companion.vetPhone ?? ''}
-								placeholder={t(locale, 'common.placeholderPhone')}
-							/>
-						</div>
-					</div>
+			<Separator />
+
+			<!-- CONTACTS section -->
+			<section class="space-y-4">
+				<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+					{t(locale, 'page.companion.edit.cardContacts')}
+				</p>
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 					<div class="space-y-1.5">
-						<Label for="vetClinic">{t(locale, 'page.companion.edit.labelVetClinic')}</Label>
+						<Label for="vetName">{t(locale, 'page.companion.edit.labelVetName')}</Label>
 						<Input
-							id="vetClinic"
-							name="vetClinic"
+							id="vetName"
+							name="vetName"
 							type="text"
 							autocomplete="off"
-							value={companion.vetClinic ?? ''}
-							placeholder={t(locale, 'page.companion.edit.placeholderVetClinic')}
+							value={companion.vetName ?? ''}
+							placeholder={t(locale, 'page.companion.edit.placeholderVetName')}
 						/>
 					</div>
-
-					<Separator />
-
-					<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-						<div class="space-y-1.5">
-							<Label for="emergencyContactName"
-								>{t(locale, 'page.companion.edit.labelEmergencyContact')}</Label
-							>
-							<Input
-								id="emergencyContactName"
-								name="emergencyContactName"
-								type="text"
-								autocomplete="off"
-								value={companion.emergencyContactName ?? ''}
-								placeholder={t(locale, 'page.companion.edit.placeholderEmergencyContact')}
-							/>
-						</div>
-						<div class="space-y-1.5">
-							<Label for="emergencyContactPhone"
-								>{t(locale, 'page.companion.edit.labelEmergencyPhone')}</Label
-							>
-							<Input
-								id="emergencyContactPhone"
-								name="emergencyContactPhone"
-								type="tel"
-								autocomplete="off"
-								value={companion.emergencyContactPhone ?? ''}
-								placeholder={t(locale, 'common.placeholderPhone')}
-							/>
-						</div>
-					</div>
-				</CardContent>
-			</Card>
-
-			<Card>
-				<CardHeader>
-					<CardTitle>{t(locale, 'page.companion.edit.cardSitterNotes')}</CardTitle>
-				</CardHeader>
-				<CardContent class="space-y-4">
 					<div class="space-y-1.5">
-						<Label for="notesForSitter"
-							>{t(locale, 'page.companion.edit.labelNotesForSitter')}</Label
-						>
-						<MarkdownTextarea
-							id="notesForSitter"
-							name="notesForSitter"
-							value={companion.notesForSitter ?? ''}
-							placeholder={t(locale, 'page.companion.edit.placeholderSitterNotes')}
-							rows={5}
+						<Label for="vetPhone">{t(locale, 'page.companion.edit.labelVetPhone')}</Label>
+						<Input
+							id="vetPhone"
+							name="vetPhone"
+							type="tel"
+							autocomplete="off"
+							value={companion.vetPhone ?? ''}
+							placeholder={t(locale, 'common.placeholderPhone')}
 						/>
 					</div>
-				</CardContent>
-			</Card>
+				</div>
+				<div class="space-y-1.5">
+					<Label for="vetClinic">{t(locale, 'page.companion.edit.labelVetClinic')}</Label>
+					<Input
+						id="vetClinic"
+						name="vetClinic"
+						type="text"
+						autocomplete="off"
+						value={companion.vetClinic ?? ''}
+						placeholder={t(locale, 'page.companion.edit.placeholderVetClinic')}
+					/>
+				</div>
+
+				<Separator />
+
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+					<div class="space-y-1.5">
+						<Label for="emergencyContactName"
+							>{t(locale, 'page.companion.edit.labelEmergencyContact')}</Label
+						>
+						<Input
+							id="emergencyContactName"
+							name="emergencyContactName"
+							type="text"
+							autocomplete="off"
+							value={companion.emergencyContactName ?? ''}
+							placeholder={t(locale, 'page.companion.edit.placeholderEmergencyContact')}
+						/>
+					</div>
+					<div class="space-y-1.5">
+						<Label for="emergencyContactPhone"
+							>{t(locale, 'page.companion.edit.labelEmergencyPhone')}</Label
+						>
+						<Input
+							id="emergencyContactPhone"
+							name="emergencyContactPhone"
+							type="tel"
+							autocomplete="off"
+							value={companion.emergencyContactPhone ?? ''}
+							placeholder={t(locale, 'common.placeholderPhone')}
+						/>
+					</div>
+				</div>
+			</section>
+
+			<Separator />
+
+			<!-- SITTER NOTES section -->
+			<section class="space-y-4">
+				<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+					{t(locale, 'page.companion.edit.cardSitterNotes')}
+				</p>
+				<div class="space-y-1.5">
+					<Label for="notesForSitter">{t(locale, 'page.companion.edit.labelNotesForSitter')}</Label>
+					<MarkdownTextarea
+						id="notesForSitter"
+						name="notesForSitter"
+						value={companion.notesForSitter ?? ''}
+						placeholder={t(locale, 'page.companion.edit.placeholderSitterNotes')}
+						rows={5}
+					/>
+				</div>
+			</section>
 		</div>
 
 		<!-- Actions: always visible -->
@@ -396,72 +404,70 @@
 		</div>
 	{/if}
 
-	<!-- Archive companion: admin only -->
+	<!-- Archive companion: admin only — outside tab content, always visible -->
 	{#if data.user?.role === 'admin'}
-		<Card>
-			<CardHeader>
-				<CardTitle>{t(locale, 'page.companion.edit.cardArchive')}</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<p class="text-sm text-muted-foreground mb-4">
-					{t(locale, 'page.companion.edit.archiveDescription', { name: companion.name })}
-				</p>
-				<Button
-					variant="outline"
-					onclick={() => (showArchivePanel = true)}
-					disabled={showArchivePanel}
-				>
-					{t(locale, 'page.companion.edit.archiveButton', { name: companion.name })}
-				</Button>
+		<div class="rounded-xl border border-coral/40 p-4 space-y-3">
+			<p class="text-[11px] font-semibold uppercase tracking-wider text-coral">
+				{t(locale, 'page.companion.edit.cardArchive')}
+			</p>
+			<p class="text-sm text-muted-foreground">
+				{t(locale, 'page.companion.edit.archiveDescription', { name: companion.name })}
+			</p>
+			<Button
+				variant="softDestructive"
+				onclick={() => (showArchivePanel = true)}
+				disabled={showArchivePanel}
+			>
+				{t(locale, 'page.companion.edit.archiveButton', { name: companion.name })}
+			</Button>
 
-				{#if showArchivePanel}
-					<div class="mt-4 space-y-4 border-t border-border pt-4 animate-slide-up">
-						<form
-							method="POST"
-							action="?/archive"
-							use:enhance={() => {
-								loading = true;
-								return async ({ update }) => {
-									loading = false;
-									await update({ reset: false });
-								};
-							}}
-							class="space-y-4"
-						>
-							<div class="space-y-1.5">
-								<Label for="archivedAt">{t(locale, 'page.companion.edit.labelArchiveDate')}</Label>
-								<Input
-									id="archivedAt"
-									name="archivedAt"
-									type="date"
-									autocomplete="off"
-									value={new Date().toISOString().slice(0, 10)}
-								/>
-							</div>
-							<div class="space-y-1.5">
-								<Label for="archiveNote">{t(locale, 'page.companion.edit.labelArchiveNote')}</Label>
-								<Input
-									id="archiveNote"
-									name="archiveNote"
-									type="text"
-									autocomplete="off"
-									placeholder={t(locale, 'page.companion.edit.placeholderArchiveNote')}
-								/>
-							</div>
-							<div class="flex gap-2">
-								<Button type="submit" variant="secondary" disabled={loading}>
-									{loading
-										? t(locale, 'page.companion.edit.archiving')
-										: t(locale, 'page.companion.edit.archive')}
-								</Button>
-								<Button type="button" variant="ghost" onclick={() => (showArchivePanel = false)}>
-									{t(locale, 'common.cancel')}
-								</Button>
-							</div>
-						</form>
-					</div>
-				{/if}
-			</CardContent>
-		</Card>
+			{#if showArchivePanel}
+				<div class="mt-2 space-y-4 border-t border-coral/20 pt-4 animate-slide-up">
+					<form
+						method="POST"
+						action="?/archive"
+						use:enhance={() => {
+							loading = true;
+							return async ({ update }) => {
+								loading = false;
+								await update({ reset: false });
+							};
+						}}
+						class="space-y-4"
+					>
+						<div class="space-y-1.5">
+							<Label for="archivedAt">{t(locale, 'page.companion.edit.labelArchiveDate')}</Label>
+							<Input
+								id="archivedAt"
+								name="archivedAt"
+								type="date"
+								autocomplete="off"
+								value={new Date().toISOString().slice(0, 10)}
+							/>
+						</div>
+						<div class="space-y-1.5">
+							<Label for="archiveNote">{t(locale, 'page.companion.edit.labelArchiveNote')}</Label>
+							<Input
+								id="archiveNote"
+								name="archiveNote"
+								type="text"
+								autocomplete="off"
+								placeholder={t(locale, 'page.companion.edit.placeholderArchiveNote')}
+							/>
+						</div>
+						<div class="flex gap-2">
+							<Button type="submit" variant="secondary" disabled={loading}>
+								{loading
+									? t(locale, 'page.companion.edit.archiving')
+									: t(locale, 'page.companion.edit.archive')}
+							</Button>
+							<Button type="button" variant="ghost" onclick={() => (showArchivePanel = false)}>
+								{t(locale, 'common.cancel')}
+							</Button>
+						</div>
+					</form>
+				</div>
+			{/if}
+		</div>
 	{/if}
 </div>

--- a/src/routes/(app)/companions/[id]/edit/+page.svelte
+++ b/src/routes/(app)/companions/[id]/edit/+page.svelte
@@ -18,6 +18,7 @@
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 	let { companion } = $derived(data);
 	let loading = $state(false);
+	let archiving = $state(false);
 	let activeTab = $state<'profile' | 'caretaker'>('profile');
 	const locale = getLocale();
 
@@ -95,9 +96,14 @@
 	{/if}
 
 	<!-- Segmented tab control -->
-	<div class="inline-flex w-full rounded-lg border border-border bg-muted p-0.5">
+	<div
+		role="group"
+		aria-label={t(locale, 'page.companion.edit.tabsAria')}
+		class="inline-flex w-full rounded-lg border border-border bg-muted p-0.5"
+	>
 		<button
 			type="button"
+			aria-pressed={activeTab === 'profile'}
 			onclick={() => (activeTab = 'profile')}
 			class={[
 				'flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-all',
@@ -110,6 +116,7 @@
 		</button>
 		<button
 			type="button"
+			aria-pressed={activeTab === 'caretaker'}
 			onclick={() => (activeTab = 'caretaker')}
 			class={[
 				'flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-all',
@@ -155,7 +162,7 @@
 			<!-- BASICS section -->
 			<section class="space-y-4">
 				<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-					Basics
+					{t(locale, 'page.companion.edit.sectionBasics')}
 				</p>
 
 				<div class="space-y-1.5">
@@ -230,7 +237,7 @@
 			<!-- ABOUT section -->
 			<section class="space-y-4">
 				<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-					About
+					{t(locale, 'page.companion.edit.sectionAbout')}
 				</p>
 				<div class="space-y-1.5">
 					<Label for="bio">{t(locale, 'page.companion.labelBio')}</Label>
@@ -427,9 +434,9 @@
 						method="POST"
 						action="?/archive"
 						use:enhance={() => {
-							loading = true;
+							archiving = true;
 							return async ({ update }) => {
-								loading = false;
+								archiving = false;
 								await update({ reset: false });
 							};
 						}}
@@ -456,8 +463,8 @@
 							/>
 						</div>
 						<div class="flex gap-2">
-							<Button type="submit" variant="secondary" disabled={loading}>
-								{loading
+							<Button type="submit" variant="secondary" disabled={archiving}>
+								{archiving
 									? t(locale, 'page.companion.edit.archiving')
 									: t(locale, 'page.companion.edit.archive')}
 							</Button>

--- a/src/routes/(app)/companions/new/+page.svelte
+++ b/src/routes/(app)/companions/new/+page.svelte
@@ -21,9 +21,9 @@
 </svelte:head>
 
 <div class="max-w-2xl mx-auto space-y-6">
-	<Button href="/settings" variant="ghost" size="sm" class="gap-1.5 -ml-2 mb-4">
+	<Button href="/" variant="ghost" size="sm" class="gap-1.5 -ml-2 mb-4">
 		<ChevronLeft class="h-4 w-4" />
-		<span class="hidden sm:inline">{t(locale, 'page.companion.new.backToSettings')}</span>
+		<span class="hidden sm:inline">{t(locale, 'page.companion.edit.backToCompanions')}</span>
 	</Button>
 
 	<div>
@@ -141,7 +141,7 @@
 			<Button type="submit" disabled={loading}>
 				{loading ? t(locale, 'common.saving') : t(locale, 'page.companion.new.submit')}
 			</Button>
-			<Button href="/settings" variant="outline">{t(locale, 'common.cancel')}</Button>
+			<Button href="/" variant="outline">{t(locale, 'common.cancel')}</Button>
 		</div>
 	</form>
 </div>

--- a/src/routes/(app)/companions/new/+page.svelte
+++ b/src/routes/(app)/companions/new/+page.svelte
@@ -2,11 +2,11 @@
 	import type { ActionData } from './$types';
 	import { enhance } from '$app/forms';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
-	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Select } from '$lib/components/ui/select/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { ChevronLeft } from '@lucide/svelte';
 	import { t, getLocale } from '$lib/i18n';
@@ -35,105 +35,113 @@
 		</p>
 	</div>
 
-	<Card>
-		<CardHeader>
-			<CardTitle>{t(locale, 'page.companion.new.cardTitle')}</CardTitle>
-		</CardHeader>
-		<CardContent class="pt-2">
-			<form
-				method="POST"
-				use:enhance={() => {
-					loading = true;
-					return async ({ update }) => {
-						loading = false;
-						await update();
-					};
-				}}
-				class="space-y-5"
-			>
-				{#if form?.error}
-					<Alert variant="destructive">
-						<AlertDescription>{form.error}</AlertDescription>
-					</Alert>
-				{/if}
+	{#if form?.error}
+		<Alert variant="destructive">
+			<AlertDescription>{form.error}</AlertDescription>
+		</Alert>
+	{/if}
 
+	<form
+		method="POST"
+		use:enhance={() => {
+			loading = true;
+			return async ({ update }) => {
+				loading = false;
+				await update();
+			};
+		}}
+		class="space-y-6"
+	>
+		<!-- BASICS section -->
+		<section class="space-y-4">
+			<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+				{t(locale, 'page.companion.edit.sectionBasics')}
+			</p>
+
+			<div class="space-y-1.5">
+				<Label for="name"
+					>{t(locale, 'page.companion.labelName')} <span class="text-destructive">*</span></Label
+				>
+				<Input
+					id="name"
+					name="name"
+					type="text"
+					autocomplete="off"
+					placeholder={t(locale, 'page.companion.placeholderName')}
+					required
+				/>
+			</div>
+
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 				<div class="space-y-1.5">
-					<Label for="name"
-						>{t(locale, 'page.companion.labelName')} <span class="text-destructive">*</span></Label
-					>
+					<Label for="breed">{t(locale, 'page.companion.labelBreed')}</Label>
 					<Input
-						id="name"
-						name="name"
+						id="breed"
+						name="breed"
 						type="text"
 						autocomplete="off"
-						placeholder={t(locale, 'page.companion.placeholderName')}
-						required
+						placeholder={t(locale, 'page.companion.placeholderBreed')}
 					/>
 				</div>
-
-				<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-					<div class="space-y-1.5">
-						<Label for="breed">{t(locale, 'page.companion.labelBreed')}</Label>
-						<Input
-							id="breed"
-							name="breed"
-							type="text"
-							autocomplete="off"
-							placeholder={t(locale, 'page.companion.placeholderBreed')}
-						/>
-					</div>
-					<div class="space-y-1.5">
-						<Label for="sex">{t(locale, 'page.companion.labelSex')}</Label>
-						<Select id="sex" name="sex">
-							<option value="">{t(locale, 'page.companion.sexUnknown')}</option>
-							<option value="male">{t(locale, 'enum.sex.male')}</option>
-							<option value="female">{t(locale, 'enum.sex.female')}</option>
-						</Select>
-					</div>
-				</div>
-
-				<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-					<div class="space-y-1.5">
-						<Label for="dob">{t(locale, 'page.companion.labelDob')}</Label>
-						<Input id="dob" name="dob" type="date" autocomplete="off" />
-					</div>
-					<div class="space-y-1.5">
-						<Label for="weightUnit">{t(locale, 'page.companion.labelWeightUnit')}</Label>
-						<Select id="weightUnit" name="weightUnit">
-							<option value="lbs">lbs</option>
-							<option value="kg">kg</option>
-						</Select>
-					</div>
-				</div>
-
 				<div class="space-y-1.5">
-					<Label for="microchip">{t(locale, 'page.companion.labelMicrochip')}</Label>
-					<Input
-						id="microchip"
-						name="microchip"
-						type="text"
-						autocomplete="off"
-						placeholder={t(locale, 'page.companion.placeholderMicrochip')}
-					/>
+					<Label for="sex">{t(locale, 'page.companion.labelSex')}</Label>
+					<Select id="sex" name="sex">
+						<option value="">{t(locale, 'page.companion.sexUnknown')}</option>
+						<option value="male">{t(locale, 'enum.sex.male')}</option>
+						<option value="female">{t(locale, 'enum.sex.female')}</option>
+					</Select>
 				</div>
+			</div>
 
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 				<div class="space-y-1.5">
-					<Label for="bio">{t(locale, 'page.companion.labelBio')}</Label>
-					<MarkdownTextarea
-						id="bio"
-						name="bio"
-						placeholder={t(locale, 'page.companion.placeholderBio')}
-						rows={4}
-					/>
+					<Label for="dob">{t(locale, 'page.companion.labelDob')}</Label>
+					<Input id="dob" name="dob" type="date" autocomplete="off" />
 				</div>
+				<div class="space-y-1.5">
+					<Label for="weightUnit">{t(locale, 'page.companion.labelWeightUnit')}</Label>
+					<Select id="weightUnit" name="weightUnit">
+						<option value="lbs">lbs</option>
+						<option value="kg">kg</option>
+					</Select>
+				</div>
+			</div>
 
-				<div class="flex gap-3 pt-2">
-					<Button type="submit" disabled={loading}>
-						{loading ? t(locale, 'common.saving') : t(locale, 'page.companion.new.submit')}
-					</Button>
-					<Button href="/settings" variant="outline">{t(locale, 'common.cancel')}</Button>
-				</div>
-			</form>
-		</CardContent>
-	</Card>
+			<div class="space-y-1.5">
+				<Label for="microchip">{t(locale, 'page.companion.labelMicrochip')}</Label>
+				<Input
+					id="microchip"
+					name="microchip"
+					type="text"
+					autocomplete="off"
+					placeholder={t(locale, 'page.companion.placeholderMicrochip')}
+				/>
+			</div>
+		</section>
+
+		<Separator />
+
+		<!-- ABOUT section -->
+		<section class="space-y-4">
+			<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+				{t(locale, 'page.companion.edit.sectionAbout')}
+			</p>
+			<div class="space-y-1.5">
+				<Label for="bio">{t(locale, 'page.companion.labelBio')}</Label>
+				<MarkdownTextarea
+					id="bio"
+					name="bio"
+					placeholder={t(locale, 'page.companion.placeholderBio')}
+					rows={4}
+				/>
+			</div>
+		</section>
+
+		<div class="flex gap-3 pt-2">
+			<Button type="submit" disabled={loading}>
+				{loading ? t(locale, 'common.saving') : t(locale, 'page.companion.new.submit')}
+			</Button>
+			<Button href="/settings" variant="outline">{t(locale, 'common.cancel')}</Button>
+		</div>
+	</form>
 </div>

--- a/tests/e2e/documents.spec.ts
+++ b/tests/e2e/documents.spec.ts
@@ -99,6 +99,24 @@ test.describe('documents', () => {
 		await expect(asMember.getByText('e2e-doc-del.pdf')).toHaveCount(0);
 	});
 
+	test('category chips filter the document list', async ({ asMember }) => {
+		await asMember.goto(`/${COMP}/documents`);
+		await asMember.locator('input[type="file"]').setInputFiles(pdfUpload('e2e-doc-chip.pdf'));
+		await expect(asMember.getByText('e2e-doc-chip.pdf')).toBeVisible({ timeout: 15_000 });
+		const li = asMember.locator('li').filter({ hasText: 'e2e-doc-chip.pdf' }).first();
+		await li.getByRole('button', { name: 'Edit document' }).click();
+		await asMember.locator('select[id^="doc-cat-"]').selectOption('medical');
+		await asMember.getByRole('button', { name: 'Save' }).first().click();
+		await expect(asMember.getByText('e2e-doc-chip.pdf')).toBeVisible({ timeout: 8_000 });
+
+		await asMember.getByRole('button', { name: 'Medical', exact: true }).click();
+		await expect(asMember.getByText('e2e-doc-chip.pdf')).toBeVisible({ timeout: 8_000 });
+		await asMember.getByRole('button', { name: 'Insurance', exact: true }).click();
+		await expect(asMember.getByText('e2e-doc-chip.pdf')).toHaveCount(0, { timeout: 8_000 });
+		await asMember.getByRole('button', { name: 'All categories', exact: true }).click();
+		await expect(asMember.getByText('e2e-doc-chip.pdf')).toBeVisible({ timeout: 8_000 });
+	});
+
 	test('caretaker blocked', async ({ asCaretaker }) => {
 		const response = await asCaretaker.request.get(`/api/companions/${COMP}/documents`);
 		expect(response.status()).toBe(403);


### PR DESCRIPTION
Draft. Stacked on #119 (SP3b) — base branch is `redesign-sp3b-health-reminders`, not `main`. Review/merge after SP1, SP2, SP3a, SP3b. Final group of SP3 (owner inner-page redesigns); after this the owner inner-page arc is complete.

## What's in it

**Documents — category chips.** A chip row (All + Receipt/Invoice/Medical/Insurance/Ownership/Other) replaces the dropdown filter, with an active soft-primary state and `aria-pressed`. The list is de-carded into info-dense rows (type icon, category badge, date, size, linked health event) with the existing soft preview/download/edit/delete actions.

**Companion edit — profile hero + sections.** The Profile tab leads with a centered editable avatar, then light-labeled BASICS and ABOUT sections. The Profile/Caretaker switcher became a segmented control with `aria-pressed`, and the Caretaker tab's three cards became flat Schedules / Contacts / Sitter-notes sections. Archive moved into a coral danger zone (kept outside the tabs so it stays reachable without switching).

**Companion new.** The create form gained the same sectioned treatment; its back and cancel links now point at the companion list instead of the removed Settings entry.

**Markdown line breaks.** `renderMarkdown` now enables GFM `breaks`, so a single newline renders as a line break everywhere (journal, notes, schedules). The `MarkdownTextarea` preview was also switched from a `flex` container to a block one, which was causing rendered paragraphs to be pushed apart and right-aligned.

## Out of scope
Settings, admin, auth-rest, the setup wizard, and the caretaker pages are later sub-projects. No server logic, schema, or API changed.

## Tests
`npm run lint`, `npm run check`, and 193 unit tests pass (added a markdown line-break test). `documents.spec.ts` gained a category-chip filter test; `companions.spec.ts` / `admin-companions.spec.ts` pass with the create/edit/archive flows intact.