### PR TITLE
Redesign SP6: auth + onboarding

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -418,6 +418,14 @@
 	.prose hr {
 		border-color: hsl(var(--border));
 	}
+
+	/* Auth brand hero gradient (login + setup panels, forgot/reset backdrop) */
+	.bg-auth-brand {
+		background:
+			radial-gradient(130% 130% at 0% 0%, hsl(252 100% 65% / 0.55), transparent 55%),
+			radial-gradient(130% 130% at 100% 100%, hsl(13 100% 67% / 0.5), transparent 55%),
+			hsl(237 28% 11%);
+	}
 }
 
 /* ============================================================

--- a/src/lib/components/auth/AuthBackdrop.svelte
+++ b/src/lib/components/auth/AuthBackdrop.svelte
@@ -2,14 +2,14 @@
 	import type { Snippet } from 'svelte';
 	import PawLogo from '$lib/components/PawLogo.svelte';
 
-	let { children }: { children: Snippet } = $props();
+	let { children, linkLabel }: { children: Snippet; linkLabel: string } = $props();
 </script>
 
 <div class="bg-auth-brand flex min-h-screen items-center justify-center p-4">
 	<div class="w-full max-w-sm">
 		<a
 			href="/auth/login"
-			aria-label="Go to sign in"
+			aria-label={linkLabel}
 			class="mb-6 flex items-center justify-center gap-2.5"
 		>
 			<div

--- a/src/lib/components/auth/AuthBackdrop.svelte
+++ b/src/lib/components/auth/AuthBackdrop.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import PawLogo from '$lib/components/PawLogo.svelte';
+
+	let { children }: { children: Snippet } = $props();
+</script>
+
+<div class="bg-auth-brand flex min-h-screen items-center justify-center p-4">
+	<div class="w-full max-w-sm">
+		<a
+			href="/auth/login"
+			aria-label="EinVault"
+			class="mb-6 flex items-center justify-center gap-2.5"
+		>
+			<div
+				class="bg-brand-gradient flex h-9 w-9 shrink-0 items-center justify-center rounded-xl shadow-lg"
+				aria-hidden="true"
+			>
+				<PawLogo class="h-5 w-5 text-white" />
+			</div>
+			<span class="font-display text-xl font-extrabold tracking-tight text-white">EinVault</span>
+		</a>
+		{@render children()}
+	</div>
+</div>

--- a/src/lib/components/auth/AuthBackdrop.svelte
+++ b/src/lib/components/auth/AuthBackdrop.svelte
@@ -9,7 +9,7 @@
 	<div class="w-full max-w-sm">
 		<a
 			href="/auth/login"
-			aria-label="EinVault"
+			aria-label="Go to sign in"
 			class="mb-6 flex items-center justify-center gap-2.5"
 		>
 			<div

--- a/src/lib/components/auth/AuthBrandPanel.svelte
+++ b/src/lib/components/auth/AuthBrandPanel.svelte
@@ -19,7 +19,7 @@
 		aria-hidden="true"
 	></div>
 
-	<a href="/" class="relative z-10 flex items-center gap-2.5 self-start">
+	<a href="/" aria-label="EinVault home" class="relative z-10 flex items-center gap-2.5 self-start">
 		<div
 			class="bg-brand-gradient flex h-9 w-9 shrink-0 items-center justify-center rounded-xl shadow-lg"
 			aria-hidden="true"

--- a/src/lib/components/auth/AuthBrandPanel.svelte
+++ b/src/lib/components/auth/AuthBrandPanel.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import PawLogo from '$lib/components/PawLogo.svelte';
+
+	let { tagline, subtext, footer }: { tagline: string; subtext: string; footer: string } = $props();
+</script>
+
+<div
+	class="bg-auth-brand relative flex flex-col justify-between overflow-hidden px-8 py-7 text-white md:px-11 md:py-12"
+>
+	<!-- Radial accent blobs -->
+	<div
+		class="pointer-events-none absolute -left-20 -top-20 h-64 w-64 rounded-full opacity-20"
+		style="background: radial-gradient(circle, hsl(252 100% 65%), transparent 70%);"
+		aria-hidden="true"
+	></div>
+	<div
+		class="pointer-events-none absolute -bottom-16 -right-16 h-56 w-56 rounded-full opacity-15"
+		style="background: radial-gradient(circle, hsl(13 100% 67%), transparent 70%);"
+		aria-hidden="true"
+	></div>
+
+	<a href="/" class="relative z-10 flex items-center gap-2.5 self-start">
+		<div
+			class="bg-brand-gradient flex h-9 w-9 shrink-0 items-center justify-center rounded-xl shadow-lg"
+			aria-hidden="true"
+		>
+			<PawLogo class="h-5 w-5 text-white" />
+		</div>
+		<span class="font-display text-xl font-extrabold tracking-tight text-white">EinVault</span>
+	</a>
+
+	<div class="relative z-10 hidden md:block">
+		<p class="font-display text-4xl font-extrabold leading-[1.03] tracking-tight">{tagline}</p>
+		<p class="mt-3 max-w-[30ch] text-[15px] text-white/80">{subtext}</p>
+		<div class="mt-5 flex gap-2" aria-hidden="true">
+			<span class="h-2.5 w-2.5 rounded-full bg-primary"></span>
+			<span class="h-2.5 w-2.5 rounded-full bg-coral"></span>
+			<span class="h-2.5 w-2.5 rounded-full bg-gold"></span>
+			<span class="h-2.5 w-2.5 rounded-full bg-teal"></span>
+		</div>
+	</div>
+
+	<p class="relative z-10 hidden text-xs text-white/50 md:block">{footer}</p>
+</div>

--- a/src/lib/components/auth/AuthBrandPanel.svelte
+++ b/src/lib/components/auth/AuthBrandPanel.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import PawLogo from '$lib/components/PawLogo.svelte';
 
-	let { tagline, subtext, footer }: { tagline: string; subtext: string; footer: string } = $props();
+	let {
+		tagline,
+		subtext,
+		footer,
+		homeLabel
+	}: { tagline: string; subtext: string; footer: string; homeLabel: string } = $props();
 </script>
 
 <div
@@ -19,7 +24,7 @@
 		aria-hidden="true"
 	></div>
 
-	<a href="/" aria-label="EinVault home" class="relative z-10 flex items-center gap-2.5 self-start">
+	<a href="/" aria-label={homeLabel} class="relative z-10 flex items-center gap-2.5 self-start">
 		<div
 			class="bg-brand-gradient flex h-9 w-9 shrink-0 items-center justify-center rounded-xl shadow-lg"
 			aria-hidden="true"

--- a/src/lib/components/ui/alert/alert.svelte
+++ b/src/lib/components/ui/alert/alert.svelte
@@ -8,8 +8,7 @@
 				default: 'bg-card text-foreground',
 				destructive:
 					'border-destructive/50 bg-destructive/10 text-destructive dark:border-destructive/50 dark:bg-destructive/20 dark:text-red-400',
-				success:
-					'border-moss-200 bg-moss-50 text-moss-800 dark:border-moss-800 dark:bg-moss-950/50 dark:text-moss-300'
+				success: 'border-teal/30 bg-teal/10 text-teal'
 			}
 		},
 		defaultVariants: { variant: 'default' }

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -846,6 +846,8 @@ const messages: Record<keyof Messages, string> = {
 	// Aria labels
 	'aria.caretakerNav': 'Betreuer-Navigation',
 	'aria.adminNav': 'Verwaltungsbereiche',
+	'aria.einvaultHome': 'EinVault Startseite',
+	'aria.goToSignIn': 'Zur Anmeldung',
 	'aria.mainNav': 'Hauptnavigation',
 	'aria.moreActions': 'Weitere Aktionen',
 	'aria.deleteEntry': 'Eintrag löschen',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -306,6 +306,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.signIn': 'Anmelden',
 	'page.login.signingIn': 'Anmeldung…',
 	'page.login.forgotPassword': 'Passwort vergessen?',
+	'page.login.welcomeHeading': 'Willkommen zurück',
+	'page.login.welcomeSubtext': 'Melde dich an und mach dort weiter, wo du aufgehört hast.',
+	'page.login.taglineSubtext':
+		'Der selbst gehostete Tresor für Gesundheit, Tagebuch und tägliche Pflege deines Begleiters.',
+	'page.login.brandFooter': 'Deine Daten. Dein Server. Deine Begleiter.',
 
 	// Page: Forgot password
 	'page.forgot.title': 'Passwort zurücksetzen',
@@ -340,6 +345,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.setup.createAccount': 'Administratorkonto erstellen',
 	'page.setup.creatingAccount': 'Konto wird erstellt…',
 	'page.setup.firstRunNote': 'Diese Seite ist nur bei der Ersteinrichtung verfügbar.',
+	'page.setup.brandSubtext': 'Richte deinen Begleiter-Tresor ein.',
 
 	// Page: Error
 	'page.error.404.title': 'Seite nicht gefunden',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -836,6 +836,8 @@ const messages = {
 	// Aria labels
 	'aria.caretakerNav': 'Caretaker navigation',
 	'aria.adminNav': 'Admin sections',
+	'aria.einvaultHome': 'EinVault home',
+	'aria.goToSignIn': 'Go to sign in',
 	'aria.mainNav': 'Main navigation',
 	'aria.moreActions': 'More actions',
 	'aria.deleteEntry': 'Delete entry',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -299,6 +299,11 @@ const messages = {
 	'page.login.signIn': 'Sign in',
 	'page.login.signingIn': 'Signing in…',
 	'page.login.forgotPassword': 'Forgot password?',
+	'page.login.welcomeHeading': 'Welcome back',
+	'page.login.welcomeSubtext': 'Sign in to pick up where you left off.',
+	'page.login.taglineSubtext':
+		"The self-hosted vault for your companion's health, journal, and daily care.",
+	'page.login.brandFooter': 'Your data. Your server. Your companions.',
 
 	// Page: Forgot password
 	'page.forgot.title': 'Reset your password',
@@ -333,6 +338,7 @@ const messages = {
 	'page.setup.createAccount': 'Create Admin Account',
 	'page.setup.creatingAccount': 'Creating Account…',
 	'page.setup.firstRunNote': 'This page is only available on first run.',
+	'page.setup.brandSubtext': 'Set up your companion vault.',
 
 	// Page: Error
 	'page.error.404.title': 'Page not found',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -845,6 +845,8 @@ const messages: Record<keyof Messages, string> = {
 	// Aria labels
 	'aria.caretakerNav': 'Navegación del cuidador',
 	'aria.adminNav': 'Secciones de administración',
+	'aria.einvaultHome': 'Inicio de EinVault',
+	'aria.goToSignIn': 'Ir a iniciar sesión',
 	'aria.mainNav': 'Navegación principal',
 	'aria.moreActions': 'Más acciones',
 	'aria.deleteEntry': 'Eliminar entrada',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -306,6 +306,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.signIn': 'Iniciar sesión',
 	'page.login.signingIn': 'Iniciando sesión…',
 	'page.login.forgotPassword': '¿Olvidaste tu contraseña?',
+	'page.login.welcomeHeading': 'Bienvenido de nuevo',
+	'page.login.welcomeSubtext': 'Inicia sesión y retoma donde lo dejaste.',
+	'page.login.taglineSubtext':
+		'El baúl autoalojado para la salud, el diario y el cuidado diario de tu compañero.',
+	'page.login.brandFooter': 'Tus datos. Tu servidor. Tus compañeros.',
 
 	// Page: Forgot password
 	'page.forgot.title': 'Restablecer tu contraseña',
@@ -340,6 +345,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.setup.createAccount': 'Crear cuenta de administrador',
 	'page.setup.creatingAccount': 'Creando cuenta…',
 	'page.setup.firstRunNote': 'Esta página solo está disponible en la primera ejecución.',
+	'page.setup.brandSubtext': 'Configura el baúl de tu compañero.',
 
 	// Page: Error
 	'page.error.404.title': 'Página no encontrada',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -847,6 +847,8 @@ const messages: Record<keyof Messages, string> = {
 	// Aria labels
 	'aria.caretakerNav': 'Navigation gardien',
 	'aria.adminNav': "Sections d'administration",
+	'aria.einvaultHome': 'Accueil EinVault',
+	'aria.goToSignIn': 'Aller à la connexion',
 	'aria.mainNav': 'Navigation principale',
 	'aria.moreActions': "Plus d'actions",
 	'aria.deleteEntry': "Supprimer l'entrée",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -304,6 +304,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.signIn': 'Se connecter',
 	'page.login.signingIn': 'Connexion…',
 	'page.login.forgotPassword': 'Mot de passe oublié ?',
+	'page.login.welcomeHeading': 'Bon retour',
+	'page.login.welcomeSubtext': 'Connectez-vous pour reprendre où vous en étiez.',
+	'page.login.taglineSubtext':
+		'Le coffre auto-hébergé pour la santé, le journal et les soins quotidiens de votre compagnon.',
+	'page.login.brandFooter': 'Vos données. Votre serveur. Vos compagnons.',
 
 	// Page: Forgot password
 	'page.forgot.title': 'Réinitialiser votre mot de passe',
@@ -339,6 +344,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.setup.createAccount': 'Créer un compte administrateur',
 	'page.setup.creatingAccount': 'Création du compte…',
 	'page.setup.firstRunNote': "Cette page n'est disponible qu'au premier lancement.",
+	'page.setup.brandSubtext': 'Configurez le coffre de votre compagnon.',
 
 	// Page: Error
 	'page.error.404.title': 'Page introuvable',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -840,6 +840,8 @@ const messages: Record<keyof Messages, string> = {
 	// Aria labels
 	'aria.caretakerNav': 'Navigazione custode',
 	'aria.adminNav': 'Sezioni di amministrazione',
+	'aria.einvaultHome': 'Home di EinVault',
+	'aria.goToSignIn': "Vai all'accesso",
 	'aria.mainNav': 'Navigazione principale',
 	'aria.moreActions': 'Altre azioni',
 	'aria.deleteEntry': 'Elimina voce',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -302,6 +302,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.signIn': 'Accedi',
 	'page.login.signingIn': 'Accesso in corso…',
 	'page.login.forgotPassword': 'Password dimenticata?',
+	'page.login.welcomeHeading': 'Bentornato',
+	'page.login.welcomeSubtext': 'Accedi e riprendi da dove avevi interrotto.',
+	'page.login.taglineSubtext':
+		'Il forziere self-hosted per la salute, il diario e la cura quotidiana del tuo compagno.',
+	'page.login.brandFooter': 'I tuoi dati. Il tuo server. I tuoi compagni.',
 
 	// Page: Forgot password
 	'page.forgot.title': 'Reimposta la tua password',
@@ -336,6 +341,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.setup.createAccount': 'Crea account amministratore',
 	'page.setup.creatingAccount': 'Creazione account…',
 	'page.setup.firstRunNote': 'Questa pagina è disponibile solo alla prima esecuzione.',
+	'page.setup.brandSubtext': 'Configura il forziere del tuo compagno.',
 
 	// Page: Error
 	'page.error.404.title': 'Pagina non trovata',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -842,6 +842,8 @@ const messages: Record<keyof Messages, string> = {
 	// Aria labels
 	'aria.caretakerNav': 'Navegação do cuidador',
 	'aria.adminNav': 'Secções de administração',
+	'aria.einvaultHome': 'Início do EinVault',
+	'aria.goToSignIn': 'Ir para iniciar sessão',
 	'aria.mainNav': 'Navegação principal',
 	'aria.moreActions': 'Mais ações',
 	'aria.deleteEntry': 'Eliminar entrada',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -303,6 +303,11 @@ const messages: Record<keyof Messages, string> = {
 	'page.login.signIn': 'Iniciar sessão',
 	'page.login.signingIn': 'A iniciar sessão…',
 	'page.login.forgotPassword': 'Esqueceu a senha?',
+	'page.login.welcomeHeading': 'Bem-vindo de volta',
+	'page.login.welcomeSubtext': 'Inicie sessão e continue de onde parou.',
+	'page.login.taglineSubtext':
+		'O cofre auto-hospedado para a saúde, o diário e os cuidados diários do seu companheiro.',
+	'page.login.brandFooter': 'Os teus dados. O teu servidor. Os teus companheiros.',
 
 	// Page: Forgot password
 	'page.forgot.title': 'Redefinir sua senha',
@@ -337,6 +342,7 @@ const messages: Record<keyof Messages, string> = {
 	'page.setup.createAccount': 'Criar conta de administrador',
 	'page.setup.creatingAccount': 'A criar conta…',
 	'page.setup.firstRunNote': 'Esta página só está disponível na primeira execução.',
+	'page.setup.brandSubtext': 'Configura o cofre do teu companheiro.',
 
 	// Page: Error
 	'page.error.404.title': 'Página não encontrada',

--- a/src/routes/auth/forgot/+page.svelte
+++ b/src/routes/auth/forgot/+page.svelte
@@ -16,7 +16,7 @@
 	<title>{t(locale, 'page.forgot.title')} | EinVault</title>
 </svelte:head>
 
-<AuthBackdrop>
+<AuthBackdrop linkLabel={t(locale, 'aria.goToSignIn')}>
 	<div class="rounded-2xl border border-border bg-card p-6 shadow-2xl animate-slide-up">
 		<h1 class="font-display text-xl font-bold text-foreground mb-4 text-center">
 			{t(locale, 'page.forgot.title')}

--- a/src/routes/auth/forgot/+page.svelte
+++ b/src/routes/auth/forgot/+page.svelte
@@ -3,9 +3,9 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import { Card, CardContent } from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { t, getLocale } from '$lib/i18n';
+	import AuthBackdrop from '$lib/components/auth/AuthBackdrop.svelte';
 
 	let { form }: { form: ActionData } = $props();
 	let loading = $state(false);
@@ -16,49 +16,40 @@
 	<title>{t(locale, 'page.forgot.title')} | EinVault</title>
 </svelte:head>
 
-<div class="min-h-screen flex items-center justify-center p-4 bg-background">
-	<div class="w-full max-w-sm">
-		<div class="text-center mb-8">
-			<h1 class="font-display text-2xl font-bold text-primary">
-				{t(locale, 'page.forgot.title')}
-			</h1>
-		</div>
-
-		<Card class="animate-slide-up">
-			<CardContent class="pt-6">
-				{#if form?.success}
-					<Alert>
-						<AlertDescription>{t(locale, 'page.forgot.success')}</AlertDescription>
+<AuthBackdrop>
+	<div class="rounded-2xl border border-border bg-card p-6 shadow-2xl animate-slide-up">
+		<h1 class="font-display text-xl font-bold text-foreground mb-4 text-center">
+			{t(locale, 'page.forgot.title')}
+		</h1>
+		{#if form?.success}
+			<Alert>
+				<AlertDescription>{t(locale, 'page.forgot.success')}</AlertDescription>
+			</Alert>
+		{:else}
+			<form method="POST" onsubmit={() => (loading = true)} class="space-y-4">
+				{#if form?.error}
+					<Alert variant="destructive">
+						<AlertDescription>{form.error}</AlertDescription>
 					</Alert>
-				{:else}
-					<form method="POST" onsubmit={() => (loading = true)} class="space-y-4">
-						{#if form?.error}
-							<Alert variant="destructive">
-								<AlertDescription>{form.error}</AlertDescription>
-							</Alert>
-						{/if}
-
-						<p class="text-sm text-muted-foreground">
-							{t(locale, 'page.forgot.instruction')}
-						</p>
-
-						<div class="space-y-1.5">
-							<Label for="email">{t(locale, 'page.forgot.emailLabel')}</Label>
-							<Input id="email" name="email" type="email" required autocomplete="email" />
-						</div>
-
-						<Button type="submit" class="w-full" disabled={loading}>
-							{loading ? t(locale, 'page.forgot.sending') : t(locale, 'page.forgot.submit')}
-						</Button>
-					</form>
 				{/if}
 
-				<div class="mt-4 text-center">
-					<a href="/auth/login" class="text-xs text-muted-foreground hover:text-primary underline">
-						{t(locale, 'page.forgot.backToLogin')}
-					</a>
+				<p class="text-sm text-muted-foreground">{t(locale, 'page.forgot.instruction')}</p>
+
+				<div class="space-y-1.5">
+					<Label for="email">{t(locale, 'page.forgot.emailLabel')}</Label>
+					<Input id="email" name="email" type="email" required autocomplete="email" />
 				</div>
-			</CardContent>
-		</Card>
+
+				<Button type="submit" class="w-full" disabled={loading}>
+					{loading ? t(locale, 'page.forgot.sending') : t(locale, 'page.forgot.submit')}
+				</Button>
+			</form>
+		{/if}
+
+		<div class="mt-4 text-center">
+			<a href="/auth/login" class="text-xs text-muted-foreground hover:text-primary underline">
+				{t(locale, 'page.forgot.backToLogin')}
+			</a>
+		</div>
 	</div>
-</div>
+</AuthBackdrop>

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -33,6 +33,7 @@
 			tagline={t(locale, 'page.login.tagline')}
 			subtext={t(locale, 'page.login.taglineSubtext')}
 			footer={t(locale, 'page.login.brandFooter')}
+			homeLabel={t(locale, 'aria.einvaultHome')}
 		/>
 
 		<!-- Form panel -->

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -38,7 +38,7 @@
 		<!-- Form panel -->
 		<div class="flex flex-col justify-center px-8 py-8 md:px-11 md:py-12 bg-card">
 			<!-- Mobile-only tagline (replaces the hidden brand panel text) -->
-			<div class="mb-6 md:hidden text-center">
+			<div class="mb-6 md:hidden text-center" aria-hidden="true">
 				<p class="text-sm text-muted-foreground">{t(locale, 'page.login.tagline')}</p>
 			</div>
 

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -5,7 +5,7 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Select } from '$lib/components/ui/select/index.js';
-	import PawLogo from '$lib/components/PawLogo.svelte';
+	import AuthBrandPanel from '$lib/components/auth/AuthBrandPanel.svelte';
 	import { t, getLocale, SUPPORTED_LOCALES, LOCALE_LABELS } from '$lib/i18n';
 
 	let { form, data }: { form: ActionData; data: PageData } = $props();
@@ -29,54 +29,11 @@
 		class="w-full max-w-sm md:max-w-none md:w-[860px] rounded-2xl overflow-hidden shadow-2xl md:grid md:grid-cols-[1.05fr_0.95fr]"
 	>
 		<!-- Brand panel — full column at md+, compact header strip on mobile -->
-		<div
-			class="relative flex flex-col justify-between px-8 py-7 md:px-11 md:py-12 text-white overflow-hidden"
-			style="background: radial-gradient(130% 130% at 0% 0%, hsl(252 100% 65% / 0.55), transparent 55%), radial-gradient(130% 130% at 100% 100%, hsl(13 100% 67% / 0.5), transparent 55%), hsl(237 28% 11%);"
-		>
-			<!-- Radial accent blobs -->
-			<div
-				class="pointer-events-none absolute -top-20 -left-20 w-64 h-64 rounded-full opacity-20"
-				style="background: radial-gradient(circle, hsl(252 100% 65%), transparent 70%);"
-				aria-hidden="true"
-			></div>
-			<div
-				class="pointer-events-none absolute -bottom-16 -right-16 w-56 h-56 rounded-full opacity-15"
-				style="background: radial-gradient(circle, hsl(13 100% 67%), transparent 70%);"
-				aria-hidden="true"
-			></div>
-
-			<!-- Logo row -->
-			<a href="/" class="relative flex items-center gap-2.5 self-start z-10">
-				<div
-					class="w-9 h-9 rounded-xl shrink-0 flex items-center justify-center bg-brand-gradient shadow-lg"
-					aria-hidden="true"
-				>
-					<PawLogo class="w-5 h-5 text-white" />
-				</div>
-				<span class="font-display font-extrabold text-xl tracking-tight text-white">EinVault</span>
-			</a>
-
-			<!-- Tagline block — hidden on mobile (too cramped in strip mode) -->
-			<div class="relative z-10 hidden md:block">
-				<p class="font-display font-extrabold text-4xl leading-[1.03] tracking-tight">
-					{t(locale, 'page.login.tagline')}
-				</p>
-				<p class="mt-3 text-[15px] text-white/80 max-w-[30ch]">
-					The self-hosted vault for your companion's health, journal, and daily care.
-				</p>
-				<div class="flex gap-2 mt-5" aria-hidden="true">
-					<span class="w-2.5 h-2.5 rounded-full bg-primary"></span>
-					<span class="w-2.5 h-2.5 rounded-full bg-coral"></span>
-					<span class="w-2.5 h-2.5 rounded-full bg-gold"></span>
-					<span class="w-2.5 h-2.5 rounded-full bg-teal"></span>
-				</div>
-			</div>
-
-			<!-- Footer line — desktop only -->
-			<p class="relative z-10 hidden md:block text-xs text-white/50">
-				Your data. Your server. Your companions.
-			</p>
-		</div>
+		<AuthBrandPanel
+			tagline={t(locale, 'page.login.tagline')}
+			subtext={t(locale, 'page.login.taglineSubtext')}
+			footer={t(locale, 'page.login.brandFooter')}
+		/>
 
 		<!-- Form panel -->
 		<div class="flex flex-col justify-center px-8 py-8 md:px-11 md:py-12 bg-card">
@@ -85,8 +42,10 @@
 				<p class="text-sm text-muted-foreground">{t(locale, 'page.login.tagline')}</p>
 			</div>
 
-			<h2 class="font-display font-bold text-2xl text-foreground mb-1">Welcome back</h2>
-			<p class="text-sm text-muted-foreground mb-7">Sign in to pick up where you left off.</p>
+			<h2 class="font-display font-bold text-2xl text-foreground mb-1">
+				{t(locale, 'page.login.welcomeHeading')}
+			</h2>
+			<p class="text-sm text-muted-foreground mb-7">{t(locale, 'page.login.welcomeSubtext')}</p>
 
 			{#if data.oidcError}
 				<Alert variant="destructive" class="mb-5 animate-slide-up">

--- a/src/routes/auth/reset/+page.svelte
+++ b/src/routes/auth/reset/+page.svelte
@@ -19,7 +19,7 @@
 	<title>{t(locale, 'page.reset.title')} | EinVault</title>
 </svelte:head>
 
-<AuthBackdrop>
+<AuthBackdrop linkLabel={t(locale, 'aria.goToSignIn')}>
 	<div class="rounded-2xl border border-border bg-card p-6 shadow-2xl animate-slide-up">
 		<h1 class="font-display text-xl font-bold text-foreground mb-4 text-center">
 			{t(locale, 'page.reset.title')}

--- a/src/routes/auth/reset/+page.svelte
+++ b/src/routes/auth/reset/+page.svelte
@@ -4,9 +4,9 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import { Card, CardContent } from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { t, getLocale } from '$lib/i18n';
+	import AuthBackdrop from '$lib/components/auth/AuthBackdrop.svelte';
 
 	let { form, data }: { form: ActionData; data: PageData } = $props();
 	let loading = $state(false);
@@ -19,76 +19,69 @@
 	<title>{t(locale, 'page.reset.title')} | EinVault</title>
 </svelte:head>
 
-<div class="min-h-screen flex items-center justify-center p-4 bg-background">
-	<div class="w-full max-w-sm">
-		<div class="text-center mb-8">
-			<h1 class="font-display text-2xl font-bold text-primary">
-				{t(locale, 'page.reset.title')}
-			</h1>
-		</div>
-
-		<Card class="animate-slide-up">
-			<CardContent class="pt-6">
-				{#if form?.success}
-					<Alert>
-						<AlertDescription>{t(locale, 'page.reset.success')}</AlertDescription>
-					</Alert>
-					<div class="mt-4 text-center">
-						<a href="/auth/login" class="text-sm text-primary underline">
-							{t(locale, 'page.forgot.backToLogin')}
-						</a>
-					</div>
-				{:else if form?.tokenInvalid || (!data.valid && !form?.error)}
+<AuthBackdrop>
+	<div class="rounded-2xl border border-border bg-card p-6 shadow-2xl animate-slide-up">
+		<h1 class="font-display text-xl font-bold text-foreground mb-4 text-center">
+			{t(locale, 'page.reset.title')}
+		</h1>
+		{#if form?.success}
+			<Alert>
+				<AlertDescription>{t(locale, 'page.reset.success')}</AlertDescription>
+			</Alert>
+			<div class="mt-4 text-center">
+				<a href="/auth/login" class="text-sm text-primary underline">
+					{t(locale, 'page.forgot.backToLogin')}
+				</a>
+			</div>
+		{:else if form?.tokenInvalid || (!data.valid && !form?.error)}
+			<Alert variant="destructive">
+				<AlertDescription>{t(locale, 'page.reset.invalid')}</AlertDescription>
+			</Alert>
+			<div class="mt-4 text-center">
+				<a href="/auth/forgot" class="text-sm text-primary underline">
+					{t(locale, 'page.reset.requestNew')}
+				</a>
+			</div>
+		{:else}
+			<form method="POST" onsubmit={() => (loading = true)} class="space-y-4">
+				{#if form?.error}
 					<Alert variant="destructive">
-						<AlertDescription>{t(locale, 'page.reset.invalid')}</AlertDescription>
+						<AlertDescription>{form.error}</AlertDescription>
 					</Alert>
-					<div class="mt-4 text-center">
-						<a href="/auth/forgot" class="text-sm text-primary underline">
-							{t(locale, 'page.reset.requestNew')}
-						</a>
-					</div>
-				{:else}
-					<form method="POST" onsubmit={() => (loading = true)} class="space-y-4">
-						{#if form?.error}
-							<Alert variant="destructive">
-								<AlertDescription>{form.error}</AlertDescription>
-							</Alert>
-						{/if}
-
-						<input type="hidden" name="token" value={token} />
-
-						<div class="space-y-1.5">
-							<Label for="newPassword">{t(locale, 'page.reset.newPasswordLabel')}</Label>
-							<Input
-								id="newPassword"
-								name="newPassword"
-								type="password"
-								required
-								minlength={8}
-								maxlength={128}
-								autocomplete="new-password"
-							/>
-						</div>
-
-						<div class="space-y-1.5">
-							<Label for="confirmPassword">{t(locale, 'page.reset.confirmPasswordLabel')}</Label>
-							<Input
-								id="confirmPassword"
-								name="confirmPassword"
-								type="password"
-								required
-								minlength={8}
-								maxlength={128}
-								autocomplete="new-password"
-							/>
-						</div>
-
-						<Button type="submit" class="w-full" disabled={loading}>
-							{loading ? t(locale, 'page.reset.saving') : t(locale, 'page.reset.submit')}
-						</Button>
-					</form>
 				{/if}
-			</CardContent>
-		</Card>
+
+				<input type="hidden" name="token" value={token} />
+
+				<div class="space-y-1.5">
+					<Label for="newPassword">{t(locale, 'page.reset.newPasswordLabel')}</Label>
+					<Input
+						id="newPassword"
+						name="newPassword"
+						type="password"
+						required
+						minlength={8}
+						maxlength={128}
+						autocomplete="new-password"
+					/>
+				</div>
+
+				<div class="space-y-1.5">
+					<Label for="confirmPassword">{t(locale, 'page.reset.confirmPasswordLabel')}</Label>
+					<Input
+						id="confirmPassword"
+						name="confirmPassword"
+						type="password"
+						required
+						minlength={8}
+						maxlength={128}
+						autocomplete="new-password"
+					/>
+				</div>
+
+				<Button type="submit" class="w-full" disabled={loading}>
+					{loading ? t(locale, 'page.reset.saving') : t(locale, 'page.reset.submit')}
+				</Button>
+			</form>
+		{/if}
 	</div>
-</div>
+</AuthBackdrop>

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -1,15 +1,9 @@
 <script lang="ts">
 	import type { ActionData } from './$types';
+	import AuthBrandPanel from '$lib/components/auth/AuthBrandPanel.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
-	import {
-		Card,
-		CardHeader,
-		CardTitle,
-		CardDescription,
-		CardContent
-	} from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { t, getLocale, SUPPORTED_LOCALES, LOCALE_LABELS } from '$lib/i18n';
 	import { Select } from '$lib/components/ui/select/index.js';
@@ -29,98 +23,98 @@
 	<title>{t(locale, 'page.setup.title')} | EinVault</title>
 </svelte:head>
 
-<div class="min-h-screen flex items-center justify-center p-4 bg-background">
-	<div class="w-full max-w-md">
-		<div class="text-center mb-8">
-			<h1 class="font-display text-4xl font-bold tracking-tight text-foreground">EinVault</h1>
-			<p class="mt-2 text-sm text-muted-foreground">{t(locale, 'page.setup.tagline')}</p>
-		</div>
+<div class="min-h-screen flex items-center justify-center bg-background p-4 md:p-0">
+	<div
+		class="w-full max-w-sm md:max-w-none md:w-[860px] rounded-2xl overflow-hidden shadow-2xl md:grid md:grid-cols-[1.05fr_0.95fr]"
+	>
+		<AuthBrandPanel
+			tagline={t(locale, 'page.login.tagline')}
+			subtext={t(locale, 'page.setup.brandSubtext')}
+			footer={t(locale, 'page.login.brandFooter')}
+		/>
 
-		<Card class="animate-slide-up">
-			<CardHeader>
-				<CardTitle>{t(locale, 'page.setup.cardTitle')}</CardTitle>
-				<CardDescription>
-					{t(locale, 'page.setup.cardDescription')}
-				</CardDescription>
-			</CardHeader>
-			<CardContent>
-				<form method="POST" onsubmit={() => (loading = true)} class="space-y-4">
-					{#if form?.error}
-						<Alert variant="destructive">
-							<AlertDescription>{form.error}</AlertDescription>
-						</Alert>
-					{/if}
+		<div class="flex flex-col justify-center bg-card px-8 py-8 md:px-11 md:py-12">
+			<h2 class="font-display font-bold text-2xl text-foreground mb-1">
+				{t(locale, 'page.setup.cardTitle')}
+			</h2>
+			<p class="text-sm text-muted-foreground mb-7">{t(locale, 'page.setup.cardDescription')}</p>
 
-					<div class="space-y-1.5">
-						<Label for="displayName">{t(locale, 'page.setup.displayNameLabel')}</Label>
-						<Input
-							id="displayName"
-							name="displayName"
-							type="text"
-							placeholder={t(locale, 'page.setup.displayNamePlaceholder')}
-							required
-							autocomplete="name"
-						/>
-					</div>
+			<form method="POST" onsubmit={() => (loading = true)} class="space-y-4">
+				{#if form?.error}
+					<Alert variant="destructive">
+						<AlertDescription>{form.error}</AlertDescription>
+					</Alert>
+				{/if}
 
-					<div class="space-y-1.5">
-						<Label for="username">{t(locale, 'page.login.usernameLabel')}</Label>
-						<Input
-							id="username"
-							name="username"
-							type="text"
-							placeholder={t(locale, 'page.setup.usernamePlaceholder')}
-							required
-							autocomplete="username"
-						/>
-					</div>
+				<div class="space-y-1.5">
+					<Label for="displayName">{t(locale, 'page.setup.displayNameLabel')}</Label>
+					<Input
+						id="displayName"
+						name="displayName"
+						type="text"
+						placeholder={t(locale, 'page.setup.displayNamePlaceholder')}
+						required
+						autocomplete="name"
+					/>
+				</div>
 
-					<div class="space-y-1.5">
-						<Label for="password">{t(locale, 'page.login.passwordLabel')}</Label>
-						<Input
-							id="password"
-							name="password"
-							type="password"
-							placeholder="••••••••"
-							required
-							minlength={8}
-							autocomplete="new-password"
-						/>
-					</div>
+				<div class="space-y-1.5">
+					<Label for="username">{t(locale, 'page.login.usernameLabel')}</Label>
+					<Input
+						id="username"
+						name="username"
+						type="text"
+						placeholder={t(locale, 'page.setup.usernamePlaceholder')}
+						required
+						autocomplete="username"
+					/>
+				</div>
 
-					<div class="space-y-1.5">
-						<Label for="confirmPassword">{t(locale, 'page.setup.confirmPasswordLabel')}</Label>
-						<Input
-							id="confirmPassword"
-							name="confirmPassword"
-							type="password"
-							placeholder="••••••••"
-							required
-							minlength={8}
-							autocomplete="new-password"
-						/>
-					</div>
+				<div class="space-y-1.5">
+					<Label for="password">{t(locale, 'page.login.passwordLabel')}</Label>
+					<Input
+						id="password"
+						name="password"
+						type="password"
+						placeholder="••••••••"
+						required
+						minlength={8}
+						autocomplete="new-password"
+					/>
+				</div>
 
-					<Button type="submit" class="w-full mt-2" disabled={loading}>
-						{loading
-							? t(locale, 'page.setup.creatingAccount')
-							: t(locale, 'page.setup.createAccount')}
-					</Button>
-				</form>
-			</CardContent>
-		</Card>
+				<div class="space-y-1.5">
+					<Label for="confirmPassword">{t(locale, 'page.setup.confirmPasswordLabel')}</Label>
+					<Input
+						id="confirmPassword"
+						name="confirmPassword"
+						type="password"
+						placeholder="••••••••"
+						required
+						minlength={8}
+						autocomplete="new-password"
+					/>
+				</div>
 
-		<p class="text-center text-xs mt-6 text-muted-foreground">
-			{t(locale, 'page.setup.firstRunNote')}
-		</p>
+				<Button type="submit" class="w-full mt-2" disabled={loading}>
+					{loading
+						? t(locale, 'page.setup.creatingAccount')
+						: t(locale, 'page.setup.createAccount')}
+				</Button>
+			</form>
 
-		<div class="flex justify-center mt-4">
-			<div class="max-w-[200px]">
-				<Select value={locale} onchange={changeLocale}>
-					{#each SUPPORTED_LOCALES as loc (loc)}
-						<option value={loc}>{LOCALE_LABELS[loc]}</option>
-					{/each}
-				</Select>
+			<p class="text-center text-xs mt-6 text-muted-foreground">
+				{t(locale, 'page.setup.firstRunNote')}
+			</p>
+
+			<div class="flex justify-center mt-4">
+				<div class="max-w-[200px]">
+					<Select value={locale} onchange={changeLocale}>
+						{#each SUPPORTED_LOCALES as loc (loc)}
+							<option value={loc}>{LOCALE_LABELS[loc]}</option>
+						{/each}
+					</Select>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -31,6 +31,7 @@
 			tagline={t(locale, 'page.login.tagline')}
 			subtext={t(locale, 'page.setup.brandSubtext')}
 			footer={t(locale, 'page.login.brandFooter')}
+			homeLabel={t(locale, 'aria.einvaultHome')}
 		/>
 
 		<div class="flex flex-col justify-center bg-card px-8 py-8 md:px-11 md:py-12">

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -34,6 +34,11 @@
 		/>
 
 		<div class="flex flex-col justify-center bg-card px-8 py-8 md:px-11 md:py-12">
+			<!-- Mobile-only subtext (the brand panel's copy is hidden on mobile) -->
+			<div class="mb-6 md:hidden text-center" aria-hidden="true">
+				<p class="text-sm text-muted-foreground">{t(locale, 'page.setup.brandSubtext')}</p>
+			</div>
+
 			<h2 class="font-display font-bold text-2xl text-foreground mb-1">
 				{t(locale, 'page.setup.cardTitle')}
 			</h2>


### PR DESCRIPTION
Sixth redesign sub-project. Unifies the unauthenticated pages (login, setup, forgot, reset) on the Companion brand treatment. Presentation + i18n only — no server, auth-flow, form-action, field-id, or accessible-name changes. Stacks on SP5 (`redesign-sp5-admin-pages`).

## Changes

- **`.bg-auth-brand`** CSS utility centralizes login's brand gradient (was an inline `style` string).
- **`AuthBrandPanel.svelte`** — the two-column brand panel, extracted from login. Presentational (copy via props). Login now renders it; **setup** adopts the same two-column branded layout (single admin-create form preserved).
- **`AuthBackdrop.svelte`** — branded centered-card shell on the gradient; **forgot** and **reset** wrap their content in it (was a plain `bg-background` card).
- **Login i18n** — "Welcome back", "Sign in to pick up…", the tagline subtext, and the brand footer move to i18n keys.
- **`Alert` success variant** retokenized `moss` → teal (app-wide; every `variant="success"` inherits it).
- **Logo aria-labels** i18n'd (`aria.einvaultHome`, `aria.goToSignIn`) and passed as props so the components stay `t`-free.

## Tokens / i18n / a11y / tests

- No `moss`/`bark`/`sky` in `src/routes/auth`, `src/routes/setup`, `src/lib/components/auth`, or `src/lib/components/ui/alert`. (The Badge variant defs + settings/dashboard usages remain — separate cleanup; auth was not the last consumer.)
- New i18n keys across all six locales.
- Label/input bindings preserved; decorative blobs/dots/duplicate mobile taglines `aria-hidden`; mobile tagline fallbacks on login + setup.
- Env-variant e2e (`auth`/`setup`/`oidc`/`oidc-variants`) pass unchanged — every selector (field ids, "Sign in"/"Send reset link"/"Set new password"/"Create Admin Account"/"sign in with …") preserved.

Gates: lint, check (0 errors), 194 unit, build, 14/14 auth+setup+oidc e2e green.