### PR TITLE
Redesign SP5: admin pages

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -154,6 +154,15 @@
 			transform: translateY(0);
 		}
 	}
+
+	@keyframes slide-in-from-right {
+		from {
+			transform: translateX(100%);
+		}
+		to {
+			transform: translateX(0);
+		}
+	}
 }
 
 /* ============================================================
@@ -346,6 +355,11 @@
 		--tw-enter-translate-y: 1rem;
 	}
 
+	/* Right-edge slide-over (admin Manage drawer) */
+	.animate-slide-in-right {
+		animation: slide-in-from-right var(--tw-duration, 200ms) cubic-bezier(0.16, 1, 0.3, 1) both;
+	}
+
 	/* sm:slide-in-from-bottom-0 — zero vertical translate at sm breakpoint */
 	@media (min-width: 640px) {
 		.sm\:slide-in-from-bottom-0 {
@@ -357,7 +371,8 @@
 @media (prefers-reduced-motion: reduce) {
 	.animate-fade-in,
 	.animate-slide-up,
-	.animate-in {
+	.animate-in,
+	.animate-slide-in-right {
 		animation: none;
 	}
 

--- a/src/lib/components/admin/UserManageDrawer.svelte
+++ b/src/lib/components/admin/UserManageDrawer.svelte
@@ -75,8 +75,19 @@
 		return `${dt.getFullYear()}-${p(dt.getMonth() + 1)}-${p(dt.getDate())}T${p(dt.getHours())}:${p(dt.getMinutes())}`;
 	}
 
+	let triggerEl: HTMLElement | null = null;
+	let didFocus = false;
 	$effect(() => {
-		tick().then(() => dialogEl?.focus());
+		if (dialogEl && !didFocus) {
+			didFocus = true;
+			triggerEl = document.activeElement as HTMLElement | null;
+			tick().then(() => dialogEl?.focus());
+		}
+	});
+	$effect(() => {
+		return () => {
+			triggerEl?.focus();
+		};
 	});
 
 	function trapFocus(e: KeyboardEvent) {
@@ -386,6 +397,7 @@
 												variant="softDestructive"
 												size="sm"
 												class="h-7 gap-1.5 px-2 text-xs"
+												aria-label={t(locale, 'common.delete')}
 												onclick={() => {
 													deleteShiftId = shift.id;
 													confirmOpen = true;
@@ -474,6 +486,8 @@
 							update()}
 					class="flex gap-2"
 				>
+					<input type="hidden" name="userId" value={user.id} />
+					<Label for="np-{user.id}" class="sr-only">{t(locale, 'page.admin.labelPassword')}</Label>
 					<Input
 						id="np-{user.id}"
 						name="newPassword"
@@ -509,18 +523,16 @@
 			{/if}
 		</div>
 	</div>
+	<form bind:this={deleteShiftForm} method="POST" action="?/deleteShift" use:enhance class="hidden">
+		<input type="hidden" name="shiftId" value={deleteShiftId} />
+	</form>
+	<ConfirmDialog
+		open={confirmOpen}
+		message={t(locale, 'component.confirmDialog.cantBeUndone')}
+		onconfirm={() => {
+			confirmOpen = false;
+			deleteShiftForm?.requestSubmit();
+		}}
+		oncancel={() => (confirmOpen = false)}
+	/>
 </div>
-
-<form bind:this={deleteShiftForm} method="POST" action="?/deleteShift" use:enhance class="hidden">
-	<input type="hidden" name="shiftId" value={deleteShiftId} />
-</form>
-
-<ConfirmDialog
-	open={confirmOpen}
-	message={t(locale, 'component.confirmDialog.cantBeUndone')}
-	onconfirm={() => {
-		confirmOpen = false;
-		deleteShiftForm?.requestSubmit();
-	}}
-	oncancel={() => (confirmOpen = false)}
-/>

--- a/src/lib/components/admin/UserManageDrawer.svelte
+++ b/src/lib/components/admin/UserManageDrawer.svelte
@@ -316,7 +316,7 @@
 										class="space-y-3 rounded-lg border border-border bg-background px-3 py-3"
 									>
 										<input type="hidden" name="shiftId" value={shift.id} />
-										<div class="grid grid-cols-2 gap-3">
+										<div class="space-y-3">
 											<div class="space-y-1">
 												<Label for="es-start-{shift.id}" class="text-xs"
 													>{t(locale, 'page.admin.shiftLabelStart')}</Label
@@ -432,7 +432,7 @@
 						<p class="text-xs font-medium text-muted-foreground">
 							{t(locale, 'page.admin.addShiftLabel')}
 						</p>
-						<div class="grid grid-cols-2 gap-3">
+						<div class="space-y-3">
 							<div class="space-y-1">
 								<Label for="ns-start-{user.id}" class="text-xs"
 									>{t(locale, 'page.admin.shiftLabelStart')}</Label

--- a/src/lib/components/admin/UserManageDrawer.svelte
+++ b/src/lib/components/admin/UserManageDrawer.svelte
@@ -132,7 +132,7 @@
 		tabindex="-1"
 		onkeydown={trapFocus}
 		class="relative z-10 flex h-full w-full max-w-[380px] flex-col border-l border-border bg-card text-card-foreground shadow-2xl
-			animate-in slide-in-from-right duration-200"
+			animate-slide-in-right"
 	>
 		<div class="flex items-center gap-2 border-b border-border px-5 py-4">
 			<Badge variant={roleBadge[user.role]}

--- a/src/lib/components/admin/UserManageDrawer.svelte
+++ b/src/lib/components/admin/UserManageDrawer.svelte
@@ -375,15 +375,19 @@
 									</form>
 								{:else}
 									<div
-										class="flex items-center justify-between gap-3 text-sm rounded-lg border border-border bg-background px-3 py-2"
+										class="flex items-center justify-between gap-2 rounded-lg border border-border bg-background px-3 py-2"
 									>
-										<div class="min-w-0 text-foreground">
-											<LocalTime date={shift.startAt} format="datetime" />
-											<span class="mx-1 text-muted-foreground">→</span>
-											<LocalTime date={shift.endAt} format="datetime" />
-											{#if shift.notes}<span class="ml-2 text-xs text-muted-foreground"
-													>{shift.notes}</span
-												>{/if}
+										<div class="min-w-0 text-foreground text-xs leading-snug">
+											<div class="truncate">
+												<LocalTime date={shift.startAt} format="datetime" />
+											</div>
+											<!-- shift end shown on its own line below -->
+											<div class="truncate text-muted-foreground">
+												→ <LocalTime date={shift.endAt} format="datetime" />
+											</div>
+											{#if shift.notes}<div class="truncate text-muted-foreground">
+													{shift.notes}
+												</div>{/if}
 										</div>
 										<div class="flex gap-1 shrink-0">
 											<Button

--- a/src/lib/components/admin/UserManageDrawer.svelte
+++ b/src/lib/components/admin/UserManageDrawer.svelte
@@ -92,6 +92,8 @@
 
 	function trapFocus(e: KeyboardEvent) {
 		if (e.key === 'Escape') {
+			// Let the shift-delete confirmation handle its own Escape first.
+			if (confirmOpen) return;
 			onclose();
 			return;
 		}

--- a/src/lib/components/admin/UserManageDrawer.svelte
+++ b/src/lib/components/admin/UserManageDrawer.svelte
@@ -214,6 +214,7 @@
 								type="email"
 								class="h-8 text-sm"
 								autocomplete="email"
+								placeholder="radical@edward.com"
 								value={user.email ?? ''}
 							/>
 						</div>
@@ -230,6 +231,7 @@
 								type="tel"
 								class="h-8 text-sm"
 								autocomplete="tel"
+								placeholder={t(locale, 'common.placeholderPhone')}
 								value={user.phone ?? ''}
 							/>
 						</div>

--- a/src/lib/components/admin/UserManageDrawer.svelte
+++ b/src/lib/components/admin/UserManageDrawer.svelte
@@ -1,0 +1,526 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { tick } from 'svelte';
+	import LocalTime from '$lib/components/LocalTime.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Select } from '$lib/components/ui/select/index.js';
+	import { Trash2, X } from '@lucide/svelte';
+	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import { localDatetimes } from '$lib/actions/localDatetimes';
+	import { t, getLocale } from '$lib/i18n';
+
+	interface UserRow {
+		id: string;
+		displayName: string;
+		username: string;
+		email: string | null;
+		phone: string | null;
+		role: 'admin' | 'member' | 'caretaker';
+		isActive: boolean;
+	}
+	interface CompanionRow {
+		id: string;
+		name: string;
+		breed: string | null;
+	}
+	interface AssignmentRow {
+		userId: string;
+		companionId: string;
+	}
+	interface ShiftRow {
+		id: string;
+		userId: string;
+		startAt: Date | string;
+		endAt: Date | string;
+		notes: string | null;
+	}
+
+	let {
+		user,
+		companions,
+		assignments,
+		shifts,
+		currentUserId,
+		onclose
+	}: {
+		user: UserRow;
+		companions: CompanionRow[];
+		assignments: AssignmentRow[];
+		shifts: ShiftRow[];
+		currentUserId: string;
+		onclose: () => void;
+	} = $props();
+
+	const locale = getLocale();
+
+	let editingShiftId = $state<string | null>(null);
+	let confirmOpen = $state(false);
+	let deleteShiftId = $state('');
+	let deleteShiftForm = $state<HTMLFormElement | null>(null);
+
+	let dialogEl = $state<HTMLElement | null>(null);
+	let assignedIds = $derived(
+		assignments.filter((a) => a.userId === user.id).map((a) => a.companionId)
+	);
+	let userShifts = $derived(shifts.filter((s) => s.userId === user.id));
+
+	const roleBadge = { admin: 'primary', caretaker: 'teal', member: 'secondary' } as const;
+
+	function localDatetimeISO(d: Date | string) {
+		const dt = new Date(d);
+		const p = (n: number) => String(n).padStart(2, '0');
+		return `${dt.getFullYear()}-${p(dt.getMonth() + 1)}-${p(dt.getDate())}T${p(dt.getHours())}:${p(dt.getMinutes())}`;
+	}
+
+	$effect(() => {
+		tick().then(() => dialogEl?.focus());
+	});
+
+	function trapFocus(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			onclose();
+			return;
+		}
+		if (e.key !== 'Tab' || !dialogEl) return;
+		const f = Array.from(
+			dialogEl.querySelectorAll<HTMLElement>(
+				'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+			)
+		).filter((el) => !el.hasAttribute('disabled'));
+		if (!f.length) return;
+		const first = f[0];
+		const last = f[f.length - 1];
+		if (e.shiftKey && document.activeElement === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && document.activeElement === last) {
+			e.preventDefault();
+			first.focus();
+		}
+	}
+
+	const sectionLabel =
+		'text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3';
+</script>
+
+<div class="fixed inset-0 z-50 flex justify-end">
+	<button
+		tabindex="-1"
+		class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+		aria-label={t(locale, 'common.close')}
+		onclick={onclose}
+	></button>
+	<div
+		bind:this={dialogEl}
+		role="dialog"
+		aria-modal="true"
+		aria-label={t(locale, 'page.admin.editUserLabel', { name: user.displayName })}
+		tabindex="-1"
+		onkeydown={trapFocus}
+		class="relative z-10 flex h-full w-full max-w-[380px] flex-col border-l border-border bg-card text-card-foreground shadow-2xl
+			animate-in slide-in-from-right duration-200"
+	>
+		<div class="flex items-center gap-2 border-b border-border px-5 py-4">
+			<Badge variant={roleBadge[user.role]}
+				>{t(
+					locale,
+					user.role === 'admin'
+						? 'enum.role.admin'
+						: user.role === 'caretaker'
+							? 'enum.role.caretaker'
+							: 'enum.role.member'
+				)}</Badge
+			>
+			<span class="font-semibold text-foreground truncate">{user.displayName}</span>
+			<button
+				onclick={onclose}
+				aria-label={t(locale, 'common.close')}
+				class="ml-auto rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+			>
+				<X class="h-4 w-4" />
+			</button>
+		</div>
+
+		<div class="flex-1 overflow-y-auto px-5 py-5 space-y-7">
+			<!-- Profile (name/username/email/phone/role) -->
+			<section>
+				<h2 class={sectionLabel}>{t(locale, 'page.admin.drawerProfile')}</h2>
+				<form
+					method="POST"
+					action="?/editUser"
+					use:enhance={() =>
+						({ result, update }) => {
+							update();
+							if (result.type === 'success') onclose();
+						}}
+					class="space-y-3"
+				>
+					<input type="hidden" name="userId" value={user.id} />
+					<div class="grid grid-cols-2 gap-3">
+						<div class="space-y-1.5">
+							<Label for="d-name-{user.id}" class="text-xs"
+								>{t(locale, 'page.admin.labelDisplayName')}</Label
+							>
+							<Input
+								id="d-name-{user.id}"
+								name="displayName"
+								class="h-8 text-sm"
+								autocomplete="name"
+								value={user.displayName}
+								required
+							/>
+						</div>
+						<div class="space-y-1.5">
+							<Label for="d-username-{user.id}" class="text-xs"
+								>{t(locale, 'page.admin.labelUsername')}</Label
+							>
+							<Input
+								id="d-username-{user.id}"
+								name="username"
+								class="h-8 text-sm"
+								autocomplete="username"
+								value={user.username}
+								required
+							/>
+						</div>
+					</div>
+					<div class="grid grid-cols-2 gap-3">
+						<div class="space-y-1.5">
+							<Label for="d-email-{user.id}" class="text-xs"
+								>{t(locale, 'page.admin.labelEmail')}
+								<span class="font-normal text-muted-foreground"
+									>{t(locale, 'page.admin.labelOptional')}</span
+								></Label
+							>
+							<Input
+								id="d-email-{user.id}"
+								name="email"
+								type="email"
+								class="h-8 text-sm"
+								autocomplete="email"
+								value={user.email ?? ''}
+							/>
+						</div>
+						<div class="space-y-1.5">
+							<Label for="d-phone-{user.id}" class="text-xs"
+								>{t(locale, 'page.admin.labelPhone')}
+								<span class="font-normal text-muted-foreground"
+									>{t(locale, 'page.admin.labelOptional')}</span
+								></Label
+							>
+							<Input
+								id="d-phone-{user.id}"
+								name="phone"
+								type="tel"
+								class="h-8 text-sm"
+								autocomplete="tel"
+								value={user.phone ?? ''}
+							/>
+						</div>
+					</div>
+					<div class="space-y-1.5">
+						<Label for="d-role-{user.id}" class="text-xs">{t(locale, 'page.admin.labelRole')}</Label
+						>
+						<Select id="d-role-{user.id}" name="role" class="h-8">
+							<option value="member" selected={user.role === 'member'}
+								>{t(locale, 'enum.role.member')}</option
+							>
+							<option value="admin" selected={user.role === 'admin'}
+								>{t(locale, 'enum.role.admin')}</option
+							>
+							<option value="caretaker" selected={user.role === 'caretaker'}
+								>{t(locale, 'enum.role.caretaker')}</option
+							>
+						</Select>
+					</div>
+					<Button type="submit" size="sm">{t(locale, 'common.save')}</Button>
+				</form>
+			</section>
+
+			{#if user.role === 'caretaker'}
+				<!-- Assigned companions -->
+				<section>
+					<h2 class={sectionLabel}>{t(locale, 'page.admin.menuCompanions')}</h2>
+					<form
+						method="POST"
+						action="?/assignCompanions"
+						use:enhance={() =>
+							({ update }) =>
+								update()}
+						class="space-y-3"
+					>
+						<input type="hidden" name="userId" value={user.id} />
+						{#if companions.length === 0}
+							<p class="text-xs text-muted-foreground">
+								{t(locale, 'page.admin.noActiveCompanions')}
+							</p>
+						{:else}
+							<div class="space-y-2">
+								{#each companions as companion (companion.id)}
+									<label class="flex items-center gap-2 cursor-pointer">
+										<input
+											type="checkbox"
+											name="companionId"
+											value={companion.id}
+											checked={assignedIds.includes(companion.id)}
+											class="rounded border-border"
+										/>
+										<span class="text-sm text-foreground">{companion.name}</span>
+										{#if companion.breed}<span class="text-xs text-muted-foreground"
+												>{companion.breed}</span
+											>{/if}
+									</label>
+								{/each}
+							</div>
+						{/if}
+						<Button type="submit" size="sm">{t(locale, 'common.save')}</Button>
+					</form>
+				</section>
+
+				<!-- Shifts -->
+				<section>
+					<h2 class={sectionLabel}>{t(locale, 'page.admin.menuShifts')}</h2>
+					{#if userShifts.length === 0}
+						<p class="text-xs text-muted-foreground mb-3">
+							{t(locale, 'page.admin.noShiftsScheduled')}
+						</p>
+					{:else}
+						<div class="space-y-2 mb-3">
+							{#each userShifts as shift (shift.id)}
+								{#if editingShiftId === shift.id}
+									<form
+										method="POST"
+										action="?/updateShift"
+										use:localDatetimes
+										use:enhance={() =>
+											({ update }) => {
+												update();
+												editingShiftId = null;
+											}}
+										class="space-y-3 rounded-lg border border-border bg-background px-3 py-3"
+									>
+										<input type="hidden" name="shiftId" value={shift.id} />
+										<div class="grid grid-cols-2 gap-3">
+											<div class="space-y-1">
+												<Label for="es-start-{shift.id}" class="text-xs"
+													>{t(locale, 'page.admin.shiftLabelStart')}</Label
+												>
+												<Input
+													id="es-start-{shift.id}"
+													name="startAt"
+													type="datetime-local"
+													autocomplete="off"
+													class="h-8 text-sm"
+													value={localDatetimeISO(shift.startAt)}
+													required
+												/>
+											</div>
+											<div class="space-y-1">
+												<Label for="es-end-{shift.id}" class="text-xs"
+													>{t(locale, 'page.admin.shiftLabelEnd')}</Label
+												>
+												<Input
+													id="es-end-{shift.id}"
+													name="endAt"
+													type="datetime-local"
+													autocomplete="off"
+													class="h-8 text-sm"
+													value={localDatetimeISO(shift.endAt)}
+													required
+												/>
+											</div>
+										</div>
+										<div class="space-y-1">
+											<Label for="es-notes-{shift.id}" class="text-xs"
+												>{t(locale, 'page.admin.shiftLabelLabel')}
+												<span class="font-normal text-muted-foreground"
+													>{t(locale, 'page.admin.labelOptional')}</span
+												></Label
+											>
+											<Input
+												id="es-notes-{shift.id}"
+												name="notes"
+												type="text"
+												autocomplete="off"
+												class="h-8 text-sm"
+												value={shift.notes ?? ''}
+												placeholder={t(locale, 'page.admin.shiftPlaceholder')}
+											/>
+										</div>
+										<div class="flex gap-2">
+											<Button type="submit" size="sm">{t(locale, 'common.save')}</Button>
+											<Button
+												type="button"
+												variant="secondary"
+												size="sm"
+												onclick={() => (editingShiftId = null)}>{t(locale, 'common.cancel')}</Button
+											>
+										</div>
+									</form>
+								{:else}
+									<div
+										class="flex items-center justify-between gap-3 text-sm rounded-lg border border-border bg-background px-3 py-2"
+									>
+										<div class="min-w-0 text-foreground">
+											<LocalTime date={shift.startAt} format="datetime" />
+											<span class="mx-1 text-muted-foreground">→</span>
+											<LocalTime date={shift.endAt} format="datetime" />
+											{#if shift.notes}<span class="ml-2 text-xs text-muted-foreground"
+													>{shift.notes}</span
+												>{/if}
+										</div>
+										<div class="flex gap-1 shrink-0">
+											<Button
+												type="button"
+												variant="soft"
+												size="sm"
+												class="h-7 text-xs"
+												onclick={() => (editingShiftId = shift.id)}
+												>{t(locale, 'common.edit')}</Button
+											>
+											<Button
+												type="button"
+												variant="softDestructive"
+												size="sm"
+												class="h-7 gap-1.5 px-2 text-xs"
+												onclick={() => {
+													deleteShiftId = shift.id;
+													confirmOpen = true;
+												}}
+											>
+												<Trash2 class="h-3.5 w-3.5" /><span class="hidden sm:inline"
+													>{t(locale, 'common.delete')}</span
+												>
+											</Button>
+										</div>
+									</div>
+								{/if}
+							{/each}
+						</div>
+					{/if}
+					<form
+						method="POST"
+						action="?/addShift"
+						use:localDatetimes
+						use:enhance={() =>
+							({ update }) =>
+								update()}
+						class="space-y-3 pt-3 border-t border-border"
+					>
+						<input type="hidden" name="userId" value={user.id} />
+						<p class="text-xs font-medium text-muted-foreground">
+							{t(locale, 'page.admin.addShiftLabel')}
+						</p>
+						<div class="grid grid-cols-2 gap-3">
+							<div class="space-y-1">
+								<Label for="ns-start-{user.id}" class="text-xs"
+									>{t(locale, 'page.admin.shiftLabelStart')}</Label
+								>
+								<Input
+									id="ns-start-{user.id}"
+									name="startAt"
+									type="datetime-local"
+									autocomplete="off"
+									class="h-8 text-sm"
+									required
+								/>
+							</div>
+							<div class="space-y-1">
+								<Label for="ns-end-{user.id}" class="text-xs"
+									>{t(locale, 'page.admin.shiftLabelEnd')}</Label
+								>
+								<Input
+									id="ns-end-{user.id}"
+									name="endAt"
+									type="datetime-local"
+									autocomplete="off"
+									class="h-8 text-sm"
+									required
+								/>
+							</div>
+						</div>
+						<div class="space-y-1">
+							<Label for="ns-notes-{user.id}" class="text-xs"
+								>{t(locale, 'page.admin.shiftLabelLabel')}
+								<span class="font-normal text-muted-foreground"
+									>{t(locale, 'page.admin.labelOptional')}</span
+								></Label
+							>
+							<Input
+								id="ns-notes-{user.id}"
+								name="notes"
+								type="text"
+								autocomplete="off"
+								class="h-8 text-sm"
+								placeholder={t(locale, 'page.admin.shiftPlaceholder')}
+							/>
+						</div>
+						<Button type="submit" size="sm">{t(locale, 'page.admin.addShiftSubmit')}</Button>
+					</form>
+				</section>
+			{/if}
+
+			<!-- Password -->
+			<section>
+				<h2 class={sectionLabel}>{t(locale, 'page.admin.labelPassword')}</h2>
+				<form
+					method="POST"
+					action="?/resetPassword"
+					use:enhance={() =>
+						({ update }) =>
+							update()}
+					class="flex gap-2"
+				>
+					<Input
+						id="np-{user.id}"
+						name="newPassword"
+						type="password"
+						autocomplete="new-password"
+						class="max-w-[200px] h-9 text-sm"
+						placeholder={t(locale, 'page.admin.newPasswordPlaceholder')}
+						minlength={8}
+						required
+					/>
+					<Button type="submit" size="sm">{t(locale, 'page.admin.setPassword')}</Button>
+				</form>
+			</section>
+
+			<!-- Deactivate / Activate -->
+			{#if user.id !== currentUserId}
+				<section class="border-t border-border pt-5">
+					<form
+						method="POST"
+						action="?/toggleActive"
+						use:enhance={() =>
+							({ update }) =>
+								update()}
+					>
+						<input type="hidden" name="userId" value={user.id} />
+						<Button type="submit" variant="softDestructive" size="sm">
+							{user.isActive
+								? t(locale, 'page.admin.menuDeactivate')
+								: t(locale, 'page.admin.menuActivate')}
+						</Button>
+					</form>
+				</section>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<form bind:this={deleteShiftForm} method="POST" action="?/deleteShift" use:enhance class="hidden">
+	<input type="hidden" name="shiftId" value={deleteShiftId} />
+</form>
+
+<ConfirmDialog
+	open={confirmOpen}
+	message={t(locale, 'component.confirmDialog.cantBeUndone')}
+	onconfirm={() => {
+		confirmOpen = false;
+		deleteShiftForm?.requestSubmit();
+	}}
+	oncancel={() => (confirmOpen = false)}
+/>

--- a/src/lib/components/ui/badge/badge.test.ts
+++ b/src/lib/components/ui/badge/badge.test.ts
@@ -12,4 +12,8 @@ describe('badgeVariants', () => {
 			expect(typeof badgeVariants({ variant: v })).toBe('string');
 		}
 	});
+	it('exposes a soft primary variant for role badges', () => {
+		expect(badgeVariants({ variant: 'primary' })).toContain('text-primary');
+		expect(badgeVariants({ variant: 'primary' })).toContain('bg-primary/15');
+	});
 });

--- a/src/lib/components/ui/badge/index.ts
+++ b/src/lib/components/ui/badge/index.ts
@@ -16,7 +16,8 @@ export const badgeVariants = cva(
 				teal: 'border-transparent bg-teal/15 text-teal',
 				gold: 'border-transparent bg-gold/15 text-gold',
 				coral: 'border-transparent bg-coral/15 text-coral',
-				primary: 'border-transparent bg-primary/15 text-primary'
+				primary: 'border-transparent bg-primary/15 text-primary',
+				destructiveSoft: 'border-transparent bg-destructive/15 text-destructive'
 			}
 		},
 		defaultVariants: {

--- a/src/lib/components/ui/badge/index.ts
+++ b/src/lib/components/ui/badge/index.ts
@@ -15,7 +15,8 @@ export const badgeVariants = cva(
 				sky: 'border-transparent bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300',
 				teal: 'border-transparent bg-teal/15 text-teal',
 				gold: 'border-transparent bg-gold/15 text-gold',
-				coral: 'border-transparent bg-coral/15 text-coral'
+				coral: 'border-transparent bg-coral/15 text-coral',
+				primary: 'border-transparent bg-primary/15 text-primary'
 			}
 		},
 		defaultVariants: {

--- a/src/lib/components/ui/badge/index.ts
+++ b/src/lib/components/ui/badge/index.ts
@@ -16,8 +16,7 @@ export const badgeVariants = cva(
 				teal: 'border-transparent bg-teal/15 text-teal',
 				gold: 'border-transparent bg-gold/15 text-gold',
 				coral: 'border-transparent bg-coral/15 text-coral',
-				primary: 'border-transparent bg-primary/15 text-primary',
-				destructiveSoft: 'border-transparent bg-destructive/15 text-destructive'
+				primary: 'border-transparent bg-primary/15 text-primary'
 			}
 		},
 		defaultVariants: {

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -828,6 +828,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.care.title': 'Betreuung',
 	'page.admin.pageTitle': 'Benutzerverwaltung',
 	'page.admin.companionsTitle': 'Begleiter',
+	'page.admin.companionsActiveCount': '{count} aktiver Begleiter',
+	'page.admin.companionsActiveCountPlural': '{count} aktive Begleiter',
+	'page.admin.companionActiveBadge': 'Aktiv',
+	'page.admin.companionRestored': 'Begleiter erfolgreich wiederhergestellt.',
+	'page.admin.restore': 'Wiederherstellen',
 	'page.companion.edit.pageTitle': '{name} bearbeiten',
 
 	// Aria labels

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -789,6 +789,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.menuDeactivate': 'Deaktivieren',
 	'page.admin.menuActivate': 'Aktivieren',
 	'page.admin.menuResetPassword': 'Passwort zurücksetzen',
+	'page.admin.manage': 'Verwalten',
+	'page.admin.drawerProfile': 'Profil',
 	'page.admin.editUserLabel': '{name} bearbeiten',
 	'page.admin.assignCompanionsLabel': 'Begleiter an {name} zuweisen',
 	'page.admin.noActiveCompanions': 'Keine aktiven Begleiter.',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -832,6 +832,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Aria labels
 	'aria.caretakerNav': 'Betreuer-Navigation',
+	'aria.adminNav': 'Verwaltungsbereiche',
 	'aria.mainNav': 'Hauptnavigation',
 	'aria.moreActions': 'Weitere Aktionen',
 	'aria.deleteEntry': 'Eintrag löschen',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -780,6 +780,8 @@ const messages = {
 	'page.admin.menuDeactivate': 'Deactivate',
 	'page.admin.menuActivate': 'Activate',
 	'page.admin.menuResetPassword': 'Reset Password',
+	'page.admin.manage': 'Manage',
+	'page.admin.drawerProfile': 'Profile',
 	'page.admin.editUserLabel': 'Edit {name}',
 	'page.admin.assignCompanionsLabel': 'Assign companions to {name}',
 	'page.admin.noActiveCompanions': 'No active companions.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -818,6 +818,11 @@ const messages = {
 	'page.care.title': 'Care',
 	'page.admin.pageTitle': 'User Admin',
 	'page.admin.companionsTitle': 'Companions',
+	'page.admin.companionsActiveCount': '{count} active companion',
+	'page.admin.companionsActiveCountPlural': '{count} active companions',
+	'page.admin.companionActiveBadge': 'Active',
+	'page.admin.companionRestored': 'Companion restored successfully.',
+	'page.admin.restore': 'Restore',
 	'page.companion.edit.pageTitle': 'Edit {name}',
 
 	// Aria labels

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -822,6 +822,7 @@ const messages = {
 
 	// Aria labels
 	'aria.caretakerNav': 'Caretaker navigation',
+	'aria.adminNav': 'Admin sections',
 	'aria.mainNav': 'Main navigation',
 	'aria.moreActions': 'More actions',
 	'aria.deleteEntry': 'Delete entry',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -789,6 +789,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.menuDeactivate': 'Desactivar',
 	'page.admin.menuActivate': 'Activar',
 	'page.admin.menuResetPassword': 'Restablecer contraseña',
+	'page.admin.manage': 'Gestionar',
+	'page.admin.drawerProfile': 'Perfil',
 	'page.admin.editUserLabel': 'Editar {name}',
 	'page.admin.assignCompanionsLabel': 'Asignar compañeros a {name}',
 	'page.admin.noActiveCompanions': 'Sin compañeros activos.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -827,6 +827,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.care.title': 'Cuidado',
 	'page.admin.pageTitle': 'Gestión de usuarios',
 	'page.admin.companionsTitle': 'Compañeros',
+	'page.admin.companionsActiveCount': '{count} compañero activo',
+	'page.admin.companionsActiveCountPlural': '{count} compañeros activos',
+	'page.admin.companionActiveBadge': 'Activo',
+	'page.admin.companionRestored': 'Compañero restaurado correctamente.',
+	'page.admin.restore': 'Restaurar',
 	'page.companion.edit.pageTitle': 'Editar {name}',
 
 	// Aria labels

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -831,6 +831,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Aria labels
 	'aria.caretakerNav': 'Navegación del cuidador',
+	'aria.adminNav': 'Secciones de administración',
 	'aria.mainNav': 'Navegación principal',
 	'aria.moreActions': 'Más acciones',
 	'aria.deleteEntry': 'Eliminar entrada',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -829,6 +829,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.care.title': 'Soins',
 	'page.admin.pageTitle': 'Gestion des utilisateurs',
 	'page.admin.companionsTitle': 'Compagnons',
+	'page.admin.companionsActiveCount': '{count} compagnon actif',
+	'page.admin.companionsActiveCountPlural': '{count} compagnons actifs',
+	'page.admin.companionActiveBadge': 'Actif',
+	'page.admin.companionRestored': 'Compagnon restauré avec succès.',
+	'page.admin.restore': 'Restaurer',
 	'page.companion.edit.pageTitle': 'Modifier {name}',
 
 	// Aria labels

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -791,6 +791,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.menuDeactivate': 'Désactiver',
 	'page.admin.menuActivate': 'Activer',
 	'page.admin.menuResetPassword': 'Réinitialiser le mot de passe',
+	'page.admin.manage': 'Gérer',
+	'page.admin.drawerProfile': 'Profil',
 	'page.admin.editUserLabel': 'Modifier {name}',
 	'page.admin.assignCompanionsLabel': 'Assigner des compagnons à {name}',
 	'page.admin.noActiveCompanions': 'Aucun compagnon actif.',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -833,6 +833,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Aria labels
 	'aria.caretakerNav': 'Navigation gardien',
+	'aria.adminNav': "Sections d'administration",
 	'aria.mainNav': 'Navigation principale',
 	'aria.moreActions': "Plus d'actions",
 	'aria.deleteEntry': "Supprimer l'entrée",

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -822,6 +822,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.care.title': 'Cura',
 	'page.admin.pageTitle': 'Gestione utenti',
 	'page.admin.companionsTitle': 'Compagni',
+	'page.admin.companionsActiveCount': '{count} compagno attivo',
+	'page.admin.companionsActiveCountPlural': '{count} compagni attivi',
+	'page.admin.companionActiveBadge': 'Attivo',
+	'page.admin.companionRestored': 'Compagno ripristinato correttamente.',
+	'page.admin.restore': 'Ripristina',
 	'page.companion.edit.pageTitle': 'Modifica {name}',
 
 	// Aria labels

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -784,6 +784,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.menuDeactivate': 'Disattiva',
 	'page.admin.menuActivate': 'Attiva',
 	'page.admin.menuResetPassword': 'Reimposta password',
+	'page.admin.manage': 'Gestisci',
+	'page.admin.drawerProfile': 'Profilo',
 	'page.admin.editUserLabel': 'Modifica {name}',
 	'page.admin.assignCompanionsLabel': 'Assegna compagni a {name}',
 	'page.admin.noActiveCompanions': 'Nessun compagno attivo.',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -826,6 +826,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Aria labels
 	'aria.caretakerNav': 'Navigazione custode',
+	'aria.adminNav': 'Sezioni di amministrazione',
 	'aria.mainNav': 'Navigazione principale',
 	'aria.moreActions': 'Altre azioni',
 	'aria.deleteEntry': 'Elimina voce',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -824,6 +824,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.care.title': 'Cuidados',
 	'page.admin.pageTitle': 'Gestão de utilizadores',
 	'page.admin.companionsTitle': 'Companheiros',
+	'page.admin.companionsActiveCount': '{count} companheiro ativo',
+	'page.admin.companionsActiveCountPlural': '{count} companheiros ativos',
+	'page.admin.companionActiveBadge': 'Ativo',
+	'page.admin.companionRestored': 'Companheiro restaurado com sucesso.',
+	'page.admin.restore': 'Restaurar',
 	'page.companion.edit.pageTitle': 'Editar {name}',
 
 	// Aria labels

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -786,6 +786,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.menuDeactivate': 'Desativar',
 	'page.admin.menuActivate': 'Ativar',
 	'page.admin.menuResetPassword': 'Redefinir palavra-passe',
+	'page.admin.manage': 'Gerir',
+	'page.admin.drawerProfile': 'Perfil',
 	'page.admin.editUserLabel': 'Editar {name}',
 	'page.admin.assignCompanionsLabel': 'Atribuir companheiros a {name}',
 	'page.admin.noActiveCompanions': 'Sem companheiros ativos.',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -828,6 +828,7 @@ const messages: Record<keyof Messages, string> = {
 
 	// Aria labels
 	'aria.caretakerNav': 'Navegação do cuidador',
+	'aria.adminNav': 'Secções de administração',
 	'aria.mainNav': 'Navegação principal',
 	'aria.moreActions': 'Mais ações',
 	'aria.deleteEntry': 'Eliminar entrada',

--- a/src/routes/(app)/(admin)/+layout.svelte
+++ b/src/routes/(app)/(admin)/+layout.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { page } from '$app/state';
+	import { t, getLocale } from '$lib/i18n';
+
+	let { children }: { children: Snippet } = $props();
+	const locale = getLocale();
+
+	const tabs = $derived([
+		{ href: '/admin/users', label: t(locale, 'page.admin.usersTitle') },
+		{ href: '/admin/companions', label: t(locale, 'page.admin.companionsTitle') }
+	]);
+	let pathname = $derived(page.url.pathname);
+</script>
+
+<div class="max-w-3xl mx-auto px-4 sm:px-6 pt-2">
+	<nav class="flex gap-1.5 mb-5" aria-label="Admin sections">
+		{#each tabs as tab (tab.href)}
+			{@const active = pathname === tab.href || pathname.startsWith(tab.href + '/')}
+			<a
+				href={tab.href}
+				aria-current={active ? 'page' : undefined}
+				class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors {active
+					? 'bg-primary/10 text-primary'
+					: 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+			>
+				{tab.label}
+			</a>
+		{/each}
+	</nav>
+</div>
+
+{@render children()}

--- a/src/routes/(app)/(admin)/+layout.svelte
+++ b/src/routes/(app)/(admin)/+layout.svelte
@@ -6,28 +6,29 @@
 	let { children }: { children: Snippet } = $props();
 	const locale = getLocale();
 
-	const tabs = $derived([
+	const tabs = [
 		{ href: '/admin/users', label: t(locale, 'page.admin.usersTitle') },
 		{ href: '/admin/companions', label: t(locale, 'page.admin.companionsTitle') }
-	]);
+	];
 	let pathname = $derived(page.url.pathname);
 </script>
 
-<div class="max-w-3xl mx-auto px-4 sm:px-6 pt-2">
-	<nav class="flex gap-1.5 mb-5" aria-label="Admin sections">
-		{#each tabs as tab (tab.href)}
-			{@const active = pathname === tab.href || pathname.startsWith(tab.href + '/')}
-			<a
-				href={tab.href}
-				aria-current={active ? 'page' : undefined}
-				class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors {active
-					? 'bg-primary/10 text-primary'
-					: 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
-			>
-				{tab.label}
-			</a>
-		{/each}
-	</nav>
-</div>
+<nav
+	class="max-w-3xl mx-auto px-4 sm:px-6 pt-2 mb-5 flex gap-1.5"
+	aria-label={t(locale, 'aria.adminNav')}
+>
+	{#each tabs as tab (tab.href)}
+		{@const active = pathname === tab.href || pathname.startsWith(tab.href + '/')}
+		<a
+			href={tab.href}
+			aria-current={active ? 'page' : undefined}
+			class="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors {active
+				? 'bg-primary/10 text-primary'
+				: 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'}"
+		>
+			{tab.label}
+		</a>
+	{/each}
+</nav>
 
 {@render children()}

--- a/src/routes/(app)/(admin)/admin/companions/+page.svelte
+++ b/src/routes/(app)/(admin)/admin/companions/+page.svelte
@@ -38,8 +38,9 @@
 				{t(locale, 'page.admin.companionsTitle')}
 			</h1>
 			<p class="text-sm mt-1 text-muted-foreground">
-				{data.companions.length}
-				{data.companions.length === 1 ? 'active companion' : 'active companions'}
+				{data.companions.length === 1
+					? t(locale, 'page.admin.companionsActiveCount', { count: data.companions.length })
+					: t(locale, 'page.admin.companionsActiveCountPlural', { count: data.companions.length })}
 			</p>
 		</div>
 		<Button href="/companions/new" size="sm">
@@ -72,7 +73,7 @@
 							{#if age}
 								<span class="text-xs text-muted-foreground">{age}</span>
 							{/if}
-							<Badge variant="moss">Active</Badge>
+							<Badge variant="teal">{t(locale, 'page.admin.companionActiveBadge')}</Badge>
 						</div>
 					</div>
 					<Button href="/companions/{companion.id}/edit" variant="soft" size="sm">
@@ -91,7 +92,7 @@
 			</h2>
 			{#if form?.restoreSuccess}
 				<Alert variant="success" class="mb-3">
-					<AlertDescription>Companion restored successfully.</AlertDescription>
+					<AlertDescription>{t(locale, 'page.admin.companionRestored')}</AlertDescription>
 				</Alert>
 			{/if}
 			<Card class="divide-y divide-border">
@@ -133,7 +134,7 @@
 								<input type="hidden" name="companionId" value={companion.id} />
 								<Button type="submit" variant="softSuccess" size="sm" class="gap-1.5">
 									<RotateCcw class="h-3.5 w-3.5" />
-									<span class="hidden sm:inline">Restore</span>
+									<span class="hidden sm:inline">{t(locale, 'page.admin.restore')}</span>
 								</Button>
 							</form>
 						</div>

--- a/src/routes/(app)/(admin)/admin/companions/+page.svelte
+++ b/src/routes/(app)/(admin)/admin/companions/+page.svelte
@@ -38,9 +38,9 @@
 				{t(locale, 'page.admin.companionsTitle')}
 			</h1>
 			<p class="text-sm mt-1 text-muted-foreground">
-				{data.companions.length === 1
-					? t(locale, 'page.admin.companionsActiveCount', { count: data.companions.length })
-					: t(locale, 'page.admin.companionsActiveCountPlural', { count: data.companions.length })}
+				{data.companions.length !== 1
+					? t(locale, 'page.admin.companionsActiveCountPlural', { count: data.companions.length })
+					: t(locale, 'page.admin.companionsActiveCount', { count: data.companions.length })}
 			</p>
 		</div>
 		<Button href="/companions/new" size="sm">

--- a/src/routes/(app)/(admin)/admin/users/+page.svelte
+++ b/src/routes/(app)/(admin)/admin/users/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { PageData, ActionData } from './$types';
 	import { enhance } from '$app/forms';
-	import { tick } from 'svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
@@ -10,19 +9,8 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Select } from '$lib/components/ui/select/index.js';
-	import {
-		Plus,
-		Trash2,
-		Pencil,
-		Users,
-		CalendarClock,
-		UserX,
-		UserCheck,
-		KeyRound,
-		EllipsisVertical
-	} from '@lucide/svelte';
-	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
-	import { localDatetimes } from '$lib/actions/localDatetimes';
+	import { Plus } from '@lucide/svelte';
+	import UserManageDrawer from '$lib/components/admin/UserManageDrawer.svelte';
 	import { t, getLocale } from '$lib/i18n';
 
 	const locale = getLocale();
@@ -30,48 +18,12 @@
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 
 	let showCreateForm = $state(false);
-	let editingUserId = $state<string | null>(null);
-	let resetingUserId = $state<string | null>(null);
-	let assigningUserId = $state<string | null>(null);
-	let managingShiftsUserId = $state<string | null>(null);
-	let editingShiftId = $state<string | null>(null);
-	let openMenuUserId = $state<string | null>(null);
+	let manageUserId = $state<string | null>(null);
 
-	let confirmOpen = $state(false);
-	let deleteShiftId = $state('');
-	let deleteShiftForm = $state<HTMLFormElement | null>(null);
+	let manageUser = $derived(data.users.find((u) => u.id === manageUserId) ?? null);
 
-	let toggleActiveUserId = $state('');
-	let toggleActiveFormEl = $state<HTMLFormElement | null>(null);
-	function toggleActiveForm(userId: string) {
-		toggleActiveUserId = userId;
-		tick().then(() => toggleActiveFormEl?.requestSubmit());
-	}
-
-	function assignedCompanionIds(userId: string): string[] {
-		return data.assignments.filter((a) => a.userId === userId).map((a) => a.companionId);
-	}
-
-	function userShifts(userId: string) {
-		return data.shifts.filter((s) => s.userId === userId);
-	}
-
-	function localDatetimeISO(d: Date | string) {
-		const dt = new Date(d);
-		const p = (n: number) => String(n).padStart(2, '0');
-		return `${dt.getFullYear()}-${p(dt.getMonth() + 1)}-${p(dt.getDate())}T${p(dt.getHours())}:${p(dt.getMinutes())}`;
-	}
-
-	function handleWindowClick(e: MouseEvent) {
-		if (openMenuUserId === null) return;
-		const target = e.target as Element;
-		if (!target.closest('[data-user-menu]')) {
-			openMenuUserId = null;
-		}
-	}
+	const roleBadge = { admin: 'primary', caretaker: 'teal', member: 'secondary' } as const;
 </script>
-
-<svelte:window onclick={handleWindowClick} />
 
 <svelte:head>
 	<title>{t(locale, 'page.admin.pageTitle')} | EinVault</title>
@@ -186,555 +138,56 @@
 	<!-- User list -->
 	<Card class="divide-y divide-border">
 		{#each data.users as user (user.id)}
-			<div class="px-6 py-4 space-y-3">
-				<div class="flex items-start justify-between gap-2">
-					<div class="min-w-0">
-						<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-							<span class="font-medium text-foreground">{user.displayName}</span>
-							<Badge variant="secondary" class="font-mono">{user.username}</Badge>
-							{#if user.role === 'admin'}
-								<Badge variant="bark">{t(locale, 'enum.role.admin')}</Badge>
-							{:else if user.role === 'caretaker'}
-								<Badge variant="moss">{t(locale, 'enum.role.caretaker')}</Badge>
-							{:else}
-								<Badge variant="sky">{t(locale, 'enum.role.member')}</Badge>
-							{/if}
-							{#if !user.isActive}
-								<Badge variant="destructive">{t(locale, 'page.admin.inactiveBadge')}</Badge>
-							{/if}
-						</div>
-						{#if user.email || user.phone}
-							<p class="text-xs mt-0.5 text-muted-foreground">
-								{#if user.email}<a href="mailto:{user.email}" class="hover:underline"
-										>{user.email}</a
-									>{/if}
-								{#if user.email && user.phone}&ensp;·&ensp;{/if}
-								{#if user.phone}<a href="tel:{user.phone}" class="hover:underline">{user.phone}</a
-									>{/if}
-							</p>
+			<div class="px-6 py-4 flex items-start justify-between gap-3">
+				<div class="min-w-0">
+					<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+						<span class="font-medium text-foreground">{user.displayName}</span>
+						<Badge variant="secondary" class="font-mono">{user.username}</Badge>
+						<Badge variant={roleBadge[user.role]}
+							>{t(
+								locale,
+								user.role === 'admin'
+									? 'enum.role.admin'
+									: user.role === 'caretaker'
+										? 'enum.role.caretaker'
+										: 'enum.role.member'
+							)}</Badge
+						>
+						{#if !user.isActive}
+							<Badge variant="destructive">{t(locale, 'page.admin.inactiveBadge')}</Badge>
 						{/if}
+					</div>
+					{#if user.email || user.phone}
 						<p class="text-xs mt-0.5 text-muted-foreground">
-							{t(locale, 'page.admin.joined')}
-							<LocalTime date={user.createdAt} />
-							{#if user.lastLoginAt}&nbsp;· {t(locale, 'page.admin.lastLogin')}
-								<LocalTime date={user.lastLoginAt} />{/if}
+							{#if user.email}<a href="mailto:{user.email}" class="hover:underline">{user.email}</a
+								>{/if}
+							{#if user.email && user.phone}&ensp;·&ensp;{/if}
+							{#if user.phone}<a href="tel:{user.phone}" class="hover:underline">{user.phone}</a
+								>{/if}
 						</p>
-					</div>
-
-					<!-- Actions: Edit (primary) + overflow menu -->
-					<div class="flex items-center gap-0.5 shrink-0">
-						<Button
-							variant="soft"
-							size="sm"
-							class="h-8 w-8 p-0 md:w-auto md:px-2.5 md:gap-1.5 text-xs"
-							onclick={() => (editingUserId = editingUserId === user.id ? null : user.id)}
-						>
-							<Pencil class="h-3.5 w-3.5 shrink-0" />
-							<span class="hidden md:inline">Edit</span>
-						</Button>
-
-						<div class="relative" data-user-menu>
-							<Button
-								variant="ghost"
-								size="sm"
-								class="h-8 w-8 p-0"
-								onclick={(e: MouseEvent) => {
-									e.stopPropagation();
-									openMenuUserId = openMenuUserId === user.id ? null : user.id;
-								}}
-								aria-label={t(locale, 'aria.moreActions')}
-								aria-expanded={openMenuUserId === user.id}
-								aria-haspopup="true"
-							>
-								<EllipsisVertical class="h-4 w-4" />
-							</Button>
-
-							{#if openMenuUserId === user.id}
-								<div
-									class="absolute right-0 top-full z-50 mt-1 bg-card border border-border rounded-lg shadow-lg py-1 min-w-[160px]"
-									role="menu"
-								>
-									{#if user.role === 'caretaker'}
-										<button
-											type="button"
-											role="menuitem"
-											class="w-full flex items-center gap-2.5 px-3 py-1.5 text-sm hover:bg-accent text-left"
-											onclick={() => {
-												assigningUserId = assigningUserId === user.id ? null : user.id;
-												openMenuUserId = null;
-											}}
-										>
-											<Users class="h-3.5 w-3.5 shrink-0" />
-											{t(locale, 'page.admin.menuCompanions')}
-										</button>
-										<button
-											type="button"
-											role="menuitem"
-											class="w-full flex items-center gap-2.5 px-3 py-1.5 text-sm hover:bg-accent text-left"
-											onclick={() => {
-												managingShiftsUserId = managingShiftsUserId === user.id ? null : user.id;
-												openMenuUserId = null;
-											}}
-										>
-											<CalendarClock class="h-3.5 w-3.5 shrink-0" />
-											{t(locale, 'page.admin.menuShifts')}
-											{#if userShifts(user.id).length > 0}
-												<Badge variant="secondary" class="ml-auto text-[10px] px-1.5 py-0">
-													{userShifts(user.id).length}
-												</Badge>
-											{/if}
-										</button>
-									{/if}
-
-									{#if user.id !== data.currentUserId}
-										<button
-											type="button"
-											role="menuitem"
-											class="w-full flex items-center gap-2.5 px-3 py-1.5 text-sm hover:bg-accent text-left text-red-600 dark:text-red-400 hover:text-red-600"
-											onclick={() => {
-												openMenuUserId = null;
-												toggleActiveForm(user.id);
-											}}
-										>
-											{#if user.isActive}
-												<UserX class="h-3.5 w-3.5 shrink-0" />
-												{t(locale, 'page.admin.menuDeactivate')}
-											{:else}
-												<UserCheck class="h-3.5 w-3.5 shrink-0" />
-												{t(locale, 'page.admin.menuActivate')}
-											{/if}
-										</button>
-									{/if}
-
-									<button
-										type="button"
-										role="menuitem"
-										class="w-full flex items-center gap-2.5 px-3 py-1.5 text-sm hover:bg-accent text-left"
-										onclick={() => {
-											resetingUserId = resetingUserId === user.id ? null : user.id;
-											openMenuUserId = null;
-										}}
-									>
-										<KeyRound class="h-3.5 w-3.5 shrink-0" />
-										{t(locale, 'page.admin.menuResetPassword')}
-									</button>
-								</div>
-							{/if}
-						</div>
-					</div>
+					{/if}
+					<p class="text-xs mt-0.5 text-muted-foreground">
+						{t(locale, 'page.admin.joined')}
+						<LocalTime date={user.createdAt} />
+						{#if user.lastLoginAt}&nbsp;· {t(locale, 'page.admin.lastLogin')}
+							<LocalTime date={user.lastLoginAt} />{/if}
+					</p>
 				</div>
-
-				<!-- Edit user panel -->
-				{#if editingUserId === user.id}
-					<form
-						method="POST"
-						action="?/editUser"
-						use:enhance={() =>
-							({ result, update }) => {
-								update();
-								if (result.type === 'success') editingUserId = null;
-							}}
-						class="space-y-4 animate-slide-up rounded-lg border border-border bg-muted/30 p-4"
-					>
-						<input type="hidden" name="userId" value={user.id} />
-						<p class="text-xs font-medium text-muted-foreground">
-							{t(locale, 'page.admin.editUserLabel', { name: user.displayName })}
-						</p>
-						<div class="grid grid-cols-2 gap-3">
-							<div class="space-y-1.5">
-								<Label for="edit-displayName-{user.id}" class="text-xs"
-									>{t(locale, 'page.admin.labelDisplayName')}</Label
-								>
-								<Input
-									id="edit-displayName-{user.id}"
-									name="displayName"
-									class="h-8 text-sm"
-									autocomplete="name"
-									value={user.displayName}
-									required
-								/>
-							</div>
-							<div class="space-y-1.5">
-								<Label for="edit-username-{user.id}" class="text-xs"
-									>{t(locale, 'page.admin.labelUsername')}</Label
-								>
-								<Input
-									id="edit-username-{user.id}"
-									name="username"
-									class="h-8 text-sm"
-									autocomplete="username"
-									value={user.username}
-									required
-								/>
-							</div>
-						</div>
-						<div class="grid grid-cols-2 gap-3">
-							<div class="space-y-1.5">
-								<Label for="edit-email-{user.id}" class="text-xs"
-									>{t(locale, 'page.admin.labelEmail')}
-									<span class="font-normal text-muted-foreground"
-										>{t(locale, 'page.admin.labelOptional')}</span
-									></Label
-								>
-								<Input
-									id="edit-email-{user.id}"
-									name="email"
-									type="email"
-									class="h-8 text-sm"
-									autocomplete="email"
-									value={user.email ?? ''}
-									placeholder="radical@edward.com"
-								/>
-							</div>
-							<div class="space-y-1.5">
-								<Label for="edit-phone-{user.id}" class="text-xs"
-									>{t(locale, 'page.admin.labelPhone')}
-									<span class="font-normal text-muted-foreground"
-										>{t(locale, 'page.admin.labelOptional')}</span
-									></Label
-								>
-								<Input
-									id="edit-phone-{user.id}"
-									name="phone"
-									type="tel"
-									class="h-8 text-sm"
-									autocomplete="tel"
-									value={user.phone ?? ''}
-									placeholder="(555) 000-0000"
-								/>
-							</div>
-						</div>
-						<div class="space-y-1.5">
-							<Label for="edit-role-{user.id}" class="text-xs"
-								>{t(locale, 'page.admin.labelRole')}</Label
-							>
-							<Select id="edit-role-{user.id}" name="role" class="h-8">
-								<option value="member" selected={user.role === 'member'}
-									>{t(locale, 'enum.role.member')}</option
-								>
-								<option value="admin" selected={user.role === 'admin'}
-									>{t(locale, 'enum.role.admin')}</option
-								>
-								<option value="caretaker" selected={user.role === 'caretaker'}
-									>{t(locale, 'enum.role.caretaker')}</option
-								>
-							</Select>
-						</div>
-						<div class="flex gap-2">
-							<Button type="submit" size="sm">{t(locale, 'common.save')}</Button>
-							<Button
-								type="button"
-								variant="secondary"
-								size="sm"
-								onclick={() => (editingUserId = null)}>{t(locale, 'common.cancel')}</Button
-							>
-						</div>
-					</form>
-				{/if}
-
-				<!-- Companion assignment panel -->
-				{#if assigningUserId === user.id}
-					<form
-						method="POST"
-						action="?/assignCompanions"
-						use:enhance={() =>
-							({ update }) => {
-								update();
-								assigningUserId = null;
-							}}
-						class="space-y-3 animate-slide-up rounded-lg border border-border bg-muted/30 p-4"
-					>
-						<input type="hidden" name="userId" value={user.id} />
-						<p class="text-xs font-medium text-muted-foreground">
-							{t(locale, 'page.admin.assignCompanionsLabel', { name: user.displayName })}
-						</p>
-						{#if data.companions.length === 0}
-							<p class="text-xs text-muted-foreground">
-								{t(locale, 'page.admin.noActiveCompanions')}
-							</p>
-						{:else}
-							<div class="space-y-2">
-								{#each data.companions as companion (companion.id)}
-									<label class="flex items-center gap-2 cursor-pointer">
-										<input
-											id="companionId-{companion.id}"
-											type="checkbox"
-											name="companionId"
-											value={companion.id}
-											checked={assignedCompanionIds(user.id).includes(companion.id)}
-											class="rounded border-border"
-										/>
-										<span class="text-sm text-foreground">{companion.name}</span>
-										{#if companion.breed}<span class="text-xs text-muted-foreground"
-												>{companion.breed}</span
-											>{/if}
-									</label>
-								{/each}
-							</div>
-						{/if}
-						<div class="flex gap-2">
-							<Button type="submit" size="sm">{t(locale, 'common.save')}</Button>
-							<Button
-								type="button"
-								variant="secondary"
-								size="sm"
-								onclick={() => (assigningUserId = null)}>{t(locale, 'common.cancel')}</Button
-							>
-						</div>
-					</form>
-				{/if}
-
-				<!-- Shifts management panel -->
-				{#if managingShiftsUserId === user.id}
-					<div class="space-y-4 animate-slide-up rounded-lg border border-border bg-muted/30 p-4">
-						<p class="text-xs font-medium text-muted-foreground">
-							{t(locale, 'page.admin.shiftsForUser', { name: user.displayName })}
-						</p>
-
-						{#if userShifts(user.id).length === 0}
-							<p class="text-xs text-muted-foreground">
-								{t(locale, 'page.admin.noShiftsScheduled')}
-							</p>
-						{:else}
-							<div class="space-y-2">
-								{#each userShifts(user.id) as shift (shift.id)}
-									{#if editingShiftId === shift.id}
-										<form
-											method="POST"
-											action="?/updateShift"
-											use:localDatetimes
-											use:enhance={() =>
-												({ update }) => {
-													update();
-													editingShiftId = null;
-												}}
-											class="space-y-3 rounded-lg border border-border px-3 py-3 animate-slide-up bg-background"
-										>
-											<input type="hidden" name="shiftId" value={shift.id} />
-											<div class="grid grid-cols-2 gap-3">
-												<div class="space-y-1">
-													<Label for="edit-start-{shift.id}" class="text-xs"
-														>{t(locale, 'page.admin.shiftLabelStart')}</Label
-													>
-													<Input
-														id="edit-start-{shift.id}"
-														name="startAt"
-														type="datetime-local"
-														autocomplete="off"
-														class="h-8 text-sm"
-														value={localDatetimeISO(shift.startAt)}
-														required
-													/>
-												</div>
-												<div class="space-y-1">
-													<Label for="edit-end-{shift.id}" class="text-xs"
-														>{t(locale, 'page.admin.shiftLabelEnd')}</Label
-													>
-													<Input
-														id="edit-end-{shift.id}"
-														name="endAt"
-														type="datetime-local"
-														autocomplete="off"
-														class="h-8 text-sm"
-														value={localDatetimeISO(shift.endAt)}
-														required
-													/>
-												</div>
-											</div>
-											<div class="space-y-1">
-												<Label for="edit-notes-{shift.id}" class="text-xs"
-													>{t(locale, 'page.admin.shiftLabelLabel')}
-													<span class="font-normal text-muted-foreground"
-														>{t(locale, 'page.admin.labelOptional')}</span
-													></Label
-												>
-												<Input
-													id="edit-notes-{shift.id}"
-													name="notes"
-													type="text"
-													autocomplete="off"
-													class="h-8 text-sm"
-													value={shift.notes ?? ''}
-													placeholder={t(locale, 'page.admin.shiftPlaceholder')}
-												/>
-											</div>
-											<div class="flex gap-2">
-												<Button type="submit" size="sm">{t(locale, 'common.save')}</Button>
-												<Button
-													type="button"
-													variant="secondary"
-													size="sm"
-													onclick={() => (editingShiftId = null)}
-													>{t(locale, 'common.cancel')}</Button
-												>
-											</div>
-										</form>
-									{:else}
-										<div
-											class="flex items-center justify-between gap-3 text-sm rounded-lg border border-border px-3 py-2 bg-background"
-										>
-											<div class="min-w-0 text-sm text-foreground">
-												<LocalTime date={shift.startAt} format="datetime" />
-												<span class="mx-1 text-muted-foreground">→</span>
-												<LocalTime date={shift.endAt} format="datetime" />
-												{#if shift.notes}<span class="ml-2 text-xs text-muted-foreground"
-														>{shift.notes}</span
-													>{/if}
-											</div>
-											<div class="flex gap-1 shrink-0">
-												<Button
-													type="button"
-													variant="soft"
-													size="sm"
-													class="h-7 text-xs"
-													onclick={() => (editingShiftId = shift.id)}
-													>{t(locale, 'common.edit')}</Button
-												>
-												<Button
-													type="button"
-													variant="softDestructive"
-													size="sm"
-													class="h-7 gap-1.5 px-2 text-xs"
-													onclick={() => {
-														deleteShiftId = shift.id;
-														confirmOpen = true;
-													}}
-												>
-													<Trash2 class="h-3.5 w-3.5" />
-													<span class="hidden sm:inline">{t(locale, 'common.delete')}</span>
-												</Button>
-											</div>
-										</div>
-									{/if}
-								{/each}
-							</div>
-						{/if}
-
-						<form
-							method="POST"
-							action="?/addShift"
-							use:localDatetimes
-							use:enhance
-							class="space-y-3 pt-3 border-t border-border"
-						>
-							<input type="hidden" name="userId" value={user.id} />
-							<p class="text-xs font-medium text-muted-foreground">
-								{t(locale, 'page.admin.addShiftLabel')}
-							</p>
-							<div class="grid grid-cols-2 gap-3">
-								<div class="space-y-1">
-									<Label for="shift-start-{user.id}" class="text-xs"
-										>{t(locale, 'page.admin.shiftLabelStart')}</Label
-									>
-									<Input
-										id="shift-start-{user.id}"
-										name="startAt"
-										type="datetime-local"
-										autocomplete="off"
-										class="h-8 text-sm"
-										required
-									/>
-								</div>
-								<div class="space-y-1">
-									<Label for="shift-end-{user.id}" class="text-xs"
-										>{t(locale, 'page.admin.shiftLabelEnd')}</Label
-									>
-									<Input
-										id="shift-end-{user.id}"
-										name="endAt"
-										type="datetime-local"
-										autocomplete="off"
-										class="h-8 text-sm"
-										required
-									/>
-								</div>
-							</div>
-							<div class="space-y-1">
-								<Label for="shift-notes-{user.id}" class="text-xs"
-									>{t(locale, 'page.admin.shiftLabelLabel')}
-									<span class="font-normal text-muted-foreground"
-										>{t(locale, 'page.admin.labelOptional')}</span
-									></Label
-								>
-								<Input
-									id="shift-notes-{user.id}"
-									name="notes"
-									type="text"
-									autocomplete="off"
-									class="h-8 text-sm"
-									placeholder={t(locale, 'page.admin.shiftPlaceholder')}
-								/>
-							</div>
-							<div class="flex gap-2">
-								<Button type="submit" size="sm">{t(locale, 'page.admin.addShiftSubmit')}</Button>
-								<Button
-									type="button"
-									variant="secondary"
-									size="sm"
-									onclick={() => (managingShiftsUserId = null)}>{t(locale, 'common.close')}</Button
-								>
-							</div>
-						</form>
-					</div>
-				{/if}
-
-				<!-- Reset password panel -->
-				{#if resetingUserId === user.id}
-					<form
-						method="POST"
-						action="?/resetPassword"
-						use:enhance={() =>
-							({ update }) => {
-								update();
-								resetingUserId = null;
-							}}
-						class="flex gap-2 animate-slide-up"
-					>
-						<input type="hidden" name="userId" value={user.id} />
-						<Input
-							id="newPassword"
-							name="newPassword"
-							type="password"
-							autocomplete="new-password"
-							class="max-w-[200px] h-9 text-sm"
-							placeholder={t(locale, 'page.admin.newPasswordPlaceholder')}
-							minlength={8}
-							required
-						/>
-						<Button type="submit" size="sm">{t(locale, 'page.admin.setPassword')}</Button>
-						<Button
-							type="button"
-							variant="secondary"
-							size="sm"
-							onclick={() => (resetingUserId = null)}>{t(locale, 'common.cancel')}</Button
-						>
-					</form>
-				{/if}
+				<Button variant="soft" size="sm" class="shrink-0" onclick={() => (manageUserId = user.id)}>
+					{t(locale, 'page.admin.manage')}
+				</Button>
 			</div>
 		{/each}
 	</Card>
 </div>
 
-<form bind:this={deleteShiftForm} method="POST" action="?/deleteShift" use:enhance class="hidden">
-	<input type="hidden" name="shiftId" value={deleteShiftId} />
-</form>
-
-<form
-	bind:this={toggleActiveFormEl}
-	method="POST"
-	action="?/toggleActive"
-	use:enhance
-	class="hidden"
->
-	<input type="hidden" name="userId" value={toggleActiveUserId} />
-</form>
-
-<ConfirmDialog
-	open={confirmOpen}
-	message={t(locale, 'component.confirmDialog.cantBeUndone')}
-	onconfirm={() => {
-		confirmOpen = false;
-		deleteShiftForm?.requestSubmit();
-	}}
-	oncancel={() => (confirmOpen = false)}
-/>
+{#if manageUser}
+	<UserManageDrawer
+		user={manageUser}
+		companions={data.companions}
+		assignments={data.assignments}
+		shifts={data.shifts}
+		currentUserId={data.currentUserId}
+		onclose={() => (manageUserId = null)}
+	/>
+{/if}

--- a/src/routes/(app)/(admin)/admin/users/+page.svelte
+++ b/src/routes/(app)/(admin)/admin/users/+page.svelte
@@ -154,7 +154,7 @@
 							)}</Badge
 						>
 						{#if !user.isActive}
-							<Badge variant="destructiveSoft">{t(locale, 'page.admin.inactiveBadge')}</Badge>
+							<Badge variant="coral">{t(locale, 'page.admin.inactiveBadge')}</Badge>
 						{/if}
 					</div>
 					{#if user.email || user.phone}

--- a/src/routes/(app)/(admin)/admin/users/+page.svelte
+++ b/src/routes/(app)/(admin)/admin/users/+page.svelte
@@ -154,7 +154,7 @@
 							)}</Badge
 						>
 						{#if !user.isActive}
-							<Badge variant="destructive">{t(locale, 'page.admin.inactiveBadge')}</Badge>
+							<Badge variant="destructiveSoft">{t(locale, 'page.admin.inactiveBadge')}</Badge>
 						{/if}
 					</div>
 					{#if user.email || user.phone}

--- a/tests/e2e/admin-companions.spec.ts
+++ b/tests/e2e/admin-companions.spec.ts
@@ -16,4 +16,14 @@ test.describe('admin-companions', () => {
 		const res = await asMember.request.get('/admin/companions');
 		expect(res.status()).toBe(403);
 	});
+
+	test('sub-nav switches to users', async ({ asAdmin }) => {
+		await asAdmin.goto('/admin/companions');
+		await expect(asAdmin).toHaveURL(/\/admin\/companions/, { timeout: 10_000 });
+		await asAdmin
+			.getByRole('navigation', { name: /admin sections/i })
+			.getByRole('link', { name: /users/i })
+			.click();
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+	});
 });

--- a/tests/e2e/admin-users.spec.ts
+++ b/tests/e2e/admin-users.spec.ts
@@ -120,7 +120,7 @@ test.describe('admin-users', () => {
 		await dialog.getByRole('button', { name: /deactivate/i }).click();
 		await expect(userRow.getByText(/inactive/i)).toBeVisible({ timeout: 10_000 });
 		// Close the drawer so it doesn't intercept pointer events for the next open.
-		await asAdmin.getByRole('dialog').getByRole('button', { name: /close/i }).first().click();
+		await dialog.getByRole('button', { name: /close/i }).click();
 		await expect(asAdmin.getByRole('dialog')).toHaveCount(0, { timeout: 4_000 });
 
 		// Login with deactivated account should fail (stay on login page).
@@ -215,7 +215,7 @@ test.describe('admin-users', () => {
 		await resetPanel.locator('input[name="newPassword"]').fill(newPassword);
 		await resetPanel.getByRole('button', { name: /set password/i }).click();
 		// Drawer stays open; close it before the re-login checks.
-		await asAdmin.getByRole('dialog').getByRole('button', { name: /close/i }).first().click();
+		await dialog.getByRole('button', { name: /close/i }).click();
 		await expect(asAdmin.getByRole('dialog')).toHaveCount(0, { timeout: 4_000 });
 
 		// Old password no longer works.

--- a/tests/e2e/admin-users.spec.ts
+++ b/tests/e2e/admin-users.spec.ts
@@ -112,7 +112,7 @@ test.describe('admin-users', () => {
 		await form.getByRole('button', { name: /create user/i }).click();
 		await expect(asAdmin.getByText(/user created successfully/i)).toBeVisible({ timeout: 10_000 });
 
-		// Deactivate via More Actions menu.
+		// Deactivate via the Manage drawer.
 		const userRow = asAdmin.locator('div.px-6.py-4').filter({ hasText: 'e2e-user-3' });
 		await expect(userRow).toBeVisible({ timeout: 6_000 });
 

--- a/tests/e2e/admin-users.spec.ts
+++ b/tests/e2e/admin-users.spec.ts
@@ -22,6 +22,16 @@ async function loginAs(
 
 const INITIAL_PASSWORD = 'e2e-password-123';
 
+// Opens the Manage drawer for the user row containing `username`, returns the dialog locator.
+async function openManage(page: import('@playwright/test').Page, username: string) {
+	const row = page.locator('div.px-6.py-4').filter({ hasText: username });
+	await expect(row).toBeVisible({ timeout: 6_000 });
+	await row.getByRole('button', { name: /manage/i }).click();
+	const dialog = page.getByRole('dialog');
+	await expect(dialog).toBeVisible({ timeout: 4_000 });
+	return dialog;
+}
+
 test.describe('admin-users', () => {
 	// -----------------------------------------------------------------------
 	// 1. Admin creates a new user and it appears in the list.
@@ -106,13 +116,12 @@ test.describe('admin-users', () => {
 		const userRow = asAdmin.locator('div.px-6.py-4').filter({ hasText: 'e2e-user-3' });
 		await expect(userRow).toBeVisible({ timeout: 6_000 });
 
-		await userRow.getByRole('button', { name: /more actions/i }).click();
-		const deactivateItem = asAdmin.getByRole('menuitem', { name: /deactivate/i });
-		await expect(deactivateItem).toBeVisible({ timeout: 4_000 });
-		await deactivateItem.click();
-
-		// Wait for the inactive badge to appear.
+		let dialog = await openManage(asAdmin, 'e2e-user-3');
+		await dialog.getByRole('button', { name: /deactivate/i }).click();
 		await expect(userRow.getByText(/inactive/i)).toBeVisible({ timeout: 10_000 });
+		// Close the drawer so it doesn't intercept pointer events for the next open.
+		await asAdmin.getByRole('dialog').getByRole('button', { name: /close/i }).first().click();
+		await expect(asAdmin.getByRole('dialog')).toHaveCount(0, { timeout: 4_000 });
 
 		// Login with deactivated account should fail (stay on login page).
 		const ctx1 = await browser.newContext({ baseURL: app.server.baseURL });
@@ -126,13 +135,9 @@ test.describe('admin-users', () => {
 		await expect(loginPage1.locator('body')).not.toBeEmpty();
 		await ctx1.close();
 
-		// Reactivate via More Actions menu.
-		await userRow.getByRole('button', { name: /more actions/i }).click();
-		const activateItem = asAdmin.getByRole('menuitem', { name: /activate/i });
-		await expect(activateItem).toBeVisible({ timeout: 4_000 });
-		await activateItem.click();
-
-		// Inactive badge should disappear.
+		// Reactivate via Manage drawer.
+		dialog = await openManage(asAdmin, 'e2e-user-3');
+		await dialog.getByRole('button', { name: /^activate/i }).click();
 		await expect(userRow.getByText(/inactive/i)).toHaveCount(0, { timeout: 10_000 });
 
 		// Login now succeeds.
@@ -166,27 +171,17 @@ test.describe('admin-users', () => {
 		await form.getByRole('button', { name: /create user/i }).click();
 		await expect(asAdmin.getByText(/user created successfully/i)).toBeVisible({ timeout: 10_000 });
 
-		// Click the inline Edit button on the user row.
 		const userRow = asAdmin.locator('div.px-6.py-4').filter({ hasText: 'e2e-user-4' });
 		await expect(userRow).toBeVisible({ timeout: 6_000 });
 
-		await userRow.getByRole('button', { name: /edit/i }).click();
-
-		// The inline edit form expands within the same row.
-		const editForm = userRow.locator('form[action="?/editUser"]');
+		const dialog = await openManage(asAdmin, 'e2e-user-4');
+		const editForm = dialog.locator('form[action="?/editUser"]');
 		await expect(editForm).toBeVisible({ timeout: 4_000 });
-
-		// Clear and re-fill the displayName field.
 		const displayNameInput = editForm.locator('input[name="displayName"]');
 		await displayNameInput.clear();
 		await displayNameInput.fill('E2E Renamed');
-
 		await editForm.getByRole('button', { name: /save/i }).click();
-
-		// Success feedback.
 		await expect(asAdmin.getByText(/user updated successfully/i)).toBeVisible({ timeout: 10_000 });
-
-		// The row should now show the new display name.
 		await expect(userRow.getByText('E2E Renamed')).toBeVisible({ timeout: 6_000 });
 	});
 
@@ -213,23 +208,15 @@ test.describe('admin-users', () => {
 		const userRow = asAdmin.locator('div.px-6.py-4').filter({ hasText: 'e2e-user-5' });
 		await expect(userRow).toBeVisible({ timeout: 6_000 });
 
-		// Open More Actions → Reset Password.
-		await userRow.getByRole('button', { name: /more actions/i }).click();
-		const resetItem = asAdmin.getByRole('menuitem', { name: /reset password/i });
-		await expect(resetItem).toBeVisible({ timeout: 4_000 });
-		await resetItem.click();
-
-		// The reset-password inline panel appears (within the same row).
-		// Admin types the new password directly — there is no server-generated token.
-		const resetPanel = userRow.locator('form[action="?/resetPassword"]');
+		const dialog = await openManage(asAdmin, 'e2e-user-5');
+		const resetPanel = dialog.locator('form[action="?/resetPassword"]');
 		await expect(resetPanel).toBeVisible({ timeout: 4_000 });
-
 		const newPassword = 'e2e-new-password-456';
 		await resetPanel.locator('input[name="newPassword"]').fill(newPassword);
 		await resetPanel.getByRole('button', { name: /set password/i }).click();
-
-		// Panel disappears; no error shown.
-		await expect(resetPanel).toHaveCount(0, { timeout: 10_000 });
+		// Drawer stays open; close it before the re-login checks.
+		await asAdmin.getByRole('dialog').getByRole('button', { name: /close/i }).first().click();
+		await expect(asAdmin.getByRole('dialog')).toHaveCount(0, { timeout: 4_000 });
 
 		// Old password no longer works.
 		const ctx1 = await browser.newContext({ baseURL: app.server.baseURL });
@@ -250,5 +237,20 @@ test.describe('admin-users', () => {
 		);
 		await expect(newPassPage).not.toHaveURL(/auth\/login/, { timeout: 10_000 });
 		await cleanup();
+	});
+
+	// -----------------------------------------------------------------------
+	// 6. Sub-nav switches to companions; role badge shows for admin user.
+	// -----------------------------------------------------------------------
+	test('sub-nav switches to companions; role badge shows', async ({ asAdmin }) => {
+		await asAdmin.goto('/admin/users');
+		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
+		const adminRow = asAdmin.locator('div.px-6.py-4').filter({ hasText: 'seed-admin' });
+		await expect(adminRow.getByText('Admin', { exact: true })).toBeVisible({ timeout: 6_000 });
+		await asAdmin
+			.getByRole('navigation', { name: /admin sections/i })
+			.getByRole('link', { name: /companions/i })
+			.click();
+		await expect(asAdmin).toHaveURL(/\/admin\/companions/, { timeout: 10_000 });
 	});
 });

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -258,19 +258,20 @@ test('shift start email fires for caretaker', async ({ world, browser }) => {
 		.filter({ hasText: SEED.caretaker.displayName });
 	await expect(caretakerRow).toBeVisible({ timeout: 8_000 });
 
-	await caretakerRow.getByRole('button', { name: /more actions/i }).click();
-	await adminPage.getByRole('menuitem', { name: /shifts/i }).click();
+	await caretakerRow.getByRole('button', { name: /manage/i }).click();
+	const dialog = adminPage.getByRole('dialog');
+	await expect(dialog).toBeVisible({ timeout: 4_000 });
 
-	const panel = caretakerRow.locator('div.rounded-lg.border.border-border.bg-muted\\/30');
-	await expect(panel).toBeVisible({ timeout: 4_000 });
+	const addForm = dialog.locator('form[action="?/addShift"]');
+	await expect(addForm).toBeVisible({ timeout: 4_000 });
 
-	await panel.locator('input[name="startAt"]').fill(inNineHours());
-	await panel.locator('input[name="endAt"]').fill(inTenHours());
-	await panel.locator('input[name="notes"]').fill('e2e-notify-shift');
-	await panel.getByRole('button', { name: /add shift/i }).click();
+	await addForm.locator('input[name="startAt"]').fill(inNineHours());
+	await addForm.locator('input[name="endAt"]').fill(inTenHours());
+	await addForm.locator('input[name="notes"]').fill('e2e-notify-shift');
+	await addForm.getByRole('button', { name: /add shift/i }).click();
 
-	// After submission the panel re-renders with the new shift row.
-	await expect(panel.getByText('e2e-notify-shift')).toBeVisible({ timeout: 10_000 });
+	// After submission the drawer stays open and the new shift row appears.
+	await expect(dialog.getByText('e2e-notify-shift')).toBeVisible({ timeout: 10_000 });
 	await adminCtx.close();
 
 	// Wait for the scheduler to emit the shift-start email.

--- a/tests/e2e/shifts.spec.ts
+++ b/tests/e2e/shifts.spec.ts
@@ -26,55 +26,41 @@ test.describe('shifts', () => {
 		await asAdmin.goto('/admin/users');
 		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
 
-		// Find the seed-caretaker row and open the overflow menu.
-		// The row contains both the displayName and the username badge.
+		// Find the seed-caretaker row and open the Manage drawer.
 		const caretakerRow = asAdmin
 			.locator('div.px-6.py-4')
 			.filter({ hasText: SEED.caretaker.displayName });
 		await expect(caretakerRow).toBeVisible({ timeout: 8_000 });
 
-		const menuButton = caretakerRow.getByRole('button', { name: /more actions/i });
-		await menuButton.click();
+		await caretakerRow.getByRole('button', { name: /manage/i }).click();
+		const dialog = asAdmin.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 4_000 });
 
-		// Overflow menu is now open; click "Shifts".
-		const shiftsMenuItem = asAdmin.getByRole('menuitem', { name: /shifts/i });
-		await expect(shiftsMenuItem).toBeVisible({ timeout: 4_000 });
-		await shiftsMenuItem.click();
-
-		// The shifts management panel should now be visible for this user.
-		// "Add shift" form is rendered inside the panel.
-		// The startAt / endAt inputs have ids like shift-start-{userId}.
-		// Use name attributes which are unique within the visible panel.
-		const panel = caretakerRow.locator('div.rounded-lg.border.border-border.bg-muted\\/30');
-		await expect(panel).toBeVisible({ timeout: 4_000 });
-
-		const startInput = panel.locator('input[name="startAt"]');
-		const endInput = panel.locator('input[name="endAt"]');
-		const notesInput = panel.locator('input[name="notes"]');
+		// The Shifts section's add-shift form lives inside the drawer.
+		// (Scope to the addShift form so the inputs don't collide with an
+		// edit-shift form if one were open.)
+		const addForm = dialog.locator('form[action="?/addShift"]');
+		await expect(addForm).toBeVisible({ timeout: 4_000 });
 
 		// Fill tomorrow 09:00–17:00. The form uses use:localDatetimes which converts
-		// datetime-local values to ISO on formdata event (triggered by enhance).
-		// Playwright fills the <input type="datetime-local"> directly; the action
-		// fires when the form submits via enhance.
-		await startInput.fill(tomorrowDatetimeLocal(9));
-		await endInput.fill(tomorrowDatetimeLocal(17));
-		await notesInput.fill('e2e-shift-note');
+		// datetime-local values to ISO on the formdata event (triggered by enhance).
+		await addForm.locator('input[name="startAt"]').fill(tomorrowDatetimeLocal(9));
+		await addForm.locator('input[name="endAt"]').fill(tomorrowDatetimeLocal(17));
+		await addForm.locator('input[name="notes"]').fill('e2e-shift-note');
 
-		await panel.getByRole('button', { name: /add shift/i }).click();
+		await addForm.getByRole('button', { name: /add shift/i }).click();
 
-		// After submission the page re-loads (SvelteKit enhance invalidates loader).
-		// The new shift should appear in the shifts list for the caretaker.
-		// The panel re-opens because managingShiftsUserId stays set until "Close".
-		// The shift is rendered as a row inside the same panel showing LocalTime dates.
-		// We assert the note is visible (rendered as a muted text span next to the times).
-		await expect(panel.getByText('e2e-shift-note')).toBeVisible({ timeout: 10_000 });
+		// After submission the page re-loads (enhance invalidates the loader) and the
+		// drawer stays open; the new shift appears as a row inside the Shifts section,
+		// showing the note next to the times.
+		await expect(dialog.getByText('e2e-shift-note')).toBeVisible({ timeout: 10_000 });
 	});
 
 	test('caretaker sees the upcoming shift on the settings page', async ({
 		asAdmin,
 		asCaretaker
 	}) => {
-		// First, ensure the shift exists — add it as admin.
+		// First, ensure the shift exists — add it as admin via the Manage drawer.
 		await asAdmin.goto('/admin/users');
 		await expect(asAdmin).toHaveURL(/\/admin\/users/, { timeout: 10_000 });
 
@@ -83,20 +69,19 @@ test.describe('shifts', () => {
 			.filter({ hasText: SEED.caretaker.displayName });
 		await expect(caretakerRow).toBeVisible({ timeout: 8_000 });
 
-		await caretakerRow.getByRole('button', { name: /more actions/i }).click();
-		await asAdmin.getByRole('menuitem', { name: /shifts/i }).click();
-
-		const panel = caretakerRow.locator('div.rounded-lg.border.border-border.bg-muted\\/30');
-		await expect(panel).toBeVisible({ timeout: 4_000 });
+		await caretakerRow.getByRole('button', { name: /manage/i }).click();
+		const dialog = asAdmin.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 4_000 });
 
 		// Only add if the note isn't already there (idempotent guard).
-		const alreadyPresent = await panel.getByText('e2e-shift-note').isVisible();
+		const alreadyPresent = await dialog.getByText('e2e-shift-note').isVisible();
 		if (!alreadyPresent) {
-			await panel.locator('input[name="startAt"]').fill(tomorrowDatetimeLocal(9));
-			await panel.locator('input[name="endAt"]').fill(tomorrowDatetimeLocal(17));
-			await panel.locator('input[name="notes"]').fill('e2e-shift-note');
-			await panel.getByRole('button', { name: /add shift/i }).click();
-			await expect(panel.getByText('e2e-shift-note')).toBeVisible({ timeout: 10_000 });
+			const addForm = dialog.locator('form[action="?/addShift"]');
+			await addForm.locator('input[name="startAt"]').fill(tomorrowDatetimeLocal(9));
+			await addForm.locator('input[name="endAt"]').fill(tomorrowDatetimeLocal(17));
+			await addForm.locator('input[name="notes"]').fill('e2e-shift-note');
+			await addForm.getByRole('button', { name: /add shift/i }).click();
+			await expect(dialog.getByText('e2e-shift-note')).toBeVisible({ timeout: 10_000 });
 		}
 
 		// Now check the caretaker's settings "My Shifts" card.
@@ -114,8 +99,6 @@ test.describe('shifts', () => {
 
 		// The card header badge shows the total count of upcoming shifts (≥ 2).
 		// Badge renders as a <div> with CVA classes containing "rounded-full".
-		// The badge is `<Badge variant="secondary" class="ml-auto">{count}</Badge>`.
-		// Locate by the rounded-full class which is unique to Badge components.
 		// The seed active shift + new shift = 2 total upcoming.
 		const countBadge = shiftsCard.locator('div[class*="rounded-full"]').first();
 		const countText = await countBadge.textContent({ timeout: 8_000 });


### PR DESCRIPTION
Fifth redesign sub-project. Reskins the two admin page bodies (`admin/users`, `admin/companions`) into the Companion design language, with no server/route/action changes. Stacks on SP4 (`redesign-sp4-caretaker-pages`).

## Changes

- **Shared admin sub-nav**: new `(admin)/+layout.svelte` with Users | Companions pill tabs (active by pathname, i18n aria-label). Admin sections were previously reachable only via the account sheet.
- **Users page → Manage drawer**: each user row's inline Edit button + overflow menu and the four inline-expand panels (edit / assign companions / shifts / reset password) are replaced by a single **Manage** button opening a right-side slide-over (`UserManageDrawer.svelte`) with stacked sections: Profile (name/username/email/phone/role), Assigned companions and Shifts (caretaker only), Password, and Deactivate/Activate. ~600 lines removed from the page. Role badges use Companion tokens (admin = soft violet, caretaker = teal, member = neutral); the deactivate action uses the soft-destructive token, not raw red.
- **Companions page**: teal Active badge (was `moss`), i18n for previously-hardcoded English.
- **Badge**: new soft `primary` variant for the admin role badge.
- **Drawer polish**: proper right-edge slide animation (`animate-slide-in-right` added to `app.css`); focus trap with focus-return on close, Escape, labelled controls; shift rows stack start/end on their own lines and both shift forms stack the datetime inputs (drawer is ~380px); email/phone placeholders; inactive badge uses the coral token.

## Tokens / i18n / tests

- All `bark`/`moss`/`sky` and raw `text-red-*` removed from both admin pages and the new component (variant definitions kept — the setup wizard still uses them).
- New i18n keys across all six locales.
- `admin-users.spec.ts` reworked to drive the drawer; `admin-companions.spec.ts` + both specs gain sub-nav coverage. All existing auth/credential assertions preserved.

Gates: lint, check (0 errors), 194 unit, build, admin e2e 9/9 green.

Review fixes worth noting: caught a reset-password blocker (drawer form was missing the hidden `userId`), a no-op drawer animation, and several drawer a11y gaps.