### PR TITLE
Redesign SP4: caretaker page bodies

### DIFF
--- a/drizzle/0025_stormy_king_cobra.sql
+++ b/drizzle/0025_stormy_king_cobra.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `companions` ADD `medication_schedule` text;

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1787 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "30fc3baa-555a-47f2-88cc-cc8d8b1c57e0",
+  "prevId": "04338449-0560-4306-8fbc-7b8c0ba0e00a",
+  "tables": {
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "medication_schedule": {
+          "name": "medication_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "health_event_id": {
+          "name": "health_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "document_date": {
+          "name": "document_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "document_companion_idx": {
+          "name": "document_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "document_health_event_idx": {
+          "name": "document_health_event_idx",
+          "columns": [
+            "health_event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "documents_companion_id_companions_id_fk": {
+          "name": "documents_companion_id_companions_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_health_event_id_health_events_id_fk": {
+          "name": "documents_health_event_id_health_events_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "health_events",
+          "columnsFrom": [
+            "health_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "documents_uploaded_by_users_id_fk": {
+          "name": "documents_uploaded_by_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "journal_entries_updated_by_users_id_fk": {
+          "name": "journal_entries_updated_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'photo'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_key": {
+          "name": "poster_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_attempts": {
+          "name": "transcode_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        },
+        "photo_status_idx": {
+          "name": "photo_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_outbox": {
+      "name": "notification_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "outbox_dedupe_idx": {
+          "name": "outbox_dedupe_idx",
+          "columns": [
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_outbox_user_id_users_id_fk": {
+          "name": "notification_outbox_user_id_users_id_fk",
+          "tableFrom": "notification_outbox",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "password_reset_user_idx": {
+          "name": "password_reset_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_reminder_email": {
+          "name": "notify_reminder_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_shift_email": {
+          "name": "notify_shift_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "ntfy_topic": {
+          "name": "ntfy_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_calendar_feed_token_idx": {
+          "name": "users_calendar_feed_token_idx",
+          "columns": [
+            "calendar_feed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1781234564792,
       "tag": "0024_overrated_post",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1781349969352,
+      "tag": "0025_stormy_king_cobra",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.css
+++ b/src/app.css
@@ -33,6 +33,8 @@
 
 	--color-primary: hsl(var(--primary));
 	--color-primary-foreground: hsl(var(--primary-foreground));
+	/* Brighter violet for primary-colored link text; readable on dark cards */
+	--color-primary-link: hsl(var(--primary-link));
 
 	--color-secondary: hsl(var(--secondary));
 	--color-secondary-foreground: hsl(var(--secondary-foreground));
@@ -170,6 +172,7 @@
 		--popover-foreground: 252 43% 15%;
 		--primary: 255 89% 62%;
 		--primary-foreground: 0 0% 100%;
+		--primary-link: 255 89% 62%;
 		--secondary: 258 30% 94%;
 		--secondary-foreground: 252 43% 15%;
 		--muted: 258 30% 94%;
@@ -208,6 +211,7 @@
 		--popover-foreground: 0 0% 100%;
 		--primary: 252 100% 65%;
 		--primary-foreground: 0 0% 100%;
+		--primary-link: 252 100% 82%;
 		--secondary: 238 30% 19%;
 		--secondary-foreground: 0 0% 100%;
 		--muted: 238 30% 19%;

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -421,6 +421,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.schedulesHint': 'Wird Betreuern auf ihrer Übersichtsseite angezeigt.',
 	'page.companion.edit.labelFeedingSchedule': 'Fütterungsplan',
 	'page.companion.edit.labelWalkSchedule': 'Spaziergangsplan',
+	'page.companion.edit.labelMedicationSchedule': 'Medikamentenplan',
 	'page.companion.edit.cardContacts': 'Kontakte',
 	'page.companion.edit.labelVetName': 'Tierarztname',
 	'page.companion.edit.labelVetPhone': 'Tierarzt-Telefon',
@@ -433,6 +434,8 @@ const messages: Record<keyof Messages, string> = {
 		'z.B. 7:00 Uhr: 1 Tasse Trockenfutter\n18:00 Uhr: 1 Tasse Trockenfutter\nLeckerlis nach Spaziergängen OK',
 	'page.companion.edit.placeholderWalkSchedule':
 		'z.B. Morgens ~7 Uhr, 30 Min.\nAbends ~17:30 Uhr, 20–30 Min.\nHundepark unter der Woche meiden',
+	'page.companion.edit.placeholderMedicationSchedule':
+		'z.B. Herzwurm-Tablette am 1. des Monats\nGelenkpräparat täglich zum Frühstück\nAugentropfen morgens und abends',
 	'page.companion.edit.placeholderSitterNotes':
 		'Alles, was ein Betreuer wissen sollte: Eigenheiten, Ängste, Lieblingsorte…',
 	'page.companion.edit.placeholderMicrochip': '15-stellige ID',
@@ -546,7 +549,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.weightAsOf': 'Stand',
 	'page.dashboard.caretaker.cardFeeding': 'Fütterungsplan',
 	'page.dashboard.caretaker.cardWalk': 'Spaziergangsplan',
-	'page.dashboard.caretaker.cardMedications': 'Medikamente',
+	'page.dashboard.caretaker.cardMedicationSchedule': 'Medikamentenplan',
 	'page.dashboard.caretaker.cardReminders': 'Anstehende Erinnerungen',
 	'page.dashboard.caretaker.remindersEmpty': 'Keine anstehenden Erinnerungen.',
 	'page.dashboard.caretaker.reminderOverdue': 'Überfällig',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -558,7 +558,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'Über {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Heutige Aktivitäten',
 	'page.dashboard.caretaker.sectionQuickLog': 'Schnell erfassen',
-	'page.dashboard.caretaker.logActivity': '+ Aktivität erfassen',
+	'page.dashboard.caretaker.logActivity': 'Aktivität erfassen',
 	'page.dashboard.caretaker.activityEmpty': 'Heute noch nichts erfasst.',
 	'page.dashboard.caretaker.modalLabelType': 'Typ',
 	'page.dashboard.caretaker.modalLabelLogged': 'Erfasst',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -557,6 +557,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardSitterNotes': 'Notizen für den Betreuer',
 	'page.dashboard.caretaker.cardAbout': 'Über {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Heutige Aktivitäten',
+	'page.dashboard.caretaker.sectionQuickLog': 'Schnell erfassen',
 	'page.dashboard.caretaker.logActivity': '+ Aktivität erfassen',
 	'page.dashboard.caretaker.activityEmpty': 'Heute noch nichts erfasst.',
 	'page.dashboard.caretaker.modalLabelType': 'Typ',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -808,6 +808,9 @@ const messages: Record<keyof Messages, string> = {
 	'page.log.noUpcomingShifts': 'Keine Schichten geplant.',
 	'page.log.nextShiftStarts': 'Deine nächste Schicht beginnt',
 	'page.log.activityLogged': '✓ Aktivität erfasst!',
+	'page.log.alsoLogFor': 'Auch erfassen für…',
+	'page.log.alsoLogForHint':
+		'Weitere Begleiter auswählen, um dieselbe Aktivität für sie zu erfassen.',
 	'page.log.quickLogTitle': 'Schnellerfassung',
 	'page.log.activityLabel': 'Aktivität',
 	'page.log.durationLabel': 'Dauer (Minuten)',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -561,6 +561,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'Über {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Heutige Aktivitäten',
 	'page.dashboard.caretaker.sectionQuickLog': 'Schnell erfassen',
+	'page.dashboard.caretaker.sectionSchedules': 'Zeitpläne',
+	'page.dashboard.caretaker.sectionContacts': 'Kontakte',
 	'page.dashboard.caretaker.logActivity': 'Aktivität erfassen',
 	'page.dashboard.caretaker.activityEmpty': 'Heute noch nichts erfasst.',
 	'page.dashboard.caretaker.modalLabelType': 'Typ',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -551,7 +551,7 @@ const messages = {
 	'page.dashboard.caretaker.cardAbout': 'About {name}',
 	'page.dashboard.caretaker.cardTodayActivity': "Today's Activity",
 	'page.dashboard.caretaker.sectionQuickLog': 'Quick log',
-	'page.dashboard.caretaker.logActivity': '+ Log activity',
+	'page.dashboard.caretaker.logActivity': 'Log activity',
 	'page.dashboard.caretaker.activityEmpty': 'Nothing logged yet today.',
 	'page.dashboard.caretaker.modalLabelType': 'Type',
 	'page.dashboard.caretaker.modalLabelLogged': 'Logged',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -550,6 +550,7 @@ const messages = {
 	'page.dashboard.caretaker.cardSitterNotes': 'Notes for Sitter',
 	'page.dashboard.caretaker.cardAbout': 'About {name}',
 	'page.dashboard.caretaker.cardTodayActivity': "Today's Activity",
+	'page.dashboard.caretaker.sectionQuickLog': 'Quick log',
 	'page.dashboard.caretaker.logActivity': '+ Log activity',
 	'page.dashboard.caretaker.activityEmpty': 'Nothing logged yet today.',
 	'page.dashboard.caretaker.modalLabelType': 'Type',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -414,6 +414,7 @@ const messages = {
 	'page.companion.edit.schedulesHint': 'Shown to caretakers on their overview page.',
 	'page.companion.edit.labelFeedingSchedule': 'Feeding schedule',
 	'page.companion.edit.labelWalkSchedule': 'Walk schedule',
+	'page.companion.edit.labelMedicationSchedule': 'Medication schedule',
 	'page.companion.edit.cardContacts': 'Contacts',
 	'page.companion.edit.labelVetName': 'Vet name',
 	'page.companion.edit.labelVetPhone': 'Vet phone',
@@ -426,6 +427,8 @@ const messages = {
 		'e.g. 7:00am: 1 cup kibble\n6:00pm: 1 cup kibble\nTreats OK after walks',
 	'page.companion.edit.placeholderWalkSchedule':
 		'e.g. Morning ~7am, 30 min\nEvening ~5:30pm, 20–30 min\nAvoid the dog park on weekdays',
+	'page.companion.edit.placeholderMedicationSchedule':
+		'e.g. Heartworm chew 1st of the month\nJoint supplement daily with breakfast\nEye drops morning and night',
 	'page.companion.edit.placeholderSitterNotes':
 		'Anything a sitter or walker should know: quirks, fears, favorite spots…',
 	'page.companion.edit.placeholderMicrochip': '15-digit ID',
@@ -539,7 +542,7 @@ const messages = {
 	'page.dashboard.caretaker.weightAsOf': 'as of',
 	'page.dashboard.caretaker.cardFeeding': 'Feeding Schedule',
 	'page.dashboard.caretaker.cardWalk': 'Walk Schedule',
-	'page.dashboard.caretaker.cardMedications': 'Medications',
+	'page.dashboard.caretaker.cardMedicationSchedule': 'Medication Schedule',
 	'page.dashboard.caretaker.cardReminders': 'Upcoming Reminders',
 	'page.dashboard.caretaker.remindersEmpty': 'No upcoming reminders.',
 	'page.dashboard.caretaker.reminderOverdue': 'Overdue',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -554,6 +554,8 @@ const messages = {
 	'page.dashboard.caretaker.cardAbout': 'About {name}',
 	'page.dashboard.caretaker.cardTodayActivity': "Today's Activity",
 	'page.dashboard.caretaker.sectionQuickLog': 'Quick log',
+	'page.dashboard.caretaker.sectionSchedules': 'Schedules',
+	'page.dashboard.caretaker.sectionContacts': 'Contacts',
 	'page.dashboard.caretaker.logActivity': 'Log activity',
 	'page.dashboard.caretaker.activityEmpty': 'Nothing logged yet today.',
 	'page.dashboard.caretaker.modalLabelType': 'Type',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -799,6 +799,8 @@ const messages = {
 	'page.log.noUpcomingShifts': 'No upcoming shifts are scheduled.',
 	'page.log.nextShiftStarts': 'Your next shift starts',
 	'page.log.activityLogged': '✓ Activity logged!',
+	'page.log.alsoLogFor': 'Also Log For…',
+	'page.log.alsoLogForHint': 'Select other companions to record the same activity for.',
 	'page.log.quickLogTitle': 'Quick log',
 	'page.log.activityLabel': 'Activity',
 	'page.log.durationLabel': 'Duration (minutes)',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -561,6 +561,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'Sobre {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Actividad de hoy',
 	'page.dashboard.caretaker.sectionQuickLog': 'Registro rápido',
+	'page.dashboard.caretaker.sectionSchedules': 'Horarios',
+	'page.dashboard.caretaker.sectionContacts': 'Contactos',
 	'page.dashboard.caretaker.logActivity': 'Registrar actividad',
 	'page.dashboard.caretaker.activityEmpty': 'Nada registrado hoy.',
 	'page.dashboard.caretaker.modalLabelType': 'Tipo',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -421,6 +421,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.schedulesHint': 'Se muestran a los cuidadores en su página de resumen.',
 	'page.companion.edit.labelFeedingSchedule': 'Horario de comidas',
 	'page.companion.edit.labelWalkSchedule': 'Horario de paseos',
+	'page.companion.edit.labelMedicationSchedule': 'Horario de medicación',
 	'page.companion.edit.cardContacts': 'Contactos',
 	'page.companion.edit.labelVetName': 'Nombre del veterinario',
 	'page.companion.edit.labelVetPhone': 'Teléfono del veterinario',
@@ -433,6 +434,8 @@ const messages: Record<keyof Messages, string> = {
 		'ej. 7:00am: 1 taza de pienso\n6:00pm: 1 taza de pienso\nPremios OK después de paseos',
 	'page.companion.edit.placeholderWalkSchedule':
 		'ej. Mañana ~7am, 30 min\nTarde ~5:30pm, 20–30 min\nEvitar el parque canino entre semana',
+	'page.companion.edit.placeholderMedicationSchedule':
+		'ej. Pastilla antiparasitaria el día 1 del mes\nSuplemento articular a diario con el desayuno\nGotas oculares mañana y noche',
 	'page.companion.edit.placeholderSitterNotes':
 		'Todo lo que un cuidador debería saber: manías, miedos, lugares favoritos…',
 	'page.companion.edit.placeholderMicrochip': 'ID de 15 dígitos',
@@ -546,7 +549,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.weightAsOf': 'a fecha de',
 	'page.dashboard.caretaker.cardFeeding': 'Horario de comidas',
 	'page.dashboard.caretaker.cardWalk': 'Horario de paseos',
-	'page.dashboard.caretaker.cardMedications': 'Medicamentos',
+	'page.dashboard.caretaker.cardMedicationSchedule': 'Horario de medicación',
 	'page.dashboard.caretaker.cardReminders': 'Recordatorios próximos',
 	'page.dashboard.caretaker.remindersEmpty': 'No hay recordatorios próximos.',
 	'page.dashboard.caretaker.reminderOverdue': 'Vencido',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -557,6 +557,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardSitterNotes': 'Notas para el cuidador',
 	'page.dashboard.caretaker.cardAbout': 'Sobre {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Actividad de hoy',
+	'page.dashboard.caretaker.sectionQuickLog': 'Registro rápido',
 	'page.dashboard.caretaker.logActivity': '+ Registrar actividad',
 	'page.dashboard.caretaker.activityEmpty': 'Nada registrado hoy.',
 	'page.dashboard.caretaker.modalLabelType': 'Tipo',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -558,7 +558,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'Sobre {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Actividad de hoy',
 	'page.dashboard.caretaker.sectionQuickLog': 'Registro rápido',
-	'page.dashboard.caretaker.logActivity': '+ Registrar actividad',
+	'page.dashboard.caretaker.logActivity': 'Registrar actividad',
 	'page.dashboard.caretaker.activityEmpty': 'Nada registrado hoy.',
 	'page.dashboard.caretaker.modalLabelType': 'Tipo',
 	'page.dashboard.caretaker.modalLabelLogged': 'Registrado',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -808,6 +808,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.log.noUpcomingShifts': 'No hay turnos programados.',
 	'page.log.nextShiftStarts': 'Tu próximo turno empieza',
 	'page.log.activityLogged': '✓ ¡Actividad registrada!',
+	'page.log.alsoLogFor': 'Registrar también para…',
+	'page.log.alsoLogForHint': 'Selecciona otros compañeros para registrar la misma actividad.',
 	'page.log.quickLogTitle': 'Registro rápido',
 	'page.log.activityLabel': 'Actividad',
 	'page.log.durationLabel': 'Duración (minutos)',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -558,7 +558,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'À propos de {name}',
 	'page.dashboard.caretaker.cardTodayActivity': "Activité d'aujourd'hui",
 	'page.dashboard.caretaker.sectionQuickLog': 'Saisie rapide',
-	'page.dashboard.caretaker.logActivity': '+ Enregistrer une activité',
+	'page.dashboard.caretaker.logActivity': 'Enregistrer une activité',
 	'page.dashboard.caretaker.activityEmpty': "Rien d'enregistré aujourd'hui.",
 	'page.dashboard.caretaker.modalLabelType': 'Type',
 	'page.dashboard.caretaker.modalLabelLogged': 'Enregistré',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -561,6 +561,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'À propos de {name}',
 	'page.dashboard.caretaker.cardTodayActivity': "Activité d'aujourd'hui",
 	'page.dashboard.caretaker.sectionQuickLog': 'Saisie rapide',
+	'page.dashboard.caretaker.sectionSchedules': 'Horaires',
+	'page.dashboard.caretaker.sectionContacts': 'Contacts',
 	'page.dashboard.caretaker.logActivity': 'Enregistrer une activité',
 	'page.dashboard.caretaker.activityEmpty': "Rien d'enregistré aujourd'hui.",
 	'page.dashboard.caretaker.modalLabelType': 'Type',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -421,6 +421,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.schedulesHint': "Affichés aux gardiens sur leur page d'aperçu.",
 	'page.companion.edit.labelFeedingSchedule': 'Horaire des repas',
 	'page.companion.edit.labelWalkSchedule': 'Horaire des promenades',
+	'page.companion.edit.labelMedicationSchedule': 'Horaire des médicaments',
 	'page.companion.edit.cardContacts': 'Contacts',
 	'page.companion.edit.labelVetName': 'Nom du vétérinaire',
 	'page.companion.edit.labelVetPhone': 'Téléphone du vétérinaire',
@@ -433,6 +434,8 @@ const messages: Record<keyof Messages, string> = {
 		'ex. 7h00 : 1 tasse de croquettes\n18h00 : 1 tasse de croquettes\nFriandises OK après les promenades',
 	'page.companion.edit.placeholderWalkSchedule':
 		'ex. Matin ~7h, 30 min\nSoir ~17h30, 20–30 min\nÉviter le parc canin en semaine',
+	'page.companion.edit.placeholderMedicationSchedule':
+		'ex. Comprimé antiparasitaire le 1er du mois\nComplément articulaire chaque matin\nCollyre matin et soir',
 	'page.companion.edit.placeholderSitterNotes':
 		'Tout ce qu\u2019un gardien devrait savoir : habitudes, peurs, endroits préférés…',
 	'page.companion.edit.placeholderMicrochip': 'Identifiant à 15 chiffres',
@@ -546,7 +549,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.weightAsOf': 'au',
 	'page.dashboard.caretaker.cardFeeding': 'Horaire des repas',
 	'page.dashboard.caretaker.cardWalk': 'Horaire des promenades',
-	'page.dashboard.caretaker.cardMedications': 'Médicaments',
+	'page.dashboard.caretaker.cardMedicationSchedule': 'Horaire des médicaments',
 	'page.dashboard.caretaker.cardReminders': 'Rappels à venir',
 	'page.dashboard.caretaker.remindersEmpty': 'Aucun rappel à venir.',
 	'page.dashboard.caretaker.reminderOverdue': 'En retard',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -557,6 +557,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardSitterNotes': 'Notes pour le gardien',
 	'page.dashboard.caretaker.cardAbout': 'À propos de {name}',
 	'page.dashboard.caretaker.cardTodayActivity': "Activité d'aujourd'hui",
+	'page.dashboard.caretaker.sectionQuickLog': 'Saisie rapide',
 	'page.dashboard.caretaker.logActivity': '+ Enregistrer une activité',
 	'page.dashboard.caretaker.activityEmpty': "Rien d'enregistré aujourd'hui.",
 	'page.dashboard.caretaker.modalLabelType': 'Type',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -810,6 +810,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.log.noUpcomingShifts': 'Aucune garde programmée.',
 	'page.log.nextShiftStarts': 'Votre prochaine garde commence',
 	'page.log.activityLogged': '✓ Activité enregistrée !',
+	'page.log.alsoLogFor': 'Enregistrer aussi pour…',
+	'page.log.alsoLogForHint': 'Sélectionner d’autres compagnons pour enregistrer la même activité.',
 	'page.log.quickLogTitle': 'Enregistrement rapide',
 	'page.log.activityLabel': 'Activité',
 	'page.log.durationLabel': 'Durée (minutes)',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -803,6 +803,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.log.noUpcomingShifts': 'Nessun turno programmato.',
 	'page.log.nextShiftStarts': 'Il tuo prossimo turno inizia',
 	'page.log.activityLogged': '✓ Attività registrata!',
+	'page.log.alsoLogFor': 'Registra anche per…',
+	'page.log.alsoLogForHint': 'Seleziona altri compagni per registrare la stessa attività.',
 	'page.log.quickLogTitle': 'Registrazione rapida',
 	'page.log.activityLabel': 'Attività',
 	'page.log.durationLabel': 'Durata (minuti)',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -417,6 +417,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.schedulesHint': 'Mostrati ai custodi nella loro pagina panoramica.',
 	'page.companion.edit.labelFeedingSchedule': 'Orario pasti',
 	'page.companion.edit.labelWalkSchedule': 'Orario passeggiate',
+	'page.companion.edit.labelMedicationSchedule': 'Orario farmaci',
 	'page.companion.edit.cardContacts': 'Contatti',
 	'page.companion.edit.labelVetName': 'Nome veterinario',
 	'page.companion.edit.labelVetPhone': 'Telefono veterinario',
@@ -429,6 +430,8 @@ const messages: Record<keyof Messages, string> = {
 		'es. 7:00: 1 tazza di crocchette\n18:00: 1 tazza di crocchette\nPremietti OK dopo le passeggiate',
 	'page.companion.edit.placeholderWalkSchedule':
 		'es. Mattina ~7:00, 30 min\nSera ~17:30, 20–30 min\nEvitare il parco cani nei giorni feriali',
+	'page.companion.edit.placeholderMedicationSchedule':
+		'es. Compressa antiparassitaria il 1° del mese\nIntegratore articolare ogni mattina\nCollirio mattina e sera',
 	'page.companion.edit.placeholderSitterNotes':
 		'Tutto ciò che un dog sitter dovrebbe sapere: abitudini, paure, posti preferiti…',
 	'page.companion.edit.placeholderMicrochip': 'Codice di 15 cifre',
@@ -542,7 +545,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.weightAsOf': 'al',
 	'page.dashboard.caretaker.cardFeeding': 'Orario pasti',
 	'page.dashboard.caretaker.cardWalk': 'Orario passeggiate',
-	'page.dashboard.caretaker.cardMedications': 'Farmaci',
+	'page.dashboard.caretaker.cardMedicationSchedule': 'Orario farmaci',
 	'page.dashboard.caretaker.cardReminders': 'Promemoria in arrivo',
 	'page.dashboard.caretaker.remindersEmpty': 'Nessun promemoria in arrivo.',
 	'page.dashboard.caretaker.reminderOverdue': 'Scaduto',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -553,6 +553,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardSitterNotes': 'Note per il custode',
 	'page.dashboard.caretaker.cardAbout': 'Informazioni su {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Attività di oggi',
+	'page.dashboard.caretaker.sectionQuickLog': 'Registro rapido',
 	'page.dashboard.caretaker.logActivity': '+ Registra attività',
 	'page.dashboard.caretaker.activityEmpty': 'Nessuna attività registrata oggi.',
 	'page.dashboard.caretaker.modalLabelType': 'Tipo',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -554,7 +554,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'Informazioni su {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Attività di oggi',
 	'page.dashboard.caretaker.sectionQuickLog': 'Registro rapido',
-	'page.dashboard.caretaker.logActivity': '+ Registra attività',
+	'page.dashboard.caretaker.logActivity': 'Registra attività',
 	'page.dashboard.caretaker.activityEmpty': 'Nessuna attività registrata oggi.',
 	'page.dashboard.caretaker.modalLabelType': 'Tipo',
 	'page.dashboard.caretaker.modalLabelLogged': 'Registrato',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -557,6 +557,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'Informazioni su {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Attività di oggi',
 	'page.dashboard.caretaker.sectionQuickLog': 'Registro rapido',
+	'page.dashboard.caretaker.sectionSchedules': 'Orari',
+	'page.dashboard.caretaker.sectionContacts': 'Contatti',
 	'page.dashboard.caretaker.logActivity': 'Registra attività',
 	'page.dashboard.caretaker.activityEmpty': 'Nessuna attività registrata oggi.',
 	'page.dashboard.caretaker.modalLabelType': 'Tipo',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -555,7 +555,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'Sobre {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Atividade de hoje',
 	'page.dashboard.caretaker.sectionQuickLog': 'Registo rápido',
-	'page.dashboard.caretaker.logActivity': '+ Registar atividade',
+	'page.dashboard.caretaker.logActivity': 'Registar atividade',
 	'page.dashboard.caretaker.activityEmpty': 'Nada registado hoje.',
 	'page.dashboard.caretaker.modalLabelType': 'Tipo',
 	'page.dashboard.caretaker.modalLabelLogged': 'Registado',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -805,6 +805,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.log.noUpcomingShifts': 'Nenhum turno agendado.',
 	'page.log.nextShiftStarts': 'O seu próximo turno começa',
 	'page.log.activityLogged': '✓ Atividade registada!',
+	'page.log.alsoLogFor': 'Registar também para…',
+	'page.log.alsoLogForHint': 'Selecione outros companheiros para registar a mesma atividade.',
 	'page.log.quickLogTitle': 'Registo rápido',
 	'page.log.activityLabel': 'Atividade',
 	'page.log.durationLabel': 'Duração (minutos)',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -558,6 +558,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardAbout': 'Sobre {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Atividade de hoje',
 	'page.dashboard.caretaker.sectionQuickLog': 'Registo rápido',
+	'page.dashboard.caretaker.sectionSchedules': 'Horários',
+	'page.dashboard.caretaker.sectionContacts': 'Contactos',
 	'page.dashboard.caretaker.logActivity': 'Registar atividade',
 	'page.dashboard.caretaker.activityEmpty': 'Nada registado hoje.',
 	'page.dashboard.caretaker.modalLabelType': 'Tipo',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -418,6 +418,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.companion.edit.schedulesHint': 'Mostrados aos cuidadores na sua página de resumo.',
 	'page.companion.edit.labelFeedingSchedule': 'Horário de refeições',
 	'page.companion.edit.labelWalkSchedule': 'Horário de passeios',
+	'page.companion.edit.labelMedicationSchedule': 'Horário de medicação',
 	'page.companion.edit.cardContacts': 'Contactos',
 	'page.companion.edit.labelVetName': 'Nome do veterinário',
 	'page.companion.edit.labelVetPhone': 'Telefone do veterinário',
@@ -430,6 +431,8 @@ const messages: Record<keyof Messages, string> = {
 		'ex. 7:00: 1 chávena de ração\n18:00: 1 chávena de ração\nBiscoitos OK após passeios',
 	'page.companion.edit.placeholderWalkSchedule':
 		'ex. Manhã ~7h, 30 min\nFim de tarde ~17h30, 20–30 min\nEvitar o parque canino durante a semana',
+	'page.companion.edit.placeholderMedicationSchedule':
+		'ex. Comprimido antiparasitário no dia 1 do mês\nSuplemento articular diário ao pequeno-almoço\nColírio de manhã e à noite',
 	'page.companion.edit.placeholderSitterNotes':
 		'Tudo o que um cuidador deve saber: manias, medos, sítios preferidos…',
 	'page.companion.edit.placeholderMicrochip': 'ID de 15 dígitos',
@@ -543,7 +546,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.weightAsOf': 'em',
 	'page.dashboard.caretaker.cardFeeding': 'Horário de refeições',
 	'page.dashboard.caretaker.cardWalk': 'Horário de passeios',
-	'page.dashboard.caretaker.cardMedications': 'Medicamentos',
+	'page.dashboard.caretaker.cardMedicationSchedule': 'Horário de medicação',
 	'page.dashboard.caretaker.cardReminders': 'Lembretes próximos',
 	'page.dashboard.caretaker.remindersEmpty': 'Sem lembretes próximos.',
 	'page.dashboard.caretaker.reminderOverdue': 'Atrasado',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -554,6 +554,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.dashboard.caretaker.cardSitterNotes': 'Notas para o cuidador',
 	'page.dashboard.caretaker.cardAbout': 'Sobre {name}',
 	'page.dashboard.caretaker.cardTodayActivity': 'Atividade de hoje',
+	'page.dashboard.caretaker.sectionQuickLog': 'Registo rápido',
 	'page.dashboard.caretaker.logActivity': '+ Registar atividade',
 	'page.dashboard.caretaker.activityEmpty': 'Nada registado hoje.',
 	'page.dashboard.caretaker.modalLabelType': 'Tipo',

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -159,6 +159,7 @@ export const companions = sqliteTable(
 		bio: text('bio'),
 		feedingSchedule: text('feeding_schedule'),
 		walkSchedule: text('walk_schedule'),
+		medicationSchedule: text('medication_schedule'),
 		emergencyContactName: text('emergency_contact_name'),
 		emergencyContactPhone: text('emergency_contact_phone'),
 		vetName: text('vet_name'),

--- a/src/routes/(app)/companions/[id]/edit/+page.server.ts
+++ b/src/routes/(app)/companions/[id]/edit/+page.server.ts
@@ -45,6 +45,7 @@ export const actions: Actions = {
 				// Caretaker fields
 				feedingSchedule: String(data.get('feedingSchedule') ?? '').trim() || null,
 				walkSchedule: String(data.get('walkSchedule') ?? '').trim() || null,
+				medicationSchedule: String(data.get('medicationSchedule') ?? '').trim() || null,
 				emergencyContactName: String(data.get('emergencyContactName') ?? '').trim() || null,
 				emergencyContactPhone: String(data.get('emergencyContactPhone') ?? '').trim() || null,
 				vetName: String(data.get('vetName') ?? '').trim() || null,

--- a/src/routes/(app)/companions/[id]/edit/+page.svelte
+++ b/src/routes/(app)/companions/[id]/edit/+page.svelte
@@ -286,6 +286,18 @@
 						rows={4}
 					/>
 				</div>
+				<div class="space-y-1.5">
+					<Label for="medicationSchedule"
+						>{t(locale, 'page.companion.edit.labelMedicationSchedule')}</Label
+					>
+					<MarkdownTextarea
+						id="medicationSchedule"
+						name="medicationSchedule"
+						value={companion.medicationSchedule ?? ''}
+						placeholder={t(locale, 'page.companion.edit.placeholderMedicationSchedule')}
+						rows={4}
+					/>
+				</div>
 			</section>
 
 			<Separator />

--- a/src/routes/(caretaker)/+layout.svelte
+++ b/src/routes/(caretaker)/+layout.svelte
@@ -111,7 +111,7 @@
 			<div class="flex h-16 items-center justify-between gap-4">
 				<!-- Logo (linked) -->
 				<a
-					href="/care/{data.companions?.[0]?.id ?? ''}"
+					href="/care/{activeCompanion?.id ?? ''}"
 					class="logo-link hidden sm:flex items-center gap-2 shrink-0"
 				>
 					<PawLogo

--- a/src/routes/(caretaker)/care/[companionId]/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/+page.server.ts
@@ -17,15 +17,6 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 	});
 	if (!companion) error(404, t(locals.locale, 'error.companionNotFound'));
 
-	const medications = await db.query.healthEvents.findMany({
-		where: and(
-			eq(schema.healthEvents.companionId, params.companionId),
-			eq(schema.healthEvents.type, 'medication')
-		),
-		orderBy: (h, { desc }) => [desc(h.occurredAt)],
-		with: { logger: { columns: { displayName: true } } }
-	});
-
 	const todayStart = new Date();
 	todayStart.setHours(0, 0, 0, 0);
 	const todayActivity = isOnShift
@@ -83,7 +74,6 @@ export const load: PageServerLoad = async ({ params, parent, locals }) => {
 
 	return {
 		companion,
-		medications,
 		todayActivity,
 		latestWeight: latestWeight ?? null,
 		owners,

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -578,49 +578,45 @@
 			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
 				{t(locale, 'page.dashboard.caretaker.sectionContacts')}
 			</h2>
-			<div class="space-y-4">
-				{#if hasVetInfo || hasEmergencyContact}
-					<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-						{#if hasVetInfo}
-							<div class="rounded-xl border border-border bg-card p-4 space-y-1 text-sm">
-								<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
-									<span>🏥</span>
-									{t(locale, 'page.dashboard.caretaker.cardVetInfo')}
-								</p>
-								{#if companion.vetName}<p class="font-medium">{companion.vetName}</p>{/if}
-								{#if companion.vetClinic}<p class="text-muted-foreground">
-										{companion.vetClinic}
-									</p>{/if}
-								{#if companion.vetPhone}
-									📞 <a
-										href="tel:{companion.vetPhone}"
-										class="hover:underline font-medium text-primary-link">{companion.vetPhone}</a
-									>
-								{/if}
-							</div>
+			<div class="flex flex-col sm:flex-row gap-4">
+				{#if hasVetInfo}
+					<div class="flex-1 min-w-0 rounded-xl border border-border bg-card p-4 space-y-1 text-sm">
+						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+							<span>🏥</span>
+							{t(locale, 'page.dashboard.caretaker.cardVetInfo')}
+						</p>
+						{#if companion.vetName}<p class="font-medium">{companion.vetName}</p>{/if}
+						{#if companion.vetClinic}<p class="text-muted-foreground">{companion.vetClinic}</p>{/if}
+						{#if companion.vetPhone}
+							📞 <a
+								href="tel:{companion.vetPhone}"
+								class="hover:underline font-medium text-primary-link">{companion.vetPhone}</a
+							>
 						{/if}
-						{#if hasEmergencyContact}
-							<div class="rounded-xl border border-coral/30 bg-card p-4 space-y-1 text-sm">
-								<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
-									<span>🚨</span>
-									{t(locale, 'page.dashboard.caretaker.cardEmergencyContact')}
-								</p>
-								{#if companion.emergencyContactName}
-									<p class="font-medium">{companion.emergencyContactName}</p>
-								{/if}
-								{#if companion.emergencyContactPhone}
-									📞 <a
-										href="tel:{companion.emergencyContactPhone}"
-										class="text-coral hover:underline font-medium text-base"
-										>{companion.emergencyContactPhone}</a
-									>
-								{/if}
-							</div>
+					</div>
+				{/if}
+				{#if hasEmergencyContact}
+					<div
+						class="flex-1 min-w-0 rounded-xl border border-coral/30 bg-card p-4 space-y-1 text-sm"
+					>
+						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+							<span>🚨</span>
+							{t(locale, 'page.dashboard.caretaker.cardEmergencyContact')}
+						</p>
+						{#if companion.emergencyContactName}
+							<p class="font-medium">{companion.emergencyContactName}</p>
+						{/if}
+						{#if companion.emergencyContactPhone}
+							📞 <a
+								href="tel:{companion.emergencyContactPhone}"
+								class="text-coral hover:underline font-medium text-base"
+								>{companion.emergencyContactPhone}</a
+							>
 						{/if}
 					</div>
 				{/if}
 				{#if visibleOwners.length > 0}
-					<div class="rounded-xl border border-border bg-card p-4 space-y-3">
+					<div class="flex-1 min-w-0 rounded-xl border border-border bg-card p-4 space-y-3">
 						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
 							<span>🏠</span>
 							{visibleOwners.length === 1

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -18,8 +18,7 @@
 	import ReminderCompleteButtons from '$lib/components/reminders/ReminderCompleteButtons.svelte';
 
 	let { data }: { data: PageData } = $props();
-	let { companion, medications, todayActivity, latestWeight, owners, upcomingReminders } =
-		$derived(data);
+	let { companion, todayActivity, latestWeight, owners, upcomingReminders } = $derived(data);
 
 	const locale = getLocale();
 	const quickLogTypes = activityTypeOptions(locale).filter((opt) =>
@@ -514,13 +513,15 @@
 	{/if}
 
 	<!-- 4a. Schedules (reference) -->
-	{#if companion.feedingSchedule || companion.walkSchedule}
+	{#if companion.feedingSchedule || companion.walkSchedule || companion.medicationSchedule}
+		{@const scheduleLabels = [
+			companion.feedingSchedule && t(locale, 'page.dashboard.caretaker.cardFeeding'),
+			companion.walkSchedule && t(locale, 'page.dashboard.caretaker.cardWalk'),
+			companion.medicationSchedule && t(locale, 'page.dashboard.caretaker.cardMedicationSchedule')
+		].filter(Boolean)}
 		<section>
 			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-				{t(locale, 'page.dashboard.caretaker.cardFeeding')} &amp; {t(
-					locale,
-					'page.dashboard.caretaker.cardWalk'
-				)}
+				{scheduleLabels.join(' & ')}
 			</h2>
 			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 				{#if companion.feedingSchedule}
@@ -545,6 +546,17 @@
 						</div>
 					</div>
 				{/if}
+				{#if companion.medicationSchedule}
+					<div class="rounded-xl border border-border bg-card p-4">
+						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+							<span>💊</span>
+							{t(locale, 'page.dashboard.caretaker.cardMedicationSchedule')}
+						</p>
+						<div class="prose prose-sm dark:prose-invert max-w-none">
+							{@html renderMarkdown(companion.medicationSchedule)}
+						</div>
+					</div>
+				{/if}
 			</div>
 		</section>
 	{/if}
@@ -557,31 +569,6 @@
 			</h2>
 			<div class="prose prose-sm dark:prose-invert max-w-none">
 				{@html renderMarkdown(companion.notesForSitter)}
-			</div>
-		</section>
-	{/if}
-
-	<!-- 4c. Medications (reference) -->
-	{#if medications.length > 0}
-		<section>
-			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-				💊 {t(locale, 'page.dashboard.caretaker.cardMedications')}
-			</h2>
-			<div class="rounded-xl border border-border bg-card divide-y divide-border">
-				{#each medications as med (med.id)}
-					<div class="flex gap-3 text-sm px-4 py-3">
-						<div class="flex-1">
-							<p class="font-medium">{med.title}</p>
-							{#if med.notes}
-								<div
-									class="prose prose-sm dark:prose-invert max-w-none mt-0.5 text-muted-foreground"
-								>
-									{@html renderMarkdown(med.notes)}
-								</div>
-							{/if}
-						</div>
-					</div>
-				{/each}
 			</div>
 		</section>
 	{/if}

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -4,7 +4,7 @@
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
 	import { Badge } from '$lib/components/ui/badge/index.js';
-	import { Phone, Mail, X, Bell, CheckCheck } from '@lucide/svelte';
+	import { Phone, Mail, X, Bell } from '@lucide/svelte';
 	import { enhance } from '$app/forms';
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
@@ -22,8 +22,8 @@
 		$derived(data);
 
 	const locale = getLocale();
-	const quickLogTypes = activityTypeOptions(locale).filter((t) =>
-		['walk', 'meal', 'bathroom'].includes(t.value)
+	const quickLogTypes = activityTypeOptions(locale).filter((opt) =>
+		['walk', 'meal', 'bathroom'].includes(opt.value)
 	);
 
 	function age(dob: string | null): string {
@@ -345,9 +345,9 @@
 			<Separator />
 
 			<div class="flex gap-2 px-5 py-4">
-				<button
-					type="button"
-					onclick={() => {
+				<ReminderCompleteButtons
+					allowLogEvent={false}
+					onDone={() => {
 						if (!selectedReminder) return;
 						const item = selectedReminder;
 						const form = dismissFormRegistry.get(item.id);
@@ -355,11 +355,7 @@
 						closeReminderDetail();
 						pendingDismiss.queue(item.id, form, item.title);
 					}}
-					class="inline-flex items-center gap-1.5 justify-center rounded-md bg-primary text-primary-foreground h-9 px-3 text-sm font-medium shadow hover:bg-primary/90 transition-colors"
-				>
-					<CheckCheck class="h-3.5 w-3.5" />
-					{t(locale, 'common.reminder.done')}
-				</button>
+				/>
 			</div>
 		</div>
 	</div>
@@ -412,18 +408,32 @@
 		</div>
 	</div>
 
+	<!-- 1b. Bio / About (reference) -->
+	{#if companion.bio}
+		<section>
+			<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+				{t(locale, 'page.dashboard.caretaker.cardAbout', { name: companion.name })}
+			</p>
+			<div class="prose prose-sm dark:prose-invert max-w-none">
+				{@html renderMarkdown(companion.bio)}
+			</div>
+		</section>
+	{/if}
+
 	<!-- 2. Today's tasks (on-shift only) -->
 	{#if data.isOnShift}
 		<section>
-			<h2
-				class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-1.5"
-			>
-				<Bell class="h-3.5 w-3.5" />
-				{t(locale, 'page.dashboard.caretaker.cardReminders')}
+			<div class="mb-3 flex items-center gap-1.5">
+				<h2
+					class="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+				>
+					<Bell class="h-3.5 w-3.5" />
+					{t(locale, 'page.dashboard.caretaker.cardReminders')}
+				</h2>
 				{#if upcomingReminders.length > 0}
-					<Badge variant="secondary" class="ml-1">{upcomingReminders.length}</Badge>
+					<Badge variant="secondary">{upcomingReminders.length}</Badge>
 				{/if}
-			</h2>
+			</div>
 			{#if upcomingReminders.length === 0}
 				<p class="text-sm italic text-muted-foreground">
 					{t(locale, 'page.dashboard.caretaker.remindersEmpty')}
@@ -480,7 +490,7 @@
 		<!-- 3. Quick log -->
 		<section>
 			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-				{t(locale, 'page.dashboard.caretaker.logActivity')}
+				{t(locale, 'page.dashboard.caretaker.sectionQuickLog')}
 			</h2>
 			<div class="flex gap-2">
 				{#each quickLogTypes as opt (opt.value)}
@@ -539,7 +549,19 @@
 		</section>
 	{/if}
 
-	<!-- 4b. Medications (reference) -->
+	<!-- 4b. Sitter notes (reference) -->
+	{#if companion.notesForSitter}
+		<section>
+			<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+				{t(locale, 'page.dashboard.caretaker.cardSitterNotes')}
+			</p>
+			<div class="prose prose-sm dark:prose-invert max-w-none">
+				{@html renderMarkdown(companion.notesForSitter)}
+			</div>
+		</section>
+	{/if}
+
+	<!-- 4c. Medications (reference) -->
 	{#if medications.length > 0}
 		<section>
 			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -23,7 +23,7 @@
 
 	const locale = getLocale();
 	const quickLogTypes = activityTypeOptions(locale).filter((t) =>
-		['walk', 'meal', 'medication'].includes(t.value)
+		['walk', 'meal', 'bathroom'].includes(t.value)
 	);
 
 	function age(dob: string | null): string {

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -125,6 +125,10 @@
 	}
 
 	let visibleOwners = $derived((owners ?? []).filter((o) => o.phone || o.email));
+	let hasVetInfo = $derived(!!(companion.vetName || companion.vetClinic || companion.vetPhone));
+	let hasEmergencyContact = $derived(
+		!!(companion.emergencyContactName || companion.emergencyContactPhone)
+	);
 
 	// Pending reminder dismissals
 	const undoDelayMs = $derived((data.reminderUndoSeconds ?? 0) * 1000);
@@ -512,20 +516,15 @@
 		</section>
 	{/if}
 
-	<!-- 4a. Schedules (reference) -->
+	<!-- 4a. Schedules (reference): 1–3 cards, evenly spaced across one row (flex-1 each) -->
 	{#if companion.feedingSchedule || companion.walkSchedule || companion.medicationSchedule}
-		{@const scheduleLabels = [
-			companion.feedingSchedule && t(locale, 'page.dashboard.caretaker.cardFeeding'),
-			companion.walkSchedule && t(locale, 'page.dashboard.caretaker.cardWalk'),
-			companion.medicationSchedule && t(locale, 'page.dashboard.caretaker.cardMedicationSchedule')
-		].filter(Boolean)}
 		<section>
 			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-				{scheduleLabels.join(' & ')}
+				{t(locale, 'page.dashboard.caretaker.sectionSchedules')}
 			</h2>
-			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+			<div class="flex flex-col sm:flex-row gap-4">
 				{#if companion.feedingSchedule}
-					<div class="rounded-xl border border-border bg-card p-4">
+					<div class="flex-1 min-w-0 rounded-xl border border-border bg-card p-4">
 						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
 							<span>🍖</span>
 							{t(locale, 'page.dashboard.caretaker.cardFeeding')}
@@ -536,7 +535,7 @@
 					</div>
 				{/if}
 				{#if companion.walkSchedule}
-					<div class="rounded-xl border border-border bg-card p-4">
+					<div class="flex-1 min-w-0 rounded-xl border border-border bg-card p-4">
 						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
 							<span>🦮</span>
 							{t(locale, 'page.dashboard.caretaker.cardWalk')}
@@ -547,7 +546,7 @@
 					</div>
 				{/if}
 				{#if companion.medicationSchedule}
-					<div class="rounded-xl border border-border bg-card p-4">
+					<div class="flex-1 min-w-0 rounded-xl border border-border bg-card p-4">
 						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
 							<span>💊</span>
 							{t(locale, 'page.dashboard.caretaker.cardMedicationSchedule')}
@@ -573,84 +572,84 @@
 		</section>
 	{/if}
 
-	<!-- 4c. Contacts (reference) -->
-	{#if companion.vetName || companion.vetClinic || companion.vetPhone || companion.emergencyContactName || companion.emergencyContactPhone}
+	<!-- 4c. Contacts (reference): vet + emergency prioritized, then household -->
+	{#if hasVetInfo || hasEmergencyContact || visibleOwners.length > 0}
 		<section>
 			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-				{t(locale, 'page.dashboard.caretaker.cardVetInfo')} &amp; {t(
-					locale,
-					'page.dashboard.caretaker.cardEmergencyContact'
-				)}
+				{t(locale, 'page.dashboard.caretaker.sectionContacts')}
 			</h2>
-			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-				{#if companion.vetName || companion.vetClinic || companion.vetPhone}
-					<div class="rounded-xl border border-border bg-card p-4 space-y-1 text-sm">
-						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
-							<span>🏥</span>
-							{t(locale, 'page.dashboard.caretaker.cardVetInfo')}
-						</p>
-						{#if companion.vetName}<p class="font-medium">{companion.vetName}</p>{/if}
-						{#if companion.vetClinic}<p class="text-muted-foreground">{companion.vetClinic}</p>{/if}
-						{#if companion.vetPhone}
-							📞 <a
-								href="tel:{companion.vetPhone}"
-								class="hover:underline font-medium text-primary-link">{companion.vetPhone}</a
-							>
+			<div class="space-y-4">
+				{#if hasVetInfo || hasEmergencyContact}
+					<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+						{#if hasVetInfo}
+							<div class="rounded-xl border border-border bg-card p-4 space-y-1 text-sm">
+								<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+									<span>🏥</span>
+									{t(locale, 'page.dashboard.caretaker.cardVetInfo')}
+								</p>
+								{#if companion.vetName}<p class="font-medium">{companion.vetName}</p>{/if}
+								{#if companion.vetClinic}<p class="text-muted-foreground">
+										{companion.vetClinic}
+									</p>{/if}
+								{#if companion.vetPhone}
+									📞 <a
+										href="tel:{companion.vetPhone}"
+										class="hover:underline font-medium text-primary-link">{companion.vetPhone}</a
+									>
+								{/if}
+							</div>
+						{/if}
+						{#if hasEmergencyContact}
+							<div class="rounded-xl border border-coral/30 bg-card p-4 space-y-1 text-sm">
+								<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+									<span>🚨</span>
+									{t(locale, 'page.dashboard.caretaker.cardEmergencyContact')}
+								</p>
+								{#if companion.emergencyContactName}
+									<p class="font-medium">{companion.emergencyContactName}</p>
+								{/if}
+								{#if companion.emergencyContactPhone}
+									📞 <a
+										href="tel:{companion.emergencyContactPhone}"
+										class="text-coral hover:underline font-medium text-base"
+										>{companion.emergencyContactPhone}</a
+									>
+								{/if}
+							</div>
 						{/if}
 					</div>
 				{/if}
-				{#if companion.emergencyContactName || companion.emergencyContactPhone}
-					<div class="rounded-xl border border-coral/30 bg-card p-4 space-y-1 text-sm">
+				{#if visibleOwners.length > 0}
+					<div class="rounded-xl border border-border bg-card p-4 space-y-3">
 						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
-							<span>🚨</span>
-							{t(locale, 'page.dashboard.caretaker.cardEmergencyContact')}
+							<span>🏠</span>
+							{visibleOwners.length === 1
+								? t(locale, 'page.dashboard.caretaker.householdOwner')
+								: t(locale, 'page.dashboard.caretaker.householdContacts')}
 						</p>
-						{#if companion.emergencyContactName}
-							<p class="font-medium">{companion.emergencyContactName}</p>
-						{/if}
-						{#if companion.emergencyContactPhone}
-							📞 <a
-								href="tel:{companion.emergencyContactPhone}"
-								class="text-coral hover:underline font-medium text-base"
-								>{companion.emergencyContactPhone}</a
-							>
-						{/if}
+						{#each visibleOwners as owner (owner.id)}
+							<div class="space-y-1">
+								<p class="font-semibold text-foreground">{owner.displayName}</p>
+								{#if owner.phone}
+									<a
+										href="tel:{owner.phone}"
+										class="flex items-center gap-2 text-sm text-primary-link hover:underline"
+									>
+										<Phone class="h-4 w-4" />{owner.phone}
+									</a>
+								{/if}
+								{#if owner.email}
+									<a
+										href="mailto:{owner.email}"
+										class="flex items-center gap-2 text-sm text-muted-foreground hover:underline"
+									>
+										<Mail class="h-4 w-4" />{owner.email}
+									</a>
+								{/if}
+							</div>
+						{/each}
 					</div>
 				{/if}
-			</div>
-		</section>
-	{/if}
-
-	<!-- 4d. Household owners (reference) -->
-	{#if visibleOwners.length > 0}
-		<section>
-			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-				{visibleOwners.length === 1
-					? t(locale, 'page.dashboard.caretaker.householdOwner')
-					: t(locale, 'page.dashboard.caretaker.householdContacts')}
-			</h2>
-			<div class="rounded-xl border border-border bg-card p-4 space-y-3">
-				{#each visibleOwners as owner (owner.id)}
-					<div class="space-y-1">
-						<p class="font-semibold text-foreground">{owner.displayName}</p>
-						{#if owner.phone}
-							<a
-								href="tel:{owner.phone}"
-								class="flex items-center gap-2 text-sm text-primary-link hover:underline"
-							>
-								<Phone class="h-4 w-4" />{owner.phone}
-							</a>
-						{/if}
-						{#if owner.email}
-							<a
-								href="mailto:{owner.email}"
-								class="flex items-center gap-2 text-sm text-muted-foreground hover:underline"
-							>
-								<Mail class="h-4 w-4" />{owner.email}
-							</a>
-						{/if}
-					</div>
-				{/each}
 			</div>
 		</section>
 	{/if}

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -3,25 +3,28 @@
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
-	import { Card, CardHeader, CardContent, CardTitle } from '$lib/components/ui/card/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Phone, Mail, X, Bell, CheckCheck } from '@lucide/svelte';
 	import { enhance } from '$app/forms';
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { renderMarkdown, stripMarkdown } from '$lib/markdown';
-	import { ACTIVITY_ICONS } from '$lib/i18n/labels';
+	import { ACTIVITY_ICONS, activityTypeOptions } from '$lib/i18n/labels';
 	import { tick } from 'svelte';
 	import { t, getLocale } from '$lib/i18n';
 	import { createPendingDismissals } from '$lib/pendingDismiss.svelte';
 	import { registerDismissForm } from '$lib/actions/registerDismissForm';
 	import { clearSubmittingFlag } from '$lib/clearSubmittingFlag';
 	import { formatRecurrence } from '$lib/reminderRecurrence';
+	import ReminderCompleteButtons from '$lib/components/reminders/ReminderCompleteButtons.svelte';
 
 	let { data }: { data: PageData } = $props();
 	let { companion, medications, todayActivity, latestWeight, owners, upcomingReminders } =
 		$derived(data);
 
 	const locale = getLocale();
+	const quickLogTypes = activityTypeOptions(locale).filter((t) =>
+		['walk', 'meal', 'medication'].includes(t.value)
+	);
 
 	function age(dob: string | null): string {
 		if (!dob) return 'Unknown age';
@@ -312,9 +315,7 @@
 						>{t(locale, 'page.dashboard.caretaker.modalLabelDue')}</span
 					>
 					<span
-						class={new Date(selectedReminder.dueAt) < new Date()
-							? 'text-destructive'
-							: 'text-foreground'}
+						class={new Date(selectedReminder.dueAt) < new Date() ? 'text-coral' : 'text-foreground'}
 					>
 						<LocalTime date={selectedReminder.dueAt} format="datetime" />
 					</span>
@@ -365,10 +366,13 @@
 {/if}
 
 <div class="space-y-5">
-	<!-- Companion card -->
-	<Card class="overflow-hidden">
-		<div class="bg-gradient-to-r from-moss-600 to-moss-700 px-6 py-5 text-white">
-			<div class="flex items-center gap-4">
+	<!-- 1. Companion hero -->
+	<div
+		class="rounded-2xl border bg-card overflow-hidden"
+		style="background: radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--color-teal) 20%, transparent), transparent 55%), radial-gradient(120% 140% at 0% 120%, color-mix(in srgb, var(--color-coral) 15%, transparent), transparent 55%), var(--color-card);"
+	>
+		<div class="px-5 py-6">
+			<div class="flex items-start gap-4">
 				<CompanionAvatar
 					companionId={companion.id}
 					avatarPath={companion.avatarPath}
@@ -376,329 +380,311 @@
 					size="lg"
 					onlightbox={avatarUrl ? () => (avatarLightboxOpen = true) : undefined}
 				/>
-				<div>
-					<h1 class="font-display text-2xl font-bold">{companion.name}</h1>
-					<p class="text-moss-100 text-sm">
+				<div class="flex-1 min-w-0">
+					<h1 class="font-display text-2xl font-bold text-foreground leading-tight">
+						{companion.name}
+					</h1>
+					<p class="text-sm text-muted-foreground mt-0.5">
 						{companion.breed ?? t(locale, 'page.dashboard.mixedBreed')} · {age(
 							companion.dob
 						)}{companion.sex ? ` · ${companion.sex}` : ''}
 					</p>
 					{#if companion.microchip}
-						<p class="text-moss-200 text-xs mt-1">
+						<p class="text-xs text-muted-foreground mt-1">
 							{t(locale, 'page.dashboard.caretaker.microchip', { id: companion.microchip })}
 						</p>
 					{/if}
+					{#if latestWeight}
+						<div class="mt-2 flex items-baseline gap-1">
+							<span class="text-base font-bold text-foreground"
+								>{latestWeight.weight}<span class="text-xs font-normal ml-0.5 text-muted-foreground"
+									>{latestWeight.unit}</span
+								></span
+							>
+							<span class="text-xs text-muted-foreground">
+								· {t(locale, 'page.dashboard.caretaker.weightAsOf')}
+								<LocalTime date={latestWeight.recordedAt} /></span
+							>
+						</div>
+					{/if}
 				</div>
 			</div>
 		</div>
-	</Card>
-
-	<!-- Latest weight (read-only) -->
-	{#if latestWeight}
-		<div class="rounded-lg border border-border bg-card p-4">
-			<h3 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-				{t(locale, 'page.dashboard.caretaker.labelWeight')}
-			</h3>
-			<p class="text-2xl font-bold text-foreground">
-				{latestWeight.weight}<span class="text-sm font-normal ml-1 text-muted-foreground"
-					>{latestWeight.unit}</span
-				>
-			</p>
-			<p class="text-xs text-muted-foreground mt-1">
-				{t(locale, 'page.dashboard.caretaker.weightAsOf')}
-				<LocalTime date={latestWeight.recordedAt} />
-			</p>
-		</div>
-	{/if}
-
-	<!-- Schedules -->
-	<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-		{#if companion.feedingSchedule}
-			<Card>
-				<CardHeader class="pb-3">
-					<CardTitle class="font-semibold flex items-center gap-2">
-						<span>🍖</span>
-						{t(locale, 'page.dashboard.caretaker.cardFeeding')}
-					</CardTitle>
-				</CardHeader>
-				<CardContent>
-					<div class="prose prose-sm dark:prose-invert max-w-none">
-						{@html renderMarkdown(companion.feedingSchedule)}
-					</div>
-				</CardContent>
-			</Card>
-		{/if}
-		{#if companion.walkSchedule}
-			<Card>
-				<CardHeader class="pb-3">
-					<CardTitle class="font-semibold flex items-center gap-2">
-						<span>🦮</span>
-						{t(locale, 'page.dashboard.caretaker.cardWalk')}
-					</CardTitle>
-				</CardHeader>
-				<CardContent>
-					<div class="prose prose-sm dark:prose-invert max-w-none">
-						{@html renderMarkdown(companion.walkSchedule)}
-					</div>
-				</CardContent>
-			</Card>
-		{/if}
 	</div>
 
-	<!-- Medications -->
+	<!-- 2. Today's tasks (on-shift only) -->
+	{#if data.isOnShift}
+		<section>
+			<h2
+				class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-1.5"
+			>
+				<Bell class="h-3.5 w-3.5" />
+				{t(locale, 'page.dashboard.caretaker.cardReminders')}
+				{#if upcomingReminders.length > 0}
+					<Badge variant="secondary" class="ml-1">{upcomingReminders.length}</Badge>
+				{/if}
+			</h2>
+			{#if upcomingReminders.length === 0}
+				<p class="text-sm italic text-muted-foreground">
+					{t(locale, 'page.dashboard.caretaker.remindersEmpty')}
+				</p>
+			{:else}
+				<div class="space-y-1">
+					{#each upcomingReminders as reminder (reminder.id)}
+						{@const isOverdue = new Date(reminder.dueAt) < new Date()}
+						<div class="flex items-center gap-2 rounded-lg">
+							<button
+								type="button"
+								onclick={() => openReminderDetail(reminder)}
+								class="flex-1 flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-accent transition-colors text-left min-w-0"
+							>
+								<span class="truncate text-foreground">{reminder.title}</span>
+								{#if isOverdue}
+									<Badge variant="coral" class="shrink-0 text-xs"
+										>{t(locale, 'page.dashboard.caretaker.reminderOverdue')}</Badge
+									>
+								{/if}
+								<span
+									class="ml-auto shrink-0 text-xs {isOverdue
+										? 'text-coral'
+										: 'text-muted-foreground'}"
+								>
+									<LocalTime date={reminder.dueAt} format="datetime" />
+								</span>
+							</button>
+							<form
+								method="POST"
+								action="?/complete"
+								use:enhance={clearSubmittingFlag}
+								use:registerDismissForm={{
+									id: reminder.id,
+									registry: dismissFormRegistry
+								}}
+								class="flex items-center gap-1 shrink-0"
+							>
+								<input type="hidden" name="id" value={reminder.id} />
+								<ReminderCompleteButtons
+									allowLogEvent={false}
+									onDone={() => {
+										const form = dismissFormRegistry.get(reminder.id);
+										if (form) pendingDismiss.queue(reminder.id, form, reminder.title);
+									}}
+								/>
+							</form>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</section>
+
+		<!-- 3. Quick log -->
+		<section>
+			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+				{t(locale, 'page.dashboard.caretaker.logActivity')}
+			</h2>
+			<div class="flex gap-2">
+				{#each quickLogTypes as opt (opt.value)}
+					<a
+						href="/care/{companion.id}/log?type={opt.value}"
+						class="flex-1 flex flex-col items-center gap-1 rounded-xl border border-border bg-card p-3 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+					>
+						<span class="text-lg">{opt.icon}</span>
+						<span>{opt.label}</span>
+					</a>
+				{/each}
+				<a
+					href="/care/{companion.id}/log"
+					class="flex-1 flex flex-col items-center gap-1 rounded-xl border border-primary/30 bg-primary/5 p-3 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+				>
+					<span class="text-lg">+</span>
+					<span>{t(locale, 'page.dashboard.caretaker.logActivity')}</span>
+				</a>
+			</div>
+		</section>
+	{/if}
+
+	<!-- 4a. Schedules (reference) -->
+	{#if companion.feedingSchedule || companion.walkSchedule}
+		<section>
+			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+				{t(locale, 'page.dashboard.caretaker.cardFeeding')} &amp; {t(
+					locale,
+					'page.dashboard.caretaker.cardWalk'
+				)}
+			</h2>
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+				{#if companion.feedingSchedule}
+					<div class="rounded-xl border border-border bg-card p-4">
+						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+							<span>🍖</span>
+							{t(locale, 'page.dashboard.caretaker.cardFeeding')}
+						</p>
+						<div class="prose prose-sm dark:prose-invert max-w-none">
+							{@html renderMarkdown(companion.feedingSchedule)}
+						</div>
+					</div>
+				{/if}
+				{#if companion.walkSchedule}
+					<div class="rounded-xl border border-border bg-card p-4">
+						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+							<span>🦮</span>
+							{t(locale, 'page.dashboard.caretaker.cardWalk')}
+						</p>
+						<div class="prose prose-sm dark:prose-invert max-w-none">
+							{@html renderMarkdown(companion.walkSchedule)}
+						</div>
+					</div>
+				{/if}
+			</div>
+		</section>
+	{/if}
+
+	<!-- 4b. Medications (reference) -->
 	{#if medications.length > 0}
-		<Card>
-			<CardHeader class="pb-3">
-				<CardTitle class="font-semibold flex items-center gap-2">
-					<span>💊</span>
-					{t(locale, 'page.dashboard.caretaker.cardMedications')}
-				</CardTitle>
-			</CardHeader>
-			<CardContent class="space-y-3">
+		<section>
+			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+				💊 {t(locale, 'page.dashboard.caretaker.cardMedications')}
+			</h2>
+			<div class="rounded-xl border border-border bg-card divide-y divide-border">
 				{#each medications as med (med.id)}
-					<div class="flex gap-3 text-sm">
+					<div class="flex gap-3 text-sm px-4 py-3">
 						<div class="flex-1">
 							<p class="font-medium">{med.title}</p>
-							{#if med.notes}<div
+							{#if med.notes}
+								<div
 									class="prose prose-sm dark:prose-invert max-w-none mt-0.5 text-muted-foreground"
 								>
 									{@html renderMarkdown(med.notes)}
-								</div>{/if}
+								</div>
+							{/if}
 						</div>
 					</div>
 				{/each}
-			</CardContent>
-		</Card>
+			</div>
+		</section>
 	{/if}
 
-	<!-- Reminders (only visible when on shift) -->
-	{#if data.isOnShift}
-		<Card>
-			<CardHeader class="pb-3">
-				<CardTitle class="font-semibold flex items-center gap-2">
-					<Bell class="h-4 w-4" />
-					{t(locale, 'page.dashboard.caretaker.cardReminders')}
-					{#if upcomingReminders.length > 0}
-						<Badge variant="secondary" class="ml-auto">{upcomingReminders.length}</Badge>
-					{/if}
-				</CardTitle>
-			</CardHeader>
-			<CardContent class="pt-0">
-				{#if upcomingReminders.length === 0}
-					<p class="text-sm italic text-muted-foreground">
-						{t(locale, 'page.dashboard.caretaker.remindersEmpty')}
-					</p>
-				{:else}
-					<div class="space-y-1">
-						{#each upcomingReminders as reminder (reminder.id)}
-							{@const isOverdue = new Date(reminder.dueAt) < new Date()}
-							<div class="flex items-center gap-2 rounded-lg">
-								<button
-									type="button"
-									onclick={() => openReminderDetail(reminder)}
-									class="flex-1 flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-accent transition-colors text-left min-w-0"
-								>
-									<span class="truncate text-foreground">{reminder.title}</span>
-									{#if isOverdue}
-										<Badge variant="destructive" class="shrink-0 text-xs"
-											>{t(locale, 'page.dashboard.caretaker.reminderOverdue')}</Badge
-										>
-									{/if}
-									<span
-										class="ml-auto shrink-0 text-xs {isOverdue
-											? 'text-destructive'
-											: 'text-muted-foreground'}"
-									>
-										<LocalTime date={reminder.dueAt} format="datetime" />
-									</span>
-								</button>
-								<form
-									method="POST"
-									action="?/complete"
-									use:enhance={clearSubmittingFlag}
-									use:registerDismissForm={{
-										id: reminder.id,
-										registry: dismissFormRegistry
-									}}
-									class="flex items-center gap-1 shrink-0"
-								>
-									<input type="hidden" name="id" value={reminder.id} />
-									<button
-										type="button"
-										onclick={(e: MouseEvent) => {
-											const btn = e.currentTarget as HTMLButtonElement;
-											if (btn.form) {
-												pendingDismiss.queue(reminder.id, btn.form, reminder.title);
-											}
-										}}
-										class="inline-flex items-center gap-1 justify-center rounded-md h-9 px-3 text-sm font-medium bg-primary text-primary-foreground transition-colors hover:bg-primary/90 shrink-0"
-									>
-										<CheckCheck class="h-3.5 w-3.5" />
-										<span class="hidden sm:inline">{t(locale, 'common.reminder.done')}</span>
-									</button>
-								</form>
-							</div>
-						{/each}
+	<!-- 4c. Contacts (reference) -->
+	{#if companion.vetName || companion.vetClinic || companion.vetPhone || companion.emergencyContactName || companion.emergencyContactPhone}
+		<section>
+			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+				{t(locale, 'page.dashboard.caretaker.cardVetInfo')} &amp; {t(
+					locale,
+					'page.dashboard.caretaker.cardEmergencyContact'
+				)}
+			</h2>
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+				{#if companion.vetName || companion.vetClinic || companion.vetPhone}
+					<div class="rounded-xl border border-border bg-card p-4 space-y-1 text-sm">
+						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+							<span>🏥</span>
+							{t(locale, 'page.dashboard.caretaker.cardVetInfo')}
+						</p>
+						{#if companion.vetName}<p class="font-medium">{companion.vetName}</p>{/if}
+						{#if companion.vetClinic}<p class="text-muted-foreground">{companion.vetClinic}</p>{/if}
+						{#if companion.vetPhone}
+							📞 <a href="tel:{companion.vetPhone}" class="hover:underline font-medium text-primary"
+								>{companion.vetPhone}</a
+							>
+						{/if}
 					</div>
 				{/if}
-			</CardContent>
-		</Card>
+				{#if companion.emergencyContactName || companion.emergencyContactPhone}
+					<div class="rounded-xl border border-coral/30 bg-card p-4 space-y-1 text-sm">
+						<p class="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
+							<span>🚨</span>
+							{t(locale, 'page.dashboard.caretaker.cardEmergencyContact')}
+						</p>
+						{#if companion.emergencyContactName}
+							<p class="font-medium">{companion.emergencyContactName}</p>
+						{/if}
+						{#if companion.emergencyContactPhone}
+							📞 <a
+								href="tel:{companion.emergencyContactPhone}"
+								class="text-coral hover:underline font-medium text-base"
+								>{companion.emergencyContactPhone}</a
+							>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</section>
 	{/if}
 
-	<!-- Contacts -->
-	<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-		{#if companion.vetName || companion.vetClinic || companion.vetPhone}
-			<Card>
-				<CardHeader class="pb-3">
-					<CardTitle class="font-semibold flex items-center gap-2">
-						<span>🏥</span>
-						{t(locale, 'page.dashboard.caretaker.cardVetInfo')}
-					</CardTitle>
-				</CardHeader>
-				<CardContent class="space-y-1 text-sm">
-					{#if companion.vetName}<p class="font-medium">{companion.vetName}</p>{/if}
-					{#if companion.vetClinic}<p class="text-muted-foreground">{companion.vetClinic}</p>{/if}
-					{#if companion.vetPhone}
-						📞 <a href="tel:{companion.vetPhone}" class="hover:underline font-medium text-primary"
-							>{companion.vetPhone}</a
-						>
-					{/if}
-				</CardContent>
-			</Card>
-		{/if}
-		{#if companion.emergencyContactName || companion.emergencyContactPhone}
-			<Card class="border-destructive/30">
-				<CardHeader class="pb-3 bg-destructive/5 dark:bg-destructive/10 rounded-t-lg">
-					<CardTitle class="font-semibold flex items-center gap-2">
-						<span>🚨</span>
-						{t(locale, 'page.dashboard.caretaker.cardEmergencyContact')}
-					</CardTitle>
-				</CardHeader>
-				<CardContent class="space-y-1 text-sm">
-					{#if companion.emergencyContactName}
-						<p class="font-medium">{companion.emergencyContactName}</p>
-					{/if}
-					{#if companion.emergencyContactPhone}
-						📞 <a
-							href="tel:{companion.emergencyContactPhone}"
-							class="text-red-600 dark:text-red-400 hover:underline font-medium text-base"
-							>{companion.emergencyContactPhone}</a
-						>
-					{/if}
-				</CardContent>
-			</Card>
-		{/if}
-	</div>
-
-	<!-- Household contacts -->
+	<!-- 4d. Household owners (reference) -->
 	{#if visibleOwners.length > 0}
-		<div class="rounded-lg border border-border bg-card p-4 space-y-3">
-			<h3 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+		<section>
+			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
 				{visibleOwners.length === 1
 					? t(locale, 'page.dashboard.caretaker.householdOwner')
 					: t(locale, 'page.dashboard.caretaker.householdContacts')}
-			</h3>
-			{#each visibleOwners as owner (owner.id)}
-				<div class="space-y-1">
-					<p class="font-semibold text-foreground">{owner.displayName}</p>
-					{#if owner.phone}
-						<a
-							href="tel:{owner.phone}"
-							class="flex items-center gap-2 text-sm text-primary hover:underline"
-						>
-							<Phone class="h-4 w-4" />{owner.phone}
-						</a>
-					{/if}
-					{#if owner.email}
-						<a
-							href="mailto:{owner.email}"
-							class="flex items-center gap-2 text-sm text-muted-foreground hover:underline"
-						>
-							<Mail class="h-4 w-4" />{owner.email}
-						</a>
-					{/if}
-				</div>
-			{/each}
-		</div>
-	{/if}
-
-	<!-- Sitter notes -->
-	{#if companion.notesForSitter}
-		<Card>
-			<CardHeader class="pb-3">
-				<CardTitle class="font-semibold flex items-center gap-2">
-					<span>📌</span>
-					{t(locale, 'page.dashboard.caretaker.cardSitterNotes')}
-				</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<div class="prose prose-sm dark:prose-invert max-w-none">
-					{@html renderMarkdown(companion.notesForSitter)}
-				</div>
-			</CardContent>
-		</Card>
-	{/if}
-
-	<!-- About companion (bio) -->
-	{#if companion.bio?.trim()}
-		<div class="rounded-lg border border-border bg-card p-4">
-			<h3 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
-				{t(locale, 'page.dashboard.caretaker.cardAbout', { name: companion.name })}
-			</h3>
-			<div class="prose prose-sm dark:prose-invert max-w-none">
-				{@html renderMarkdown(companion.bio)}
-			</div>
-		</div>
-	{/if}
-
-	<!-- Today's activity (only visible when on shift) -->
-	{#if data.isOnShift}
-		<Card>
-			<CardHeader class="pb-3 flex flex-row items-center justify-between">
-				<CardTitle class="font-semibold flex items-center gap-2">
-					<span>📋</span>
-					{t(locale, 'page.dashboard.caretaker.cardTodayActivity')}
-				</CardTitle>
-				<a href="/care/{companion.id}/log" class="text-primary text-xs hover:underline"
-					>{t(locale, 'page.dashboard.caretaker.logActivity')}</a
-				>
-			</CardHeader>
-			<CardContent>
-				{#if todayActivity.length === 0}
-					<p class="text-sm italic text-muted-foreground">
-						{t(locale, 'page.dashboard.caretaker.activityEmpty')}
-					</p>
-				{:else}
+			</h2>
+			<div class="rounded-xl border border-border bg-card p-4 space-y-3">
+				{#each visibleOwners as owner (owner.id)}
 					<div class="space-y-1">
-						{#each todayActivity as event (event.id)}
-							<button
-								type="button"
-								onclick={() => openDetail(event)}
-								class="w-full rounded-lg px-2 py-1.5 hover:bg-accent transition-colors text-left"
+						<p class="font-semibold text-foreground">{owner.displayName}</p>
+						{#if owner.phone}
+							<a
+								href="tel:{owner.phone}"
+								class="flex items-center gap-2 text-sm text-primary hover:underline"
 							>
-								<div class="flex items-center gap-3 text-sm">
-									<span class="text-base shrink-0">{ACTIVITY_ICONS[event.type] ?? '📝'}</span>
-									<Badge variant="secondary" class="capitalize shrink-0">{event.type}</Badge>
-									{#if event.durationMinutes}
-										<span class="text-xs text-muted-foreground shrink-0"
-											>{event.durationMinutes} min</span
-										>
-									{/if}
-									{#if event.notes}
-										<span class="truncate text-muted-foreground text-xs"
-											>{stripMarkdown(event.notes)}</span
-										>
-									{/if}
-									<span class="ml-auto text-xs shrink-0 text-muted-foreground">
-										<LocalTime date={event.loggedAt} format="time" />
-									</span>
-								</div>
-								<ByLine user={event.logger} class="pl-8" />
-							</button>
-						{/each}
+								<Phone class="h-4 w-4" />{owner.phone}
+							</a>
+						{/if}
+						{#if owner.email}
+							<a
+								href="mailto:{owner.email}"
+								class="flex items-center gap-2 text-sm text-muted-foreground hover:underline"
+							>
+								<Mail class="h-4 w-4" />{owner.email}
+							</a>
+						{/if}
 					</div>
-				{/if}
-			</CardContent>
-		</Card>
+				{/each}
+			</div>
+		</section>
+	{/if}
+
+	<!-- 5. Today's activity -->
+	{#if data.isOnShift}
+		<section>
+			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+				📋 {t(locale, 'page.dashboard.caretaker.cardTodayActivity')}
+			</h2>
+			{#if todayActivity.length === 0}
+				<p class="text-sm italic text-muted-foreground">
+					{t(locale, 'page.dashboard.caretaker.activityEmpty')}
+				</p>
+			{:else}
+				<div class="space-y-1">
+					{#each todayActivity as event (event.id)}
+						<button
+							type="button"
+							onclick={() => openDetail(event)}
+							class="w-full rounded-lg px-2 py-1.5 hover:bg-accent transition-colors text-left"
+						>
+							<div class="flex items-center gap-3 text-sm">
+								<span class="text-base shrink-0">{ACTIVITY_ICONS[event.type] ?? '📝'}</span>
+								<Badge variant="secondary" class="capitalize shrink-0">{event.type}</Badge>
+								{#if event.durationMinutes}
+									<span class="text-xs text-muted-foreground shrink-0"
+										>{event.durationMinutes} min</span
+									>
+								{/if}
+								{#if event.notes}
+									<span class="truncate text-muted-foreground text-xs"
+										>{stripMarkdown(event.notes)}</span
+									>
+								{/if}
+								<span class="ml-auto text-xs shrink-0 text-muted-foreground">
+									<LocalTime date={event.loggedAt} format="time" />
+								</span>
+							</div>
+							<ByLine user={event.logger} class="pl-8" />
+						</button>
+					{/each}
+				</div>
+			{/if}
+		</section>
 	{/if}
 </div>

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -592,8 +592,9 @@
 						{#if companion.vetName}<p class="font-medium">{companion.vetName}</p>{/if}
 						{#if companion.vetClinic}<p class="text-muted-foreground">{companion.vetClinic}</p>{/if}
 						{#if companion.vetPhone}
-							📞 <a href="tel:{companion.vetPhone}" class="hover:underline font-medium text-primary"
-								>{companion.vetPhone}</a
+							📞 <a
+								href="tel:{companion.vetPhone}"
+								class="hover:underline font-medium text-primary-link">{companion.vetPhone}</a
 							>
 						{/if}
 					</div>
@@ -635,7 +636,7 @@
 						{#if owner.phone}
 							<a
 								href="tel:{owner.phone}"
-								class="flex items-center gap-2 text-sm text-primary hover:underline"
+								class="flex items-center gap-2 text-sm text-primary-link hover:underline"
 							>
 								<Phone class="h-4 w-4" />{owner.phone}
 							</a>

--- a/src/routes/(caretaker)/care/[companionId]/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/+page.svelte
@@ -411,9 +411,9 @@
 	<!-- 1b. Bio / About (reference) -->
 	{#if companion.bio}
 		<section>
-			<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
 				{t(locale, 'page.dashboard.caretaker.cardAbout', { name: companion.name })}
-			</p>
+			</h2>
 			<div class="prose prose-sm dark:prose-invert max-w-none">
 				{@html renderMarkdown(companion.bio)}
 			</div>
@@ -552,9 +552,9 @@
 	<!-- 4b. Sitter notes (reference) -->
 	{#if companion.notesForSitter}
 		<section>
-			<p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+			<h2 class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
 				{t(locale, 'page.dashboard.caretaker.cardSitterNotes')}
-			</p>
+			</h2>
 			<div class="prose prose-sm dark:prose-invert max-w-none">
 				{@html renderMarkdown(companion.notesForSitter)}
 			</div>

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -311,8 +311,8 @@
 			</div>
 		</div>
 
-		<!-- Write area -->
-		<Card class="overflow-hidden">
+		<!-- Write area: overflow-visible so the MarkdownTextarea "supported" popover isn't clipped -->
+		<Card class="overflow-visible">
 			<div class="border-b border-border/60 flex items-center justify-between px-4 py-2.5">
 				<span class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
 					>{t(locale, 'page.journal.caretaker.todaysNotes')}</span

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -263,7 +263,7 @@
 				{#if saveStatus === 'saving'}<span class="text-muted-foreground animate-pulse"
 						>{t(locale, 'page.journal.caretaker.savingStatus')}</span
 					>
-				{:else if saveStatus === 'saved'}<span class="text-teal-600 dark:text-teal-400"
+				{:else if saveStatus === 'saved'}<span class="text-teal"
 						>{t(locale, 'page.journal.caretaker.savedStatus')}</span
 					>
 				{:else if saveStatus === 'error'}<span class="text-destructive"

--- a/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/journal/+page.svelte
@@ -263,10 +263,10 @@
 				{#if saveStatus === 'saving'}<span class="text-muted-foreground animate-pulse"
 						>{t(locale, 'page.journal.caretaker.savingStatus')}</span
 					>
-				{:else if saveStatus === 'saved'}<span class="text-[hsl(var(--moss))]"
+				{:else if saveStatus === 'saved'}<span class="text-teal-600 dark:text-teal-400"
 						>{t(locale, 'page.journal.caretaker.savedStatus')}</span
 					>
-				{:else if saveStatus === 'error'}<span class="text-red-500"
+				{:else if saveStatus === 'error'}<span class="text-destructive"
 						>{t(locale, 'page.journal.caretaker.saveFailedStatus')}</span
 					>
 				{/if}
@@ -303,9 +303,7 @@
 						title={m.label}
 						aria-pressed={mood === m.value}
 						class="text-2xl leading-none p-2 rounded-xl transition-all
-						{mood === m.value
-							? 'bg-moss-100 dark:bg-moss-900 ring-1 ring-moss-300 dark:ring-moss-700'
-							: 'opacity-40 hover:opacity-80'}"
+						{mood === m.value ? 'bg-primary/10 ring-1 ring-primary/30' : 'opacity-40 hover:opacity-80'}"
 					>
 						{m.icon}
 					</button>
@@ -316,7 +314,7 @@
 		<!-- Write area -->
 		<Card class="overflow-hidden">
 			<div class="border-b border-border/60 flex items-center justify-between px-4 py-2.5">
-				<span class="text-sm font-medium text-muted-foreground"
+				<span class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
 					>{t(locale, 'page.journal.caretaker.todaysNotes')}</span
 				>
 				<span class="text-xs text-muted-foreground"
@@ -367,7 +365,7 @@
 			{#if uploadError}
 				<div
 					role="alert"
-					class="mx-4 my-3 rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
+					class="mx-4 my-3 rounded-lg bg-destructive/10 border border-destructive/30 px-4 py-3 text-sm text-destructive"
 				>
 					{uploadError}
 				</div>
@@ -424,7 +422,7 @@
 											aria-label={t(locale, 'aria.deleteMedia')}
 											class="absolute top-1 right-1 bg-black/60 text-white rounded-full w-6 h-6 text-xs
 											flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100
-											hover:bg-red-600 transition-all"
+											hover:bg-destructive transition-all"
 										>
 											<Trash2 class="h-3 w-3" />
 										</button>

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.server.ts
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.server.ts
@@ -2,7 +2,7 @@ import { error, fail } from '@sveltejs/kit';
 import type { PageServerLoad, Actions } from './$types';
 import { t } from '$lib/i18n';
 import { db, schema } from '$lib/server/db';
-import { eq, and, gte } from 'drizzle-orm';
+import { eq, and, gte, inArray } from 'drizzle-orm';
 import { generateId } from '$lib/server/utils';
 import { parseDailyEventType } from '$lib/server/validation';
 import { getShiftStatus } from '$lib/server/shifts';
@@ -61,15 +61,49 @@ export const actions: Actions = {
 
 		if (!type) return fail(400, { error: t(locals.locale, 'error.typeRequired') });
 
-		await db.insert(schema.dailyEvents).values({
-			id: generateId(15),
-			companionId: params.companionId,
-			type,
-			notes,
-			durationMinutes,
-			loggedAt,
-			loggedBy: locals.user.id
-		});
+		// "Also log for" — only companions this caretaker is also assigned to, and active.
+		const additionalIds = data
+			.getAll('additionalCompanionIds')
+			.map((v) => String(v))
+			.filter((v) => v && v !== params.companionId);
+
+		let validAdditionalIds: string[] = [];
+		if (additionalIds.length > 0) {
+			const assignedRows = await db.query.companionCaretakers.findMany({
+				where: and(
+					eq(schema.companionCaretakers.userId, locals.user.id),
+					inArray(schema.companionCaretakers.companionId, additionalIds)
+				),
+				columns: { companionId: true }
+			});
+			const assignedIds = assignedRows.map((r) => r.companionId);
+			if (assignedIds.length > 0) {
+				const activeRows = await db.query.companions.findMany({
+					where: and(
+						inArray(schema.companions.id, assignedIds),
+						eq(schema.companions.isActive, true)
+					),
+					columns: { id: true }
+				});
+				validAdditionalIds = activeRows.map((r) => r.id);
+			}
+		}
+
+		const targetIds = [params.companionId, ...validAdditionalIds];
+		const eventGroupId = targetIds.length > 1 ? generateId(15) : null;
+
+		await db.insert(schema.dailyEvents).values(
+			targetIds.map((cid) => ({
+				id: generateId(15),
+				companionId: cid,
+				type,
+				notes,
+				durationMinutes,
+				loggedAt,
+				loggedBy: locals.user!.id,
+				eventGroupId
+			}))
+		);
 
 		return { success: true };
 	},

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
@@ -32,6 +32,12 @@
 	let selectedType = $state(initialType);
 	let duration = $state('');
 	let notes = $state('');
+
+	// "Also log for" — other companions this caretaker is assigned to (layout-filtered to active).
+	let siblingCompanions = $derived(
+		(data.companions ?? []).filter((c) => c.id !== data.companion.id)
+	);
+	let selectedAdditionalIds = $state<string[]>([]);
 	let hasDuration = $derived(
 		EVENT_TYPES.find((t) => t.value === selectedType)?.hasDuration ?? false
 	);
@@ -108,6 +114,7 @@
 							if (result.type === 'success') {
 								duration = '';
 								notes = '';
+								selectedAdditionalIds = [];
 							}
 						}}
 					class="space-y-4"
@@ -141,6 +148,40 @@
 							{/each}
 						</div>
 					</fieldset>
+
+					{#if siblingCompanions.length > 0}
+						<fieldset class="space-y-1.5 border-0 p-0 m-0">
+							<legend class="text-sm font-medium text-foreground"
+								>{t(locale, 'page.log.alsoLogFor')}</legend
+							>
+							<p class="text-xs text-muted-foreground">
+								{t(locale, 'page.log.alsoLogForHint')}
+							</p>
+							<div class="flex flex-wrap gap-2">
+								{#each siblingCompanions as sibling (sibling.id)}
+									{@const checked = selectedAdditionalIds.includes(sibling.id)}
+									<label class="cursor-pointer">
+										<input
+											type="checkbox"
+											name="additionalCompanionIds"
+											value={sibling.id}
+											bind:group={selectedAdditionalIds}
+											class="sr-only peer"
+										/>
+										<span
+											class="inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors
+											peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2
+											{checked
+												? 'bg-primary/10 border-primary/30 text-primary'
+												: 'border-border text-muted-foreground hover:text-foreground'}"
+										>
+											{sibling.name}
+										</span>
+									</label>
+								{/each}
+							</div>
+						</fieldset>
+					{/if}
 
 					{#if hasDuration}
 						<div class="space-y-1.5 animate-slide-up">

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PageData, ActionData } from './$types';
 	import { enhance } from '$app/forms';
+	import { page } from '$app/state';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import ByLine from '$lib/components/ByLine.svelte';
 	import MarkdownTextarea from '$lib/components/MarkdownTextarea.svelte';
@@ -20,7 +21,15 @@
 
 	const EVENT_TYPES = activityTypeOptions(locale);
 
-	let selectedType = $state('walk');
+	const TYPE_VALUES = EVENT_TYPES.map((t) => t.value);
+	type ActivityType = (typeof TYPE_VALUES)[number];
+	const initialType = (() => {
+		const q = page.url.searchParams.get('type');
+		return q && (TYPE_VALUES as string[]).includes(q)
+			? (q as ActivityType)
+			: ('walk' as ActivityType);
+	})();
+	let selectedType = $state(initialType);
 	let duration = $state('');
 	let notes = $state('');
 	let hasDuration = $derived(
@@ -68,7 +77,7 @@
 	{:else}
 		{#if form?.success}
 			<div
-				class="rounded-lg bg-moss-50 dark:bg-moss-950 border border-moss-200 dark:border-moss-800 px-4 py-3 text-sm text-moss-700 dark:text-moss-300 animate-fade-in"
+				class="rounded-lg border border-teal/30 bg-teal/10 px-4 py-3 text-sm text-teal animate-fade-in"
 			>
 				{t(locale, 'page.log.activityLogged')}
 			</div>
@@ -77,7 +86,7 @@
 		{#if form?.error}
 			<div
 				role="alert"
-				class="rounded-lg bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-300"
+				class="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
 			>
 				{form.error}
 			</div>

--- a/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
+++ b/src/routes/(caretaker)/care/[companionId]/log/+page.svelte
@@ -113,9 +113,11 @@
 					class="space-y-4"
 				>
 					<!-- Activity type pills -->
-					<div class="space-y-2">
-						<Label>{t(locale, 'page.log.activityLabel')}</Label>
-						<div class="grid grid-cols-3 gap-2">
+					<fieldset class="space-y-2 border-0 p-0 m-0">
+						<legend class="text-sm font-medium text-foreground"
+							>{t(locale, 'page.log.activityLabel')}</legend
+						>
+						<div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
 							{#each EVENT_TYPES as t (t.value)}
 								<label class="cursor-pointer">
 									<input
@@ -123,11 +125,12 @@
 										name="type"
 										value={t.value}
 										bind:group={selectedType}
-										class="sr-only"
+										class="sr-only peer"
 									/>
 									<span
 										class="flex items-center justify-center gap-1 rounded-xl border px-3 py-3
 									text-sm font-medium transition-all text-center
+									peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2
 									{selectedType === t.value
 											? 'bg-primary/10 border-primary/30 text-primary shadow-sm'
 											: 'border-border text-muted-foreground hover:border-border hover:bg-accent hover:text-accent-foreground'}"
@@ -137,7 +140,7 @@
 								</label>
 							{/each}
 						</div>
-					</div>
+					</fieldset>
 
 					{#if hasDuration}
 						<div class="space-y-1.5 animate-slide-up">

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -5,14 +5,12 @@
 	import { Select } from '$lib/components/ui/select/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import AccountAvatar from '$lib/components/AccountAvatar.svelte';
 	import ReminderUndoCard from '$lib/components/settings/ReminderUndoCard.svelte';
 	import NotificationsCard from '$lib/components/settings/NotificationsCard.svelte';
-	import { Calendar } from '@lucide/svelte';
 	import { SvelteDate } from 'svelte/reactivity';
 	import { t, getLocale, SUPPORTED_LOCALES, LOCALE_LABELS, type MessageKey } from '$lib/i18n';
 	import { applyTheme, saveTheme, THEMES, THEME_ICONS, type Theme } from '$lib/theme';
@@ -86,7 +84,7 @@
 	<title>{t(locale, 'page.settings.title')} | EinVault</title>
 </svelte:head>
 
-<div class="max-w-lg mx-auto space-y-6">
+<div class="max-w-lg mx-auto space-y-8">
 	<div>
 		<h1 class="font-display text-2xl font-bold text-foreground">
 			{t(locale, 'page.settings.title')}
@@ -94,338 +92,166 @@
 		<p class="text-sm mt-1 text-muted-foreground">{t(locale, 'page.settings.subtitle')}</p>
 	</div>
 
-	<Card>
-		<CardHeader>
-			<CardTitle>{t(locale, 'page.settings.accountCard')}</CardTitle>
-		</CardHeader>
-		<CardContent>
-			{#if form?.accountSuccess}
-				<Alert variant="success" class="mb-4">
-					<AlertDescription>{t(locale, 'page.settings.accountUpdated')}</AlertDescription>
-				</Alert>
-			{/if}
-			{#if form?.accountError}
-				<Alert variant="destructive" class="mb-4">
-					<AlertDescription>{form.accountError}</AlertDescription>
-				</Alert>
-			{/if}
+	<!-- APPEARANCE -->
+	<section aria-labelledby="section-appearance">
+		<p
+			id="section-appearance"
+			class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3"
+		>
+			{t(locale, 'page.settings.appearanceCard')}
+		</p>
+		<div class="flex rounded-md border border-border p-0.5 gap-0.5 bg-muted">
+			{#each THEMES as theme (theme)}
+				{@const Icon = THEME_ICONS[theme]}
+				<button
+					type="button"
+					onclick={() => setTheme(theme)}
+					aria-label="{theme.charAt(0).toUpperCase() + theme.slice(1)} mode"
+					aria-pressed={currentTheme === theme}
+					class="flex-1 flex items-center justify-center gap-1.5 rounded px-3 py-2 text-sm transition-all {currentTheme ===
+					theme
+						? 'bg-background text-foreground shadow-sm'
+						: 'text-muted-foreground hover:text-foreground'}"
+				>
+					<Icon class="h-4 w-4 shrink-0" />
+					<span>{theme.charAt(0).toUpperCase() + theme.slice(1)}</span>
+				</button>
+			{/each}
+		</div>
+	</section>
 
-			<AccountAvatar
-				userId={data.user?.id ?? ''}
-				displayName={data.user?.displayName ?? ''}
-				avatarPath={data.user?.avatarPath}
-				immichEnabled={data.immichEnabled}
-			/>
+	<!-- LANGUAGE -->
+	<section aria-labelledby="section-language">
+		<p
+			id="section-language"
+			class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3"
+		>
+			{t(locale, 'page.settings.languageCard')}
+		</p>
+		<p class="text-sm text-muted-foreground mb-3">
+			{t(locale, 'page.settings.languageDescription')}
+		</p>
+		<form
+			method="POST"
+			action="?/locale"
+			bind:this={localeForm}
+			use:enhance={() => {
+				return async () => {
+					window.location.reload();
+				};
+			}}
+		>
+			<div class="max-w-[200px]">
+				<Select
+					name="locale"
+					value={data.user?.locale ?? 'en'}
+					onchange={() => localeForm.requestSubmit()}
+				>
+					{#each SUPPORTED_LOCALES as loc (loc)}
+						<option value={loc}>{LOCALE_LABELS[loc]}</option>
+					{/each}
+				</Select>
+			</div>
+		</form>
+	</section>
 
-			<form
-				method="POST"
-				action="?/account"
-				use:enhance={() =>
-					async ({ update }) =>
-						update({ reset: false })}
-				class="space-y-4"
+	<!-- SHIFTS -->
+	<section id="shifts" aria-labelledby="section-shifts">
+		<div class="flex items-center gap-2 mb-3">
+			<p
+				id="section-shifts"
+				class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
 			>
-				<div class="space-y-1.5">
-					<Label for="displayName">{t(locale, 'page.settings.labelDisplayName')}</Label>
-					<Input
-						id="displayName"
-						name="displayName"
-						type="text"
-						autocomplete="name"
-						value={data.user?.displayName ?? ''}
-						required
-					/>
-				</div>
+				{t(locale, 'page.settings.shiftsCard')}
+			</p>
+			{#if data.upcomingShifts.length > 0}
+				<Badge variant="secondary" class="tabular-nums">{data.upcomingShifts.length}</Badge>
+			{/if}
+		</div>
 
-				<div class="space-y-1.5">
-					<Label for="username">{t(locale, 'page.settings.labelUsername')}</Label>
-					<Input
-						id="username"
-						name="username"
-						type="text"
-						value={data.user?.username ?? ''}
-						required
-						autocomplete="username"
-					/>
-				</div>
-
-				<div class="space-y-1.5">
-					<Label for="email">
-						{t(locale, 'page.settings.labelEmail')}
-						<span class="text-muted-foreground font-normal"
-							>{t(locale, 'page.settings.optional')}</span
-						>
-					</Label>
-					<Input
-						id="email"
-						name="email"
-						type="email"
-						value={data.user?.email ?? ''}
-						autocomplete="email"
-						placeholder="jet@black.com"
-					/>
-				</div>
-
-				<div class="space-y-1.5">
-					<Label for="phone">
-						{t(locale, 'page.settings.labelPhone')}
-						<span class="text-muted-foreground font-normal"
-							>{t(locale, 'page.settings.optional')}</span
-						>
-					</Label>
-					<Input
-						id="phone"
-						name="phone"
-						type="tel"
-						value={data.user?.phone ?? ''}
-						autocomplete="tel"
-						placeholder={t(locale, 'common.placeholderPhone')}
-					/>
-				</div>
-
-				<div>
-					<button
-						type="button"
-						onclick={() => (showPasswordFields = !showPasswordFields)}
-						class="text-sm text-primary hover:underline"
-					>
-						{showPasswordFields
-							? t(locale, 'page.settings.cancelPasswordChange')
-							: t(locale, 'page.settings.changePassword')}
-					</button>
-				</div>
-
-				{#if showPasswordFields}
-					<input
-						type="text"
-						autocomplete="username"
-						value={data.user?.username ?? ''}
-						readonly
-						tabindex="-1"
-						aria-hidden="true"
-						class="sr-only"
-					/>
-					<div class="space-y-4 animate-slide-up border-t border-border pt-4">
-						<div class="space-y-1.5">
-							<Label for="currentPassword">{t(locale, 'page.settings.labelCurrentPassword')}</Label>
-							<Input
-								id="currentPassword"
-								name="currentPassword"
-								type="password"
-								placeholder="••••••••"
-								autocomplete="current-password"
-							/>
-						</div>
-						<div class="space-y-1.5">
-							<Label for="newPassword">{t(locale, 'page.settings.labelNewPassword')}</Label>
-							<Input
-								id="newPassword"
-								name="newPassword"
-								type="password"
-								placeholder="••••••••"
-								minlength={8}
-								autocomplete="new-password"
-							/>
-						</div>
-						<div class="space-y-1.5">
-							<Label for="confirmPassword">{t(locale, 'page.settings.labelConfirmPassword')}</Label>
-							<Input
-								id="confirmPassword"
-								name="confirmPassword"
-								type="password"
-								placeholder="••••••••"
-								minlength={8}
-								autocomplete="new-password"
-							/>
+		{#if data.upcomingShifts.length === 0}
+			<p class="text-sm italic text-muted-foreground">
+				{t(locale, 'page.settings.noUpcomingShifts')}
+			</p>
+		{:else}
+			<div class="space-y-4">
+				{#each grouped() as group (group.key)}
+					<div>
+						<h3 class="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1.5">
+							{group.label}
+						</h3>
+						<div class="space-y-1">
+							{#each group.shifts as shift (shift.id)}
+								{@const isActive = group.key === 'active'}
+								{@const isNext =
+									!isActive && shift.id === data.upcomingShifts.find((s) => s.startAt > now)?.id}
+								<div
+									class="rounded-lg overflow-hidden {isActive
+										? 'bg-teal/10 ring-1 ring-teal/30'
+										: isNext
+											? 'ring-1 ring-primary/20'
+											: ''}"
+								>
+									<button
+										type="button"
+										onclick={() =>
+											(expandedShiftId = expandedShiftId === shift.id ? null : shift.id)}
+										class="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-left {shift.notes
+											? 'hover:bg-accent/50 transition-colors'
+											: 'cursor-default'}"
+									>
+										{#if isActive}
+											<span
+												class="inline-block w-2 h-2 rounded-full bg-teal shrink-0"
+												aria-hidden="true"
+											></span>
+										{/if}
+										<div class="flex-1 min-w-0">
+											<span class={isActive ? 'text-teal font-medium' : 'text-foreground'}>
+												<LocalTime date={shift.startAt} format="datetime" />
+											</span>
+											<span class="text-muted-foreground mx-1">–</span>
+											{#if shift.startAt.toDateString() === shift.endAt.toDateString()}
+												<span class="text-muted-foreground"
+													><LocalTime date={shift.endAt} format="time" /></span
+												>
+											{:else}
+												<span class="text-muted-foreground"
+													><LocalTime date={shift.endAt} format="datetime" /></span
+												>
+											{/if}
+										</div>
+										<Badge variant="secondary" class="shrink-0 tabular-nums"
+											>{shiftDuration(shift)}</Badge
+										>
+									</button>
+									{#if shift.notes && expandedShiftId === shift.id}
+										<div class="px-3 pb-2.5 text-xs text-muted-foreground animate-slide-up">
+											{shift.notes}
+										</div>
+									{/if}
+								</div>
+							{/each}
 						</div>
 					</div>
-				{/if}
-
-				<Button type="submit">{t(locale, 'page.settings.saveChanges')}</Button>
-			</form>
-		</CardContent>
-	</Card>
-
-	<!-- Language -->
-	<Card>
-		<CardHeader>
-			<CardTitle>{t(locale, 'page.settings.languageCard')}</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<p class="text-sm text-muted-foreground mb-3">
-				{t(locale, 'page.settings.languageDescription')}
-			</p>
-			<form
-				method="POST"
-				action="?/locale"
-				bind:this={localeForm}
-				use:enhance={() => {
-					return async () => {
-						window.location.reload();
-					};
-				}}
-			>
-				<div class="max-w-[200px]">
-					<Select
-						name="locale"
-						value={data.user?.locale ?? 'en'}
-						onchange={() => localeForm.requestSubmit()}
-					>
-						{#each SUPPORTED_LOCALES as loc (loc)}
-							<option value={loc}>{LOCALE_LABELS[loc]}</option>
-						{/each}
-					</Select>
-				</div>
-			</form>
-		</CardContent>
-	</Card>
-
-	<Card>
-		<CardHeader>
-			<CardTitle>{t(locale, 'page.settings.appearanceCard')}</CardTitle>
-		</CardHeader>
-		<CardContent>
-			<div class="flex rounded-md border border-border p-0.5 gap-0.5 bg-muted">
-				{#each THEMES as theme (theme)}
-					{@const Icon = THEME_ICONS[theme]}
-					<button
-						type="button"
-						onclick={() => setTheme(theme)}
-						aria-label="{theme.charAt(0).toUpperCase() + theme.slice(1)} mode"
-						aria-pressed={currentTheme === theme}
-						class="flex-1 flex items-center justify-center gap-1.5 rounded px-3 py-2 text-sm transition-all {currentTheme ===
-						theme
-							? 'bg-background text-foreground shadow-sm'
-							: 'text-muted-foreground hover:text-foreground'}"
-					>
-						<Icon class="h-4 w-4 shrink-0" />
-						<span>{theme.charAt(0).toUpperCase() + theme.slice(1)}</span>
-					</button>
 				{/each}
 			</div>
-		</CardContent>
-	</Card>
+		{/if}
+	</section>
 
-	<ReminderUndoCard
-		currentValue={data.user?.reminderUndoSeconds ?? null}
-		defaultSeconds={data.reminderUndoDefault}
-		successMessage={form?.reminderUndoSuccess
-			? t(locale, 'page.settings.reminderUndoUpdated')
-			: undefined}
-		errorMessage={form?.reminderUndoError}
-	/>
-
-	{#if data.mailEnabled || data.ntfyEnabled}
-		<NotificationsCard
-			reminderEnabled={data.user?.notifyReminderEmail ?? false}
-			shiftEnabled={data.user?.notifyShiftEmail ?? false}
-			hasEmail={Boolean(data.user?.email)}
-			mailEnabled={data.mailEnabled}
-			ntfyEnabled={data.ntfyEnabled}
-			ntfyTopic={data.user?.ntfyTopic ?? null}
-			successMessage={form?.notificationsSuccess
-				? t(locale, 'page.settings.notificationsUpdated')
-				: undefined}
-			errorMessage={form?.notificationsError}
-			testSuccessMessage={form?.notificationsTestSuccess
-				? t(locale, 'page.settings.testSent')
-				: undefined}
-			testErrorMessage={form?.notificationsTestError}
-		/>
-	{/if}
-
-	<!-- My Shifts -->
-	<Card id="shifts">
-		<CardHeader class="pb-3">
-			<CardTitle class="font-semibold flex items-center gap-2">
-				<Calendar class="h-4 w-4" />
-				{t(locale, 'page.settings.shiftsCard')}
-				{#if data.upcomingShifts.length > 0}
-					<Badge variant="secondary" class="ml-auto">{data.upcomingShifts.length}</Badge>
-				{/if}
-			</CardTitle>
-		</CardHeader>
-		<CardContent class="pt-0">
-			{#if data.upcomingShifts.length === 0}
-				<p class="text-sm italic text-muted-foreground">
-					{t(locale, 'page.settings.noUpcomingShifts')}
-				</p>
-			{:else}
-				<div class="space-y-4">
-					{#each grouped() as group (group.key)}
-						<div>
-							<h3
-								class="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1.5"
-							>
-								{group.label}
-							</h3>
-							<div class="space-y-1">
-								{#each group.shifts as shift (shift.id)}
-									{@const isActive = group.key === 'active'}
-									{@const isNext =
-										!isActive && shift.id === data.upcomingShifts.find((s) => s.startAt > now)?.id}
-									<div
-										class="rounded-lg overflow-hidden {isActive
-											? 'bg-teal/10 ring-1 ring-teal/30'
-											: isNext
-												? 'ring-1 ring-primary/20'
-												: ''}"
-									>
-										<button
-											type="button"
-											onclick={() =>
-												(expandedShiftId = expandedShiftId === shift.id ? null : shift.id)}
-											class="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-left {shift.notes
-												? 'hover:bg-accent/50 transition-colors'
-												: 'cursor-default'}"
-										>
-											{#if isActive}
-												<span
-													class="inline-block w-2 h-2 rounded-full bg-teal shrink-0"
-													aria-hidden="true"
-												></span>
-											{/if}
-											<div class="flex-1 min-w-0">
-												<span class={isActive ? 'text-teal font-medium' : 'text-foreground'}>
-													<LocalTime date={shift.startAt} format="datetime" />
-												</span>
-												<span class="text-muted-foreground mx-1">–</span>
-												{#if shift.startAt.toDateString() === shift.endAt.toDateString()}
-													<span class="text-muted-foreground"
-														><LocalTime date={shift.endAt} format="time" /></span
-													>
-												{:else}
-													<span class="text-muted-foreground"
-														><LocalTime date={shift.endAt} format="datetime" /></span
-													>
-												{/if}
-											</div>
-											<Badge variant="secondary" class="shrink-0 tabular-nums"
-												>{shiftDuration(shift)}</Badge
-											>
-										</button>
-										{#if shift.notes && expandedShiftId === shift.id}
-											<div class="px-3 pb-2.5 text-xs text-muted-foreground animate-slide-up">
-												{shift.notes}
-											</div>
-										{/if}
-									</div>
-								{/each}
-							</div>
-						</div>
-					{/each}
-				</div>
-			{/if}
-		</CardContent>
-	</Card>
-
+	<!-- CALENDAR FEED -->
 	{#if data.calendarFeedAvailable}
-		<Card>
-			<CardHeader>
-				<CardTitle>{t(locale, 'settings.calendar.title')}</CardTitle>
-			</CardHeader>
-			<CardContent class="space-y-4">
-				<p class="text-sm text-muted-foreground">{t(locale, 'settings.calendar.description')}</p>
+		<section aria-labelledby="section-calendar">
+			<p
+				id="section-calendar"
+				class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3"
+			>
+				{t(locale, 'settings.calendar.title')}
+			</p>
+			<div class="space-y-4">
+				<p class="text-sm text-muted-foreground">
+					{t(locale, 'settings.calendar.description')}
+				</p>
 
 				{#if form?.calendarToken}
 					<div class="space-y-2">
@@ -492,16 +318,197 @@
 				{/if}
 
 				<p class="text-xs text-muted-foreground">{t(locale, 'settings.calendar.help')}</p>
-			</CardContent>
-		</Card>
+			</div>
+		</section>
 	{/if}
 
-	<Card>
-		<CardContent class="pt-4">
-			<div class="flex items-center justify-between text-sm">
-				<span class="text-muted-foreground">{t(locale, 'page.settings.roleLabel')}</span>
-				<Badge variant="moss">{t(locale, 'enum.role.caretaker')}</Badge>
+	<!-- NOTIFICATIONS -->
+	{#if data.mailEnabled || data.ntfyEnabled}
+		<NotificationsCard
+			reminderEnabled={data.user?.notifyReminderEmail ?? false}
+			shiftEnabled={data.user?.notifyShiftEmail ?? false}
+			hasEmail={Boolean(data.user?.email)}
+			mailEnabled={data.mailEnabled}
+			ntfyEnabled={data.ntfyEnabled}
+			ntfyTopic={data.user?.ntfyTopic ?? null}
+			successMessage={form?.notificationsSuccess
+				? t(locale, 'page.settings.notificationsUpdated')
+				: undefined}
+			errorMessage={form?.notificationsError}
+			testSuccessMessage={form?.notificationsTestSuccess
+				? t(locale, 'page.settings.testSent')
+				: undefined}
+			testErrorMessage={form?.notificationsTestError}
+		/>
+	{/if}
+
+	<!-- REMINDER UNDO -->
+	<ReminderUndoCard
+		currentValue={data.user?.reminderUndoSeconds ?? null}
+		defaultSeconds={data.reminderUndoDefault}
+		successMessage={form?.reminderUndoSuccess
+			? t(locale, 'page.settings.reminderUndoUpdated')
+			: undefined}
+		errorMessage={form?.reminderUndoError}
+	/>
+
+	<!-- PROFILE / ACCOUNT -->
+	<section aria-labelledby="section-profile">
+		<p
+			id="section-profile"
+			class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3"
+		>
+			{t(locale, 'page.settings.accountCard')}
+		</p>
+
+		{#if form?.accountSuccess}
+			<Alert variant="success" class="mb-4">
+				<AlertDescription>{t(locale, 'page.settings.accountUpdated')}</AlertDescription>
+			</Alert>
+		{/if}
+		{#if form?.accountError}
+			<Alert variant="destructive" class="mb-4">
+				<AlertDescription>{form.accountError}</AlertDescription>
+			</Alert>
+		{/if}
+
+		<AccountAvatar
+			userId={data.user?.id ?? ''}
+			displayName={data.user?.displayName ?? ''}
+			avatarPath={data.user?.avatarPath}
+			immichEnabled={data.immichEnabled}
+		/>
+
+		<form
+			method="POST"
+			action="?/account"
+			use:enhance={() =>
+				async ({ update }) =>
+					update({ reset: false })}
+			class="space-y-4"
+		>
+			<div class="space-y-1.5">
+				<Label for="displayName">{t(locale, 'page.settings.labelDisplayName')}</Label>
+				<Input
+					id="displayName"
+					name="displayName"
+					type="text"
+					autocomplete="name"
+					value={data.user?.displayName ?? ''}
+					required
+				/>
 			</div>
-		</CardContent>
-	</Card>
+
+			<div class="space-y-1.5">
+				<Label for="username">{t(locale, 'page.settings.labelUsername')}</Label>
+				<Input
+					id="username"
+					name="username"
+					type="text"
+					value={data.user?.username ?? ''}
+					required
+					autocomplete="username"
+				/>
+			</div>
+
+			<div class="space-y-1.5">
+				<Label for="email">
+					{t(locale, 'page.settings.labelEmail')}
+					<span class="text-muted-foreground font-normal"
+						>{t(locale, 'page.settings.optional')}</span
+					>
+				</Label>
+				<Input
+					id="email"
+					name="email"
+					type="email"
+					value={data.user?.email ?? ''}
+					autocomplete="email"
+					placeholder="jet@black.com"
+				/>
+			</div>
+
+			<div class="space-y-1.5">
+				<Label for="phone">
+					{t(locale, 'page.settings.labelPhone')}
+					<span class="text-muted-foreground font-normal"
+						>{t(locale, 'page.settings.optional')}</span
+					>
+				</Label>
+				<Input
+					id="phone"
+					name="phone"
+					type="tel"
+					value={data.user?.phone ?? ''}
+					autocomplete="tel"
+					placeholder={t(locale, 'common.placeholderPhone')}
+				/>
+			</div>
+
+			<div>
+				<button
+					type="button"
+					onclick={() => (showPasswordFields = !showPasswordFields)}
+					class="text-sm text-primary hover:underline"
+				>
+					{showPasswordFields
+						? t(locale, 'page.settings.cancelPasswordChange')
+						: t(locale, 'page.settings.changePassword')}
+				</button>
+			</div>
+
+			{#if showPasswordFields}
+				<input
+					type="text"
+					autocomplete="username"
+					value={data.user?.username ?? ''}
+					readonly
+					tabindex="-1"
+					aria-hidden="true"
+					class="sr-only"
+				/>
+				<div class="space-y-4 animate-slide-up border-t border-border pt-4">
+					<div class="space-y-1.5">
+						<Label for="currentPassword">{t(locale, 'page.settings.labelCurrentPassword')}</Label>
+						<Input
+							id="currentPassword"
+							name="currentPassword"
+							type="password"
+							placeholder="••••••••"
+							autocomplete="current-password"
+						/>
+					</div>
+					<div class="space-y-1.5">
+						<Label for="newPassword">{t(locale, 'page.settings.labelNewPassword')}</Label>
+						<Input
+							id="newPassword"
+							name="newPassword"
+							type="password"
+							placeholder="••••••••"
+							minlength={8}
+							autocomplete="new-password"
+						/>
+					</div>
+					<div class="space-y-1.5">
+						<Label for="confirmPassword">{t(locale, 'page.settings.labelConfirmPassword')}</Label>
+						<Input
+							id="confirmPassword"
+							name="confirmPassword"
+							type="password"
+							placeholder="••••••••"
+							minlength={8}
+							autocomplete="new-password"
+						/>
+					</div>
+				</div>
+			{/if}
+
+			<Button type="submit">{t(locale, 'page.settings.saveChanges')}</Button>
+		</form>
+
+		<div class="flex items-center justify-between text-sm mt-6 pt-4 border-t border-border">
+			<span class="text-muted-foreground">{t(locale, 'page.settings.roleLabel')}</span>
+			<Badge variant="secondary">{t(locale, 'enum.role.caretaker')}</Badge>
+		</div>
+	</section>
 </div>

--- a/tests/e2e/caretaker.spec.ts
+++ b/tests/e2e/caretaker.spec.ts
@@ -115,8 +115,9 @@ test.describe('caretaker', () => {
 
 	test('care page is action-first with a quick-log deep link', async ({ asCaretaker }) => {
 		await asCaretaker.goto(`/care/${BISCUIT}`);
-		// The quick-log tiles render "🦮 Walk" — scope to the care page links to avoid collision
-		const walkQuick = asCaretaker.getByRole('link', { name: /walk/i }).first();
+		// Scope to the quick-log section by its heading text to avoid collisions
+		const quickLogSection = asCaretaker.locator('section').filter({ hasText: 'Quick log' });
+		const walkQuick = quickLogSection.getByRole('link', { name: /walk/i });
 		await expect(walkQuick).toBeVisible({ timeout: 8_000 });
 		await walkQuick.click();
 		await expect(asCaretaker).toHaveURL(/\/log\?type=walk/, { timeout: 8_000 });

--- a/tests/e2e/caretaker.spec.ts
+++ b/tests/e2e/caretaker.spec.ts
@@ -123,15 +123,16 @@ test.describe('caretaker', () => {
 		await expect(asCaretaker).toHaveURL(/\/log\?type=walk/, { timeout: 8_000 });
 	});
 
-	test('care page shows schedules with a header reflecting present fields', async ({
+	test('care page shows a Schedules section with one card per set schedule', async ({
 		asCaretaker
 	}) => {
 		await asCaretaker.goto(`/care/${BISCUIT}`);
 		const schedules = asCaretaker.locator('section').filter({ hasText: 'Medication Schedule' });
-		// Walk schedule is unset, so the header lists only feeding + medication.
-		await expect(
-			schedules.getByRole('heading', { name: 'Feeding Schedule & Medication Schedule' })
-		).toBeVisible({ timeout: 8_000 });
+		await expect(schedules.getByRole('heading', { name: 'Schedules' })).toBeVisible({
+			timeout: 8_000
+		});
+		// Walk schedule is unset → only the feeding + medication cards render.
 		await expect(schedules.getByText('Heartworm chew monthly')).toBeVisible();
+		await expect(schedules.getByText('Morning kibble, evening kibble')).toBeVisible();
 	});
 });

--- a/tests/e2e/caretaker.spec.ts
+++ b/tests/e2e/caretaker.spec.ts
@@ -122,4 +122,16 @@ test.describe('caretaker', () => {
 		await walkQuick.click();
 		await expect(asCaretaker).toHaveURL(/\/log\?type=walk/, { timeout: 8_000 });
 	});
+
+	test('care page shows schedules with a header reflecting present fields', async ({
+		asCaretaker
+	}) => {
+		await asCaretaker.goto(`/care/${BISCUIT}`);
+		const schedules = asCaretaker.locator('section').filter({ hasText: 'Medication Schedule' });
+		// Walk schedule is unset, so the header lists only feeding + medication.
+		await expect(
+			schedules.getByRole('heading', { name: 'Feeding Schedule & Medication Schedule' })
+		).toBeVisible({ timeout: 8_000 });
+		await expect(schedules.getByText('Heartworm chew monthly')).toBeVisible();
+	});
 });

--- a/tests/e2e/caretaker.spec.ts
+++ b/tests/e2e/caretaker.spec.ts
@@ -112,4 +112,13 @@ test.describe('caretaker', () => {
 		// Must NOT be on the requested app route
 		await expect(asCaretaker).not.toHaveURL(new RegExp(`/${BISCUIT}/health`));
 	});
+
+	test('care page is action-first with a quick-log deep link', async ({ asCaretaker }) => {
+		await asCaretaker.goto(`/care/${BISCUIT}`);
+		// The quick-log tiles render "🦮 Walk" — scope to the care page links to avoid collision
+		const walkQuick = asCaretaker.getByRole('link', { name: /walk/i }).first();
+		await expect(walkQuick).toBeVisible({ timeout: 8_000 });
+		await walkQuick.click();
+		await expect(asCaretaker).toHaveURL(/\/log\?type=walk/, { timeout: 8_000 });
+	});
 });

--- a/tests/lib/seed.ts
+++ b/tests/lib/seed.ts
@@ -13,7 +13,12 @@ export const SEED = {
 	caretaker: { id: 'seed-caretaker', username: 'seed-caretaker', displayName: 'Seed Caretaker' },
 	resetUser: { id: 'seed-reset', username: 'seed-reset', displayName: 'Seed Reset' },
 	companions: {
-		biscuit: { id: 'seed-comp-biscuit', name: 'Biscuit' },
+		biscuit: {
+			id: 'seed-comp-biscuit',
+			name: 'Biscuit',
+			feedingSchedule: 'Morning kibble, evening kibble',
+			medicationSchedule: 'Heartworm chew monthly'
+		},
 		waffles: { id: 'seed-comp-waffles', name: 'Waffles' }
 	}
 } as const;


### PR DESCRIPTION
Fourth redesign sub-project. Redesigns the caretaker page bodies in the Companion design language, mobile-first, and removes the legacy `moss` tokens and raw red/teal palette still present in them. Stacks on SP3c (`redesign-sp3c-documents-profile`).

## Pages

- **Care overview** (`care/[companionId]`): action-first layout. Companion hero, then on-shift Today's tasks (shared `ReminderCompleteButtons` with undo) and Quick log deep-links, then reference sections, then today's activity.
- **Log activity** (`care/[companionId]/log`): soft type pills with keyboard focus rings, `?type=` prefill from the overview deep-links, teal success banner.
- **Journal** (`care/[companionId]/journal`): today-only write area, teal saved status.
- **Settings** (`care/settings`): de-carded into labeled sections.

## Follow-on changes in this branch

- **Medication schedule**: new per-companion field alongside feeding/walk (schema migration `0025`, edit form, server action). Shown in the overview's Schedules section.
- **Schedules / Contacts layout**: Schedules header simplified to "Schedules"; both Schedules and Contacts lay 1-3 cards out with `flex-1` so they spread evenly across one row, stacking on mobile. Vet info, emergency contact, and household owners merged into one Contacts section (vet/emergency prioritized). The old standalone medications block is removed.
- **Also-log-for**: the log form mirrors the member journal's multi-companion logging, shown only when the caretaker is assigned more than one companion; the server validates each extra companion is assigned to the caretaker and active.
- **Fixes**: markdown-help popover no longer clipped on the journal notes card; primary-colored phone links brightened in dark mode via a new `--primary-link` token; the header logo links to the active companion's overview rather than the first assigned companion.

## Tokens / i18n / tests

- All `moss`/`bark`/`sky` and raw red/teal usages removed from the caretaker pages (token definitions untouched).
- i18n added across all six locales.
- `tests/e2e/caretaker.spec.ts` extended (action-first sections, quick-log deep link, Schedules section). Seed gains feeding + medication schedules on Biscuit.

Gates: lint, check (0 errors), 193 unit, build, full e2e green (two unrelated search/calendar specs flaked under parallel load, pass in isolation).