### PR TITLE
feat: optional TOTP two-factor authentication (#116)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,6 +239,13 @@ ORIGIN=https://einvault.yourdomain.com
 # disables the HTTPS requirement on every request to the IdP.
 # OIDC_ALLOW_INSECURE_HTTP=true
 
+# Optional: two-factor authentication (2FA)
+#
+# 32-byte base64 key that encrypts stored TOTP secrets. Required to enable 2FA.
+# Generate with: openssl rand -base64 32
+# Without this variable, 2FA is unavailable and the enforcement setting is locked.
+TWOFA_ENC_KEY=
+
 # Optional: SMTP email (issue #12)
 #
 # Enables outbound email and, with it, the self-service "Forgot password?"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ EinVault is a private, self-hosted companion health and care tracker built for h
   - [Admin role mapping](#admin-role-mapping)
   - [Logout](#logout)
   - [Provider notes](#provider-notes)
+- [Two-factor authentication (2FA)](#two-factor-authentication-2fa)
 - [Adding a new locale](#adding-a-new-locale)
 - [Stack](#stack)
 - [License](#license)
@@ -111,6 +112,7 @@ Everything else in the compose file can be edited directly:
 | `user`                        | `1000:1000`         | UID:GID the container runs as. Change if your `./data` directory has different ownership.                                                                  |
 | `./data` volume               | `./data`            | Where the database and uploads are stored on the host.                                                                                                     |
 | `DATABASE_URL`                | `/data/einvault.db` | Database path inside the container. Unlikely to need changing.                                                                                             |
+| `TWOFA_ENC_KEY`               | —                   | 32-byte base64 key (`openssl rand -base64 32`) that encrypts stored TOTP secrets. Required to enable two-factor authentication.                            |
 
 The calendar feed URL contains a secret token that authenticates the subscriber. Avoid logging full `/api/calendar/` request URLs at the reverse proxy, as the token would appear in plain text in your access logs.
 
@@ -386,6 +388,38 @@ By default, logout destroys the local EinVault session and returns the user to `
 | **Authentik** | Create an OAuth2/OIDC provider; scope mapping for `groups` is built-in. `OIDC_ADMIN_GROUPS` matches the `groups` claim directly.                                                                    |
 | **Keycloak**  | Add a "Group Membership" mapper to the client with token claim name `groups` and "Full group path" off. EinVault does not read `realm_access.roles`. Add the redirect URI to "Valid Redirect URIs". |
 | **PocketID**  | Public-client first; omit `OIDC_CLIENT_SECRET`. Register the redirect URI in the client settings.                                                                                                   |
+
+---
+
+## Two-factor authentication (2FA)
+
+EinVault supports per-user TOTP-based two-factor authentication. Users can enable it under Settings → Security: scan the QR code with any TOTP app (Aegis, Bitwarden Authenticator, Google Authenticator, etc.), enter the confirmation code, and download the 10 one-time backup codes. Each backup code works once and is not shown again.
+
+**Requirements.** 2FA requires `TWOFA_ENC_KEY` to be set. This is a 32-byte base64 key used to encrypt stored TOTP secrets at rest. Without it, 2FA is unavailable and the enforcement setting in the admin panel is locked.
+
+Generate a key:
+
+```bash
+openssl rand -base64 32
+```
+
+Add it to your compose file or `.env`:
+
+```
+TWOFA_ENC_KEY=<the generated value>
+```
+
+**Admin enforcement.** Admins can require 2FA at Admin → Users → Security. Three levels are available:
+
+- **Off** — 2FA is optional. Users can enable it but are not required to.
+- **Admins only** — Admin accounts must enroll before they can use the app.
+- **Everyone** — All non-OIDC accounts must enroll.
+
+When enforcement is active, un-enrolled users are redirected to `/2fa-setup` after login and cannot access the rest of the app until they complete enrollment.
+
+**OIDC users are exempt.** Accounts that sign in via OIDC are never required to enroll. MFA for those accounts is handled by the identity provider.
+
+**Recovery.** If a user loses their authenticator app, they can sign in using one of their backup codes instead. If backup codes are also lost, an admin can reset the user's two-factor enrollment from the Manage drawer (Admin → Users → Manage → Reset two-factor). The user will be prompted to re-enroll on next login.
 
 ---
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -96,6 +96,11 @@ services:
       CALENDAR_FEED_HISTORY_DAYS: ${CALENDAR_FEED_HISTORY_DAYS:-90}
       CALENDAR_FEED_ENABLED: ${CALENDAR_FEED_ENABLED:-true}
 
+      # Optional: two-factor authentication (2FA). 32-byte base64 key that
+      # encrypts stored TOTP secrets. Required to enable 2FA.
+      # Generate with: openssl rand -base64 32
+      TWOFA_ENC_KEY: ${TWOFA_ENC_KEY:-}
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -118,6 +118,11 @@ services:
       # CALENDAR_FEED_HISTORY_DAYS: 90
       # CALENDAR_FEED_ENABLED: 'true'
 
+      # Optional: two-factor authentication (2FA). 32-byte base64 key that
+      # encrypts stored TOTP secrets. Required to enable 2FA.
+      # Generate with: openssl rand -base64 32
+      # TWOFA_ENC_KEY:
+
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/drizzle/0026_warm_iron_monger.sql
+++ b/drizzle/0026_warm_iron_monger.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `app_settings` (
+	`id` text PRIMARY KEY DEFAULT 'singleton' NOT NULL,
+	`require_2fa` text DEFAULT 'off' NOT NULL,
+	`updated_at` integer,
+	`updated_by` text,
+	FOREIGN KEY (`updated_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE TABLE `totp_backup_codes` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`code_hash` text NOT NULL,
+	`used_at` integer,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+ALTER TABLE `users` ADD `totp_secret` text;--> statement-breakpoint
+ALTER TABLE `users` ADD `totp_enabled_at` integer;--> statement-breakpoint
+ALTER TABLE `users` ADD `totp_last_step` integer;

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,1922 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9b8179c7-8a72-44f4-b2e4-a1ecae47e9af",
+  "prevId": "30fc3baa-555a-47f2-88cc-cc8d8b1c57e0",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'singleton'"
+        },
+        "require_2fa": {
+          "name": "require_2fa",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'off'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_settings_updated_by_users_id_fk": {
+          "name": "app_settings_updated_by_users_id_fk",
+          "tableFrom": "app_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "caretaker_shifts": {
+      "name": "caretaker_shifts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "shift_user_idx": {
+          "name": "shift_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "caretaker_shifts_user_id_users_id_fk": {
+          "name": "caretaker_shifts_user_id_users_id_fk",
+          "tableFrom": "caretaker_shifts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_caretakers": {
+      "name": "companion_caretakers",
+      "columns": {
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "companion_caretakers_companion_id_companions_id_fk": {
+          "name": "companion_caretakers_companion_id_companions_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "companion_caretakers_user_id_users_id_fk": {
+          "name": "companion_caretakers_user_id_users_id_fk",
+          "tableFrom": "companion_caretakers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "companion_caretakers_companion_id_user_id_pk": {
+          "columns": [
+            "companion_id",
+            "user_id"
+          ],
+          "name": "companion_caretakers_companion_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companions": {
+      "name": "companions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dog'"
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'lbs'"
+        },
+        "microchip": {
+          "name": "microchip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feeding_schedule": {
+          "name": "feeding_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "walk_schedule": {
+          "name": "walk_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "medication_schedule": {
+          "name": "medication_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_phone": {
+          "name": "vet_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_for_sitter": {
+          "name": "notes_for_sitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archive_note": {
+          "name": "archive_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_active_idx": {
+          "name": "companion_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_events": {
+      "name": "daily_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_group_id": {
+          "name": "event_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "daily_companion_idx": {
+          "name": "daily_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "daily_logged_idx": {
+          "name": "daily_logged_idx",
+          "columns": [
+            "logged_at"
+          ],
+          "isUnique": false
+        },
+        "daily_event_group_idx": {
+          "name": "daily_event_group_idx",
+          "columns": [
+            "event_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "daily_events_companion_id_companions_id_fk": {
+          "name": "daily_events_companion_id_companions_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_events_logged_by_users_id_fk": {
+          "name": "daily_events_logged_by_users_id_fk",
+          "tableFrom": "daily_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "health_event_id": {
+          "name": "health_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "document_date": {
+          "name": "document_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "document_companion_idx": {
+          "name": "document_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "document_health_event_idx": {
+          "name": "document_health_event_idx",
+          "columns": [
+            "health_event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "documents_companion_id_companions_id_fk": {
+          "name": "documents_companion_id_companions_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "documents_health_event_id_health_events_id_fk": {
+          "name": "documents_health_event_id_health_events_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "health_events",
+          "columnsFrom": [
+            "health_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "documents_uploaded_by_users_id_fk": {
+          "name": "documents_uploaded_by_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "health_events": {
+      "name": "health_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vet_name": {
+          "name": "vet_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vet_clinic": {
+          "name": "vet_clinic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "health_companion_idx": {
+          "name": "health_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "health_type_idx": {
+          "name": "health_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "health_events_companion_id_companions_id_fk": {
+          "name": "health_events_companion_id_companions_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "health_events_logged_by_users_id_fk": {
+          "name": "health_events_logged_by_users_id_fk",
+          "tableFrom": "health_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_entries": {
+      "name": "journal_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "journal_companion_date_idx": {
+          "name": "journal_companion_date_idx",
+          "columns": [
+            "companion_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_companion_id_companions_id_fk": {
+          "name": "journal_entries_companion_id_companions_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_entries_logged_by_users_id_fk": {
+          "name": "journal_entries_logged_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "journal_entries_updated_by_users_id_fk": {
+          "name": "journal_entries_updated_by_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "journal_photos": {
+      "name": "journal_photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'photo'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ready'"
+        },
+        "original_key": {
+          "name": "original_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_key": {
+          "name": "poster_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcode_attempts": {
+          "name": "transcode_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "photo_entry_idx": {
+          "name": "photo_entry_idx",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        },
+        "photo_status_idx": {
+          "name": "photo_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "journal_photos_entry_id_journal_entries_id_fk": {
+          "name": "journal_photos_entry_id_journal_entries_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "journal_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "journal_photos_logged_by_users_id_fk": {
+          "name": "journal_photos_logged_by_users_id_fk",
+          "tableFrom": "journal_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_outbox": {
+      "name": "notification_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "outbox_dedupe_idx": {
+          "name": "outbox_dedupe_idx",
+          "columns": [
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notification_outbox_user_id_users_id_fk": {
+          "name": "notification_outbox_user_id_users_id_fk",
+          "tableFrom": "notification_outbox",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "password_reset_user_idx": {
+          "name": "password_reset_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "recurrence_unit": {
+          "name": "recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_interval": {
+          "name": "recurrence_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor": {
+          "name": "recurrence_anchor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurrence_anchor_value": {
+          "name": "recurrence_anchor_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reminder_companion_idx": {
+          "name": "reminder_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        },
+        "reminder_due_idx": {
+          "name": "reminder_due_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "reminder_series_due_idx": {
+          "name": "reminder_series_due_idx",
+          "columns": [
+            "series_id",
+            "due_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reminders_companion_id_companions_id_fk": {
+          "name": "reminders_companion_id_companions_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_completed_by_users_id_fk": {
+          "name": "reminders_completed_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reminders_logged_by_users_id_fk": {
+          "name": "reminders_logged_by_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "oidc_id_token_hint": {
+          "name": "oidc_id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "totp_backup_codes": {
+      "name": "totp_backup_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "totp_backup_codes_user_id_users_id_fk": {
+          "name": "totp_backup_codes_user_id_users_id_fk",
+          "tableFrom": "totp_backup_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_undo_seconds": {
+          "name": "reminder_undo_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_recurrence_unit": {
+          "name": "default_recurrence_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_reminder_email": {
+          "name": "notify_reminder_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_shift_email": {
+          "name": "notify_shift_email",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "ntfy_topic": {
+          "name": "ntfy_topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_provider": {
+          "name": "avatar_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_storage_key": {
+          "name": "avatar_storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_enabled_at": {
+          "name": "totp_enabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "totp_last_step": {
+          "name": "totp_last_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "users_oidc_idx": {
+          "name": "users_oidc_idx",
+          "columns": [
+            "oidc_issuer",
+            "oidc_subject"
+          ],
+          "isUnique": true
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_calendar_feed_token_idx": {
+          "name": "users_calendar_feed_token_idx",
+          "columns": [
+            "calendar_feed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "weight_entries": {
+      "name": "weight_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "companion_id": {
+          "name": "companion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "weight_companion_idx": {
+          "name": "weight_companion_idx",
+          "columns": [
+            "companion_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "weight_entries_companion_id_companions_id_fk": {
+          "name": "weight_entries_companion_id_companions_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "companions",
+          "columnsFrom": [
+            "companion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "weight_entries_logged_by_users_id_fk": {
+          "name": "weight_entries_logged_by_users_id_fk",
+          "tableFrom": "weight_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "logged_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1781349969352,
       "tag": "0025_stormy_king_cobra",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1781466019317,
+      "tag": "0026_warm_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,9 @@
 				"marked": "^18.0.3",
 				"nodemailer": "^8.0.10",
 				"openid-client": "^6.8.4",
+				"otpauth": "^9.5.1",
 				"pdfjs-dist": "^6.0.227",
+				"qrcode": "^1.5.4",
 				"sharp": "^0.34.5",
 				"tailwind-merge": "^3.5.0"
 			},
@@ -41,6 +43,7 @@
 				"@types/mailparser": "^3.4.6",
 				"@types/node": "^25.9.0",
 				"@types/nodemailer": "^8.0.0",
+				"@types/qrcode": "^1.5.6",
 				"@types/smtp-server": "^3.5.13",
 				"@typescript-eslint/parser": "^8.57.2",
 				"drizzle-kit": "^0.31.10",
@@ -1773,6 +1776,18 @@
 				"@emnapi/runtime": "^1.7.1"
 			}
 		},
+		"node_modules/@noble/hashes": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+			"integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
 		"node_modules/@oslojs/asn1": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
@@ -3114,6 +3129,16 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/qrcode": {
+			"version": "1.5.6",
+			"resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+			"integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -3556,6 +3581,30 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/aria-query": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
@@ -3819,6 +3868,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/chai": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3863,6 +3921,17 @@
 				"url": "https://polar.sh/cva"
 			}
 		},
+		"node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3871,6 +3940,24 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
 		},
 		"node_modules/commondir": {
 			"version": "1.0.1",
@@ -4019,6 +4106,15 @@
 				}
 			}
 		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/decimal.js": {
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -4099,6 +4195,12 @@
 			"version": "5.8.1",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
 			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+			"license": "MIT"
+		},
+		"node_modules/dijkstrajs": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
 			"license": "MIT"
 		},
 		"node_modules/dom-serializer": {
@@ -4343,6 +4445,12 @@
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"license": "MIT"
 		},
 		"node_modules/encodeurl": {
@@ -4976,6 +5084,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
 		"node_modules/get-intrinsic": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5315,6 +5432,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-glob": {
@@ -6262,6 +6388,18 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/otpauth": {
+			"version": "9.5.1",
+			"resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.1.tgz",
+			"integrity": "sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "2.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/hectorm/otpauth?sponsor=1"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6292,6 +6430,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/parse5": {
@@ -6334,7 +6481,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6462,6 +6608,15 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/pngjs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+			"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -6710,6 +6865,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/qrcode": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+			"integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+			"license": "MIT",
+			"dependencies": {
+				"dijkstrajs": "^1.0.1",
+				"pngjs": "^5.0.0",
+				"yargs": "^15.3.1"
+			},
+			"bin": {
+				"qrcode": "bin/qrcode"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/qs": {
 			"version": "6.15.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -6812,6 +6984,15 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6820,6 +7001,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"license": "ISC"
 		},
 		"node_modules/resolve": {
 			"version": "1.22.11",
@@ -7071,6 +7258,12 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
 			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"license": "ISC"
 		},
 		"node_modules/set-cookie-parser": {
 			"version": "3.1.0",
@@ -7372,6 +7565,32 @@
 			"license": "MIT",
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -8172,6 +8391,12 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"license": "ISC"
+		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -8199,6 +8424,20 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8219,6 +8458,99 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"license": "MIT"
+		},
+		"node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"license": "ISC"
+		},
+		"node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yargs/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yargs/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@types/mailparser": "^3.4.6",
 		"@types/node": "^25.9.0",
 		"@types/nodemailer": "^8.0.0",
+		"@types/qrcode": "^1.5.6",
 		"@types/smtp-server": "^3.5.13",
 		"@typescript-eslint/parser": "^8.57.2",
 		"drizzle-kit": "^0.31.10",
@@ -68,7 +69,9 @@
 		"marked": "^18.0.3",
 		"nodemailer": "^8.0.10",
 		"openid-client": "^6.8.4",
+		"otpauth": "^9.5.1",
 		"pdfjs-dist": "^6.0.227",
+		"qrcode": "^1.5.4",
 		"sharp": "^0.34.5",
 		"tailwind-merge": "^3.5.0"
 	},

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -20,6 +20,8 @@ declare global {
 				notifyShiftEmail: boolean;
 				ntfyTopic: string | null;
 				avatarPath: string | null;
+				totpEnabled: boolean;
+				isOidc: boolean;
 			} | null;
 			session: {
 				id: string;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,3 +1,4 @@
+import { redirect } from '@sveltejs/kit';
 import type { Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { validateAuth } from '$server/auth';
@@ -17,6 +18,8 @@ import {
 } from '$lib/server/env';
 import { recoverAndStart } from '$lib/server/video/worker';
 import { startNotifyScheduler } from '$lib/server/notify/scheduler';
+import { getAppSettings } from '$lib/server/app-settings';
+import { requiresTwoFactor } from '$lib/server/auth/two-factor';
 
 logOidcBootStatus();
 logStorageBootStatus();
@@ -122,6 +125,30 @@ const authContext: Handle = async ({ event, resolve }) => {
 	return resolve(event);
 };
 
+const twoFactorGate: Handle = async ({ event, resolve }) => {
+	const user = event.locals.user;
+	if (user) {
+		const path = event.url.pathname;
+		const allowed =
+			path === '/2fa-setup' || path.startsWith('/2fa-setup/') || path.startsWith('/auth/');
+		if (!allowed) {
+			const { require2fa } = await getAppSettings();
+			if (
+				requiresTwoFactor(
+					{ role: user.role, isOidc: user.isOidc, totpEnabled: user.totpEnabled },
+					require2fa
+				)
+			) {
+				if (path.startsWith('/api/')) {
+					return new Response('Two-factor authentication required', { status: 403 });
+				}
+				redirect(303, '/2fa-setup');
+			}
+		}
+	}
+	return resolve(event);
+};
+
 const localeDetect: Handle = async ({ event, resolve }) => {
 	// Priority: user preference > cookie > Accept-Language > default
 	const cookieRaw = event.cookies.get('einvault_locale');
@@ -149,4 +176,4 @@ const localeDetect: Handle = async ({ event, resolve }) => {
 	});
 };
 
-export const handle = sequence(securityHeaders, authContext, localeDetect);
+export const handle = sequence(securityHeaders, authContext, twoFactorGate, localeDetect);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -12,7 +12,8 @@ import {
 	logDeprecatedEnvWarnings,
 	logVideoTranscodeBootStatus,
 	logSmtpBootStatus,
-	logNtfyBootStatus
+	logNtfyBootStatus,
+	logTwoFactorBootStatus
 } from '$lib/server/env';
 import { recoverAndStart } from '$lib/server/video/worker';
 import { startNotifyScheduler } from '$lib/server/notify/scheduler';
@@ -25,6 +26,7 @@ logDeprecatedEnvWarnings();
 logVideoTranscodeBootStatus();
 logSmtpBootStatus();
 logNtfyBootStatus();
+logTwoFactorBootStatus();
 
 // Resume any transcode jobs interrupted by a restart and drain the queue. No-op
 // unless VIDEO_TRANSCODE is enabled and ffmpeg is present. Fire and forget.

--- a/src/lib/components/BackupCodes.svelte
+++ b/src/lib/components/BackupCodes.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { t, getLocale } from '$lib/i18n';
+
+	// One-time 2FA backup codes display with copy/download. The acknowledge /
+	// continue action is left to the caller, since it differs per surface
+	// (Settings reloads; the forced-setup interstitial links onward).
+	let { codes }: { codes: string[] } = $props();
+	const locale = getLocale();
+	let copied = $state(false);
+
+	function asText(): string {
+		return codes.join('\n');
+	}
+	async function handleCopy() {
+		await navigator.clipboard.writeText(asText());
+		copied = true;
+		setTimeout(() => (copied = false), 2000);
+	}
+	function handleDownload() {
+		const blob = new Blob([asText()], { type: 'text/plain' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = 'einvault-backup-codes.txt';
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+</script>
+
+<div>
+	<h3 class="text-sm font-semibold mb-1">{t(locale, 'page.settings.backupCodesTitle')}</h3>
+	<p class="text-sm text-muted-foreground mb-3">{t(locale, 'page.settings.backupCodesIntro')}</p>
+	<div class="grid grid-cols-2 gap-1.5 rounded-md bg-muted p-3 mb-3 select-all font-mono text-sm">
+		{#each codes as code (code)}
+			<span class="text-center">{code}</span>
+		{/each}
+	</div>
+	<div class="flex gap-2">
+		<Button variant="outline" size="sm" onclick={handleCopy}>
+			{copied ? '✓ Copied' : 'Copy'}
+		</Button>
+		<Button variant="outline" size="sm" onclick={handleDownload}>Download</Button>
+	</div>
+</div>

--- a/src/lib/components/admin/UserManageDrawer.svelte
+++ b/src/lib/components/admin/UserManageDrawer.svelte
@@ -83,9 +83,7 @@
 
 	let selectedCompanionIds = $state<string[]>([]);
 	$effect(() => {
-		// Track user.id so the effect re-runs when the drawer opens for a different user.
-		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-		user.id;
+		void user.id; // re-run when the drawer opens for a different user
 		selectedCompanionIds = [...assignedIds];
 	});
 

--- a/src/lib/components/admin/UserManageDrawer.svelte
+++ b/src/lib/components/admin/UserManageDrawer.svelte
@@ -21,6 +21,7 @@
 		phone: string | null;
 		role: 'admin' | 'member' | 'caretaker';
 		isActive: boolean;
+		totpEnabled: boolean;
 	}
 	interface CompanionRow {
 		id: string;
@@ -567,6 +568,32 @@
 					<Button type="submit" size="sm">{t(locale, 'page.admin.setPassword')}</Button>
 				</form>
 			</section>
+
+			<!-- Security / 2FA reset -->
+			{#if user.totpEnabled}
+				<section>
+					<h2 class={sectionLabel}>{t(locale, 'page.admin.securitySection')}</h2>
+					<form
+						method="POST"
+						action="?/resetTwoFactor"
+						use:enhance={() =>
+							({ result, update }) => {
+								update({ reset: false });
+								if (result.type === 'success')
+									notify('success', t(locale, 'page.admin.twofaReset'));
+								else if (result.type === 'failure') {
+									const e = errorText(result.data, 'twofaResetError');
+									if (e) notify('error', e);
+								}
+							}}
+					>
+						<input type="hidden" name="userId" value={user.id} />
+						<Button type="submit" variant="softDestructive" size="sm">
+							{t(locale, 'page.admin.resetTwofa')}
+						</Button>
+					</form>
+				</section>
+			{/if}
 
 			<!-- Deactivate / Activate -->
 			{#if user.id !== currentUserId}

--- a/src/lib/components/settings/SecurityCard.svelte
+++ b/src/lib/components/settings/SecurityCard.svelte
@@ -5,6 +5,7 @@
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import BackupCodes from '$lib/components/BackupCodes.svelte';
 	import { t, getLocale } from '$lib/i18n';
 
 	let {
@@ -24,30 +25,6 @@
 	const backupCodes = $derived(
 		Array.isArray(form?.totpBackupCodes) ? (form.totpBackupCodes as string[]) : null
 	);
-
-	let codesCopied = $state(false);
-
-	function copyCodesText(): string {
-		return backupCodes?.join('\n') ?? '';
-	}
-
-	async function handleCopy() {
-		if (!backupCodes) return;
-		await navigator.clipboard.writeText(copyCodesText());
-		codesCopied = true;
-		setTimeout(() => (codesCopied = false), 2000);
-	}
-
-	function handleDownload() {
-		if (!backupCodes) return;
-		const blob = new Blob([copyCodesText()], { type: 'text/plain' });
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = 'einvault-backup-codes.txt';
-		a.click();
-		URL.revokeObjectURL(url);
-	}
 </script>
 
 <Card>
@@ -59,24 +36,8 @@
 			<p class="text-sm text-muted-foreground">{t(locale, 'page.settings.twofaUnavailable')}</p>
 		{:else if backupCodes}
 			<!-- State 4: backup codes just generated (after confirm or regen) -->
-			<h3 class="text-sm font-semibold mb-1">{t(locale, 'page.settings.backupCodesTitle')}</h3>
-			<p class="text-sm text-muted-foreground mb-3">
-				{t(locale, 'page.settings.backupCodesIntro')}
-			</p>
-			<div
-				class="grid grid-cols-2 gap-1.5 font-mono text-sm bg-muted rounded-md p-3 mb-3 select-all"
-			>
-				{#each backupCodes as code (code)}
-					<span>{code}</span>
-				{/each}
-			</div>
-			<div class="flex gap-2 mb-4">
-				<Button variant="outline" size="sm" onclick={handleCopy}>
-					{codesCopied ? '✓ Copied' : 'Copy'}
-				</Button>
-				<Button variant="outline" size="sm" onclick={handleDownload}>Download</Button>
-			</div>
-			<Button variant="secondary" size="sm" onclick={() => location.reload()}>
+			<BackupCodes codes={backupCodes} />
+			<Button variant="secondary" size="sm" class="mt-4" onclick={() => location.reload()}>
 				{t(locale, 'page.settings.backupCodesSaved')}
 			</Button>
 		{:else if form?.totpQr && !form?.totpSuccess}

--- a/src/lib/components/settings/SecurityCard.svelte
+++ b/src/lib/components/settings/SecurityCard.svelte
@@ -156,7 +156,22 @@
 					use:enhance={() =>
 						async ({ update }) =>
 							update({ reset: false })}
+					class="space-y-3"
 				>
+					<div class="space-y-1.5">
+						<Label for="totp-regen-code">{t(locale, 'page.settings.confirmCode')}</Label>
+						<Input
+							id="totp-regen-code"
+							name="code"
+							type="text"
+							inputmode="numeric"
+							pattern="[0-9]*"
+							maxlength={6}
+							autocomplete="one-time-code"
+							aria-label={t(locale, 'page.settings.confirmCode')}
+							class="max-w-[180px]"
+						/>
+					</div>
 					<Button variant="outline" size="sm" type="submit">
 						{t(locale, 'page.settings.regenBackup')}
 					</Button>

--- a/src/lib/components/settings/SecurityCard.svelte
+++ b/src/lib/components/settings/SecurityCard.svelte
@@ -81,7 +81,7 @@
 						class="max-w-[180px]"
 					/>
 				</div>
-				<Button type="submit">{t(locale, 'page.settings.confirmEnable')}</Button>
+				<Button type="submit" size="sm">{t(locale, 'page.settings.confirmEnable')}</Button>
 			</form>
 		{:else if !totpEnabled}
 			<!-- State 2: 2FA off, not mid-enroll -->
@@ -93,7 +93,7 @@
 					async ({ update }) =>
 						update({ reset: false })}
 			>
-				<Button type="submit">{t(locale, 'page.settings.enable2fa')}</Button>
+				<Button type="submit" size="sm">{t(locale, 'page.settings.enable2fa')}</Button>
 			</form>
 		{:else}
 			<!-- State 5: 2FA on -->

--- a/src/lib/components/settings/SecurityCard.svelte
+++ b/src/lib/components/settings/SecurityCard.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Card, CardHeader, CardTitle, CardContent } from '$lib/components/ui/card/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import { t, getLocale } from '$lib/i18n';
+
+	let {
+		totpEnabled,
+		available,
+		enforced,
+		form
+	}: {
+		totpEnabled: boolean;
+		available: boolean;
+		enforced: boolean;
+		form: Record<string, unknown> | null | undefined;
+	} = $props();
+
+	const locale = getLocale();
+
+	const backupCodes = $derived(
+		Array.isArray(form?.totpBackupCodes) ? (form.totpBackupCodes as string[]) : null
+	);
+
+	let codesCopied = $state(false);
+
+	function copyCodesText(): string {
+		return backupCodes?.join('\n') ?? '';
+	}
+
+	async function handleCopy() {
+		if (!backupCodes) return;
+		await navigator.clipboard.writeText(copyCodesText());
+		codesCopied = true;
+		setTimeout(() => (codesCopied = false), 2000);
+	}
+
+	function handleDownload() {
+		if (!backupCodes) return;
+		const blob = new Blob([copyCodesText()], { type: 'text/plain' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = 'einvault-backup-codes.txt';
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+</script>
+
+<Card>
+	<CardHeader>
+		<CardTitle>{t(locale, 'page.settings.securityCard')}</CardTitle>
+	</CardHeader>
+	<CardContent>
+		{#if !available}
+			<p class="text-sm text-muted-foreground">{t(locale, 'page.settings.twofaUnavailable')}</p>
+		{:else if backupCodes}
+			<!-- State 4: backup codes just generated (after confirm or regen) -->
+			<h3 class="text-sm font-semibold mb-1">{t(locale, 'page.settings.backupCodesTitle')}</h3>
+			<p class="text-sm text-muted-foreground mb-3">
+				{t(locale, 'page.settings.backupCodesIntro')}
+			</p>
+			<div
+				class="grid grid-cols-2 gap-1.5 font-mono text-sm bg-muted rounded-md p-3 mb-3 select-all"
+			>
+				{#each backupCodes as code (code)}
+					<span>{code}</span>
+				{/each}
+			</div>
+			<div class="flex gap-2 mb-4">
+				<Button variant="outline" size="sm" onclick={handleCopy}>
+					{codesCopied ? '✓ Copied' : 'Copy'}
+				</Button>
+				<Button variant="outline" size="sm" onclick={handleDownload}>Download</Button>
+			</div>
+			<Button variant="secondary" size="sm" onclick={() => location.reload()}>
+				{t(locale, 'page.settings.backupCodesSaved')}
+			</Button>
+		{:else if form?.totpQr && !form?.totpSuccess}
+			<!-- State 3: mid-enroll — QR shown, awaiting confirmation -->
+			<p class="text-sm text-muted-foreground mb-3">{t(locale, 'page.settings.scanQr')}</p>
+			<img
+				src={String(form.totpQr)}
+				alt=""
+				class="w-40 h-40 rounded-md border border-border mb-3"
+			/>
+			<p class="text-sm text-muted-foreground mb-1">{t(locale, 'page.settings.manualKey')}</p>
+			<code class="block font-mono text-xs bg-muted rounded px-2 py-1 mb-4 break-all">
+				{String(form.totpManualKey ?? '')}
+			</code>
+
+			{#if form?.totpError}
+				<Alert variant="coral" class="mb-3">
+					<AlertDescription>{String(form.totpError)}</AlertDescription>
+				</Alert>
+			{/if}
+
+			<form
+				method="POST"
+				action="?/totpConfirm"
+				use:enhance={() =>
+					async ({ update }) =>
+						update({ reset: false })}
+				class="space-y-3"
+			>
+				<div class="space-y-1.5">
+					<Label for="totp-confirm-code">{t(locale, 'page.settings.confirmCode')}</Label>
+					<Input
+						id="totp-confirm-code"
+						name="code"
+						type="text"
+						inputmode="numeric"
+						pattern="[0-9]*"
+						maxlength={6}
+						autocomplete="one-time-code"
+						aria-label={t(locale, 'page.settings.confirmCode')}
+						class="max-w-[180px]"
+					/>
+				</div>
+				<Button type="submit">{t(locale, 'page.settings.confirmEnable')}</Button>
+			</form>
+		{:else if !totpEnabled}
+			<!-- State 2: 2FA off, not mid-enroll -->
+			<p class="text-sm text-muted-foreground mb-4">{t(locale, 'page.settings.twofaOff')}</p>
+			<form
+				method="POST"
+				action="?/totpBegin"
+				use:enhance={() =>
+					async ({ update }) =>
+						update({ reset: false })}
+			>
+				<Button type="submit">{t(locale, 'page.settings.enable2fa')}</Button>
+			</form>
+		{:else}
+			<!-- State 5: 2FA on -->
+			{#if form?.totpSuccess}
+				<Alert variant="success" class="mb-4">
+					<AlertDescription>{t(locale, 'page.settings.twofaUpdated')}</AlertDescription>
+				</Alert>
+			{/if}
+			{#if form?.totpError}
+				<Alert variant="coral" class="mb-4">
+					<AlertDescription>{String(form.totpError)}</AlertDescription>
+				</Alert>
+			{/if}
+
+			<p class="text-sm font-medium mb-4">{t(locale, 'page.settings.twofaOn')}</p>
+
+			<div class="space-y-4">
+				<form
+					method="POST"
+					action="?/totpRegenerate"
+					use:enhance={() =>
+						async ({ update }) =>
+							update({ reset: false })}
+				>
+					<Button variant="outline" size="sm" type="submit">
+						{t(locale, 'page.settings.regenBackup')}
+					</Button>
+				</form>
+
+				{#if enforced}
+					<p class="text-sm text-muted-foreground">
+						{t(locale, 'page.twofa.cannotDisableEnforced')}
+					</p>
+				{:else}
+					<form
+						method="POST"
+						action="?/totpDisable"
+						use:enhance={() =>
+							async ({ update }) =>
+								update({ reset: false })}
+						class="space-y-3"
+					>
+						<div class="space-y-1.5">
+							<Label for="totp-disable-code">{t(locale, 'page.settings.confirmCode')}</Label>
+							<Input
+								id="totp-disable-code"
+								name="code"
+								type="text"
+								inputmode="numeric"
+								pattern="[0-9]*"
+								maxlength={6}
+								autocomplete="one-time-code"
+								aria-label={t(locale, 'page.settings.confirmCode')}
+								class="max-w-[180px]"
+							/>
+						</div>
+						<Button variant="coral" size="sm" type="submit">
+							{t(locale, 'page.settings.disable2fa')}
+						</Button>
+					</form>
+				{/if}
+			</div>
+		{/if}
+	</CardContent>
+</Card>

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -831,6 +831,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.require2faEveryone': 'Alle',
 	'page.admin.require2faHelp':
 		'Benutzer zur Einrichtung von 2FA zwingen. OIDC-Benutzer sind ausgenommen.',
+	'page.admin.require2faNoKey':
+		'TWOFA_ENC_KEY setzen, um die Zwei-Faktor-Erzwingung zu aktivieren.',
 	'page.admin.resetTwofa': 'Zwei-Faktor zurücksetzen',
 	'page.admin.twofaReset': '✓ Zwei-Faktor für diesen Benutzer zurückgesetzt.',
 

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -303,6 +303,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.twofaUnavailable':
 		'Zwei-Faktor-Authentifizierung ist nicht verfügbar. Setze TWOFA_ENC_KEY, um sie zu aktivieren.',
 	'page.settings.twofaUpdated': '✓ Zwei-Faktor-Einstellungen aktualisiert.',
+	'page.settings.reenrollNote':
+		'Deaktiviere zuerst die Zwei-Faktor-Authentifizierung, um ein neues Gerät einzurichten.',
 	'page.settings.testEmail': 'Test-E-Mail senden',
 	'page.settings.testNtfy': 'Test-Push senden',
 	'page.settings.testSent': 'Testbenachrichtigung gesendet.',

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -206,6 +206,19 @@ const messages: Record<keyof Messages, string> = {
 	'layout.caretaker.requiresActiveShift': 'erfordert aktive Schicht',
 	'layout.caretaker.shiftCalendarEvent': 'EinVault Schicht',
 
+	// Page: 2FA
+	'page.twofa.title': 'Zwei-Faktor-Authentifizierung',
+	'page.twofa.codeLabel': 'Authentifizierungscode',
+	'page.twofa.help':
+		'Gib den 6-stelligen Code aus deiner Authenticator-App ein oder einen Backup-Code.',
+	'page.twofa.invalidCode': 'Ungültiger oder abgelaufener Code.',
+	'page.twofa.submit': 'Bestätigen',
+	'page.twofa.cannotDisableEnforced':
+		'Dein Administrator verlangt Zwei-Faktor-Authentifizierung, daher kann sie nicht deaktiviert werden.',
+	'page.twofa.setupRequiredTitle': 'Zwei-Faktor-Authentifizierung erforderlich',
+	'page.twofa.setupRequiredBody':
+		'Dein Administrator verlangt Zwei-Faktor-Authentifizierung für dein Konto. Richte sie ein, um fortzufahren.',
+
 	// Page: settings
 	'page.settings.title': 'Einstellungen',
 	'page.settings.subtitle': 'Verwalte dein Konto.',
@@ -272,6 +285,24 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.ntfyTopicLabel': 'ntfy-Thema',
 	'page.settings.ntfyTopicHint':
 		'Push-Nachrichten umfassen fällige Erinnerungen und Schichtmeldungen für das, was du in EinVault sehen kannst. Sie gehen an dieses Thema auf dem vom Admin konfigurierten ntfy-Server. Wähle einen langen zufälligen Namen; jeder, der ihn kennt, kann ihn abonnieren. Leer lassen, um Push zu deaktivieren.',
+	'page.settings.securityCard': 'Sicherheit',
+	'page.settings.twofaOn': 'Zwei-Faktor-Authentifizierung ist aktiv.',
+	'page.settings.twofaOff':
+		'Füge beim Anmelden einen zweiten Schritt mit einer Authenticator-App hinzu.',
+	'page.settings.enable2fa': 'Zwei-Faktor-Authentifizierung aktivieren',
+	'page.settings.scanQr': 'Scanne diesen QR-Code mit deiner Authenticator-App.',
+	'page.settings.manualKey': 'Oder gib diesen Schlüssel manuell ein:',
+	'page.settings.confirmCode': 'Gib den 6-stelligen Code zur Bestätigung ein',
+	'page.settings.confirmEnable': 'Bestätigen',
+	'page.settings.backupCodesTitle': 'Speichere deine Backup-Codes',
+	'page.settings.backupCodesIntro':
+		'Bewahre sie sicher auf. Jeder Code kann einmal verwendet werden, falls du deinen Authenticator verlierst.',
+	'page.settings.backupCodesSaved': 'Ich habe meine Backup-Codes gespeichert',
+	'page.settings.regenBackup': 'Backup-Codes neu generieren',
+	'page.settings.disable2fa': 'Zwei-Faktor-Authentifizierung deaktivieren',
+	'page.settings.twofaUnavailable':
+		'Zwei-Faktor-Authentifizierung ist nicht verfügbar. Setze TWOFA_ENC_KEY, um sie zu aktivieren.',
+	'page.settings.twofaUpdated': '✓ Zwei-Faktor-Einstellungen aktualisiert.',
 	'page.settings.testEmail': 'Test-E-Mail senden',
 	'page.settings.testNtfy': 'Test-Push senden',
 	'page.settings.testSent': 'Testbenachrichtigung gesendet.',
@@ -793,6 +824,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.setPassword': 'Passwort festlegen',
 	'page.admin.saveProfile': 'Profil speichern',
 	'page.admin.saveCompanions': 'Begleiter speichern',
+	'page.admin.securitySection': 'Sicherheit',
+	'page.admin.require2faLabel': 'Zwei-Faktor-Authentifizierung erforderlich',
+	'page.admin.require2faOff': 'Aus',
+	'page.admin.require2faAdmins': 'Nur Admins',
+	'page.admin.require2faEveryone': 'Alle',
+	'page.admin.require2faHelp':
+		'Benutzer zur Einrichtung von 2FA zwingen. OIDC-Benutzer sind ausgenommen.',
+	'page.admin.resetTwofa': 'Zwei-Faktor zurücksetzen',
+	'page.admin.twofaReset': '✓ Zwei-Faktor für diesen Benutzer zurückgesetzt.',
 
 	// Page: Caretaker log
 	'page.log.title': 'Aktivität erfassen',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -287,6 +287,7 @@ const messages = {
 	'page.settings.twofaUnavailable':
 		'Two-factor authentication is unavailable. Set TWOFA_ENC_KEY to enable it.',
 	'page.settings.twofaUpdated': '✓ Two-factor settings updated.',
+	'page.settings.reenrollNote': 'Turn off two-factor authentication first to set up a new device.',
 	'page.settings.testEmail': 'Send test email',
 	'page.settings.testNtfy': 'Send test push',
 	'page.settings.testSent': 'Test notification sent.',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -193,6 +193,18 @@ const messages = {
 	'layout.caretaker.requiresActiveShift': 'requires active shift',
 	'layout.caretaker.shiftCalendarEvent': 'EinVault Shift',
 
+	// Page: 2FA
+	'page.twofa.title': 'Two-factor authentication',
+	'page.twofa.codeLabel': 'Authentication code',
+	'page.twofa.help': 'Enter the 6-digit code from your authenticator app, or a backup code.',
+	'page.twofa.invalidCode': 'Invalid or expired code.',
+	'page.twofa.submit': 'Verify',
+	'page.twofa.cannotDisableEnforced':
+		'Your administrator requires two-factor authentication, so it cannot be disabled.',
+	'page.twofa.setupRequiredTitle': 'Two-factor authentication required',
+	'page.twofa.setupRequiredBody':
+		'Your administrator requires two-factor authentication on your account. Set it up to continue.',
+
 	// Page: settings (shared between app and caretaker)
 	'page.settings.title': 'Settings',
 	'page.settings.subtitle': 'Manage your account.',
@@ -258,6 +270,23 @@ const messages = {
 	'page.settings.ntfyTopicLabel': 'ntfy topic',
 	'page.settings.ntfyTopicHint':
 		'Pushes cover due reminders and shift alerts for what you can see in EinVault. They go to this topic on the ntfy server configured by your admin. Pick a long random name; anyone who knows it can subscribe. Leave empty to disable pushes.',
+	'page.settings.securityCard': 'Security',
+	'page.settings.twofaOn': 'Two-factor authentication is on.',
+	'page.settings.twofaOff': 'Add a second step at sign-in with an authenticator app.',
+	'page.settings.enable2fa': 'Enable two-factor authentication',
+	'page.settings.scanQr': 'Scan this QR code with your authenticator app.',
+	'page.settings.manualKey': 'Or enter this key manually:',
+	'page.settings.confirmCode': 'Enter the 6-digit code to confirm',
+	'page.settings.confirmEnable': 'Confirm',
+	'page.settings.backupCodesTitle': 'Save your backup codes',
+	'page.settings.backupCodesIntro':
+		'Store these somewhere safe. Each code works once if you lose your authenticator.',
+	'page.settings.backupCodesSaved': "I've saved my backup codes",
+	'page.settings.regenBackup': 'Regenerate backup codes',
+	'page.settings.disable2fa': 'Disable two-factor authentication',
+	'page.settings.twofaUnavailable':
+		'Two-factor authentication is unavailable. Set TWOFA_ENC_KEY to enable it.',
+	'page.settings.twofaUpdated': '✓ Two-factor settings updated.',
 	'page.settings.testEmail': 'Send test email',
 	'page.settings.testNtfy': 'Send test push',
 	'page.settings.testSent': 'Test notification sent.',
@@ -782,6 +811,14 @@ const messages = {
 	'page.admin.setPassword': 'Set password',
 	'page.admin.saveProfile': 'Save profile',
 	'page.admin.saveCompanions': 'Save companions',
+	'page.admin.securitySection': 'Security',
+	'page.admin.require2faLabel': 'Require two-factor authentication',
+	'page.admin.require2faOff': 'Off',
+	'page.admin.require2faAdmins': 'Admins only',
+	'page.admin.require2faEveryone': 'Everyone',
+	'page.admin.require2faHelp': 'Force users to set up 2FA. OIDC users are exempt.',
+	'page.admin.resetTwofa': 'Reset two-factor',
+	'page.admin.twofaReset': '✓ Two-factor reset for this user.',
 
 	// Page: Caretaker log
 	'page.log.title': 'Log activity',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -817,6 +817,7 @@ const messages = {
 	'page.admin.require2faAdmins': 'Admins only',
 	'page.admin.require2faEveryone': 'Everyone',
 	'page.admin.require2faHelp': 'Force users to set up 2FA. OIDC users are exempt.',
+	'page.admin.require2faNoKey': 'Set TWOFA_ENC_KEY to enable two-factor enforcement.',
 	'page.admin.resetTwofa': 'Reset two-factor',
 	'page.admin.twofaReset': '✓ Two-factor reset for this user.',
 

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -302,6 +302,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.twofaUnavailable':
 		'La autenticación de dos factores no está disponible. Establece TWOFA_ENC_KEY para activarla.',
 	'page.settings.twofaUpdated': '✓ Configuración de dos factores actualizada.',
+	'page.settings.reenrollNote':
+		'Desactiva primero la autenticación de dos factores para configurar un nuevo dispositivo.',
 	'page.settings.testEmail': 'Enviar correo de prueba',
 	'page.settings.testNtfy': 'Enviar push de prueba',
 	'page.settings.testSent': 'Notificación de prueba enviada.',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -206,6 +206,19 @@ const messages: Record<keyof Messages, string> = {
 	'layout.caretaker.requiresActiveShift': 'requiere turno activo',
 	'layout.caretaker.shiftCalendarEvent': 'Turno EinVault',
 
+	// Page: 2FA
+	'page.twofa.title': 'Autenticación de dos factores',
+	'page.twofa.codeLabel': 'Código de autenticación',
+	'page.twofa.help':
+		'Introduce el código de 6 dígitos de tu app autenticadora o un código de respaldo.',
+	'page.twofa.invalidCode': 'Código inválido o expirado.',
+	'page.twofa.submit': 'Verificar',
+	'page.twofa.cannotDisableEnforced':
+		'Tu administrador exige autenticación de dos factores, por lo que no se puede desactivar.',
+	'page.twofa.setupRequiredTitle': 'Autenticación de dos factores requerida',
+	'page.twofa.setupRequiredBody':
+		'Tu administrador exige autenticación de dos factores en tu cuenta. Configúrala para continuar.',
+
 	// Page: settings
 	'page.settings.title': 'Ajustes',
 	'page.settings.subtitle': 'Gestiona tu cuenta.',
@@ -272,6 +285,23 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.ntfyTopicLabel': 'Tema de ntfy',
 	'page.settings.ntfyTopicHint':
 		'Las notificaciones push cubren recordatorios vencidos y avisos de turnos de lo que puedes ver en EinVault. Van a este tema en el servidor ntfy configurado por tu administrador. Elige un nombre largo y aleatorio; cualquiera que lo conozca puede suscribirse. Déjalo vacío para desactivar los push.',
+	'page.settings.securityCard': 'Seguridad',
+	'page.settings.twofaOn': 'La autenticación de dos factores está activada.',
+	'page.settings.twofaOff': 'Añade un segundo paso al iniciar sesión con una app autenticadora.',
+	'page.settings.enable2fa': 'Activar autenticación de dos factores',
+	'page.settings.scanQr': 'Escanea este código QR con tu app autenticadora.',
+	'page.settings.manualKey': 'O introduce esta clave manualmente:',
+	'page.settings.confirmCode': 'Introduce el código de 6 dígitos para confirmar',
+	'page.settings.confirmEnable': 'Confirmar',
+	'page.settings.backupCodesTitle': 'Guarda tus códigos de respaldo',
+	'page.settings.backupCodesIntro':
+		'Guárdalos en un lugar seguro. Cada código funciona una vez si pierdes tu autenticador.',
+	'page.settings.backupCodesSaved': 'He guardado mis códigos de respaldo',
+	'page.settings.regenBackup': 'Regenerar códigos de respaldo',
+	'page.settings.disable2fa': 'Desactivar autenticación de dos factores',
+	'page.settings.twofaUnavailable':
+		'La autenticación de dos factores no está disponible. Establece TWOFA_ENC_KEY para activarla.',
+	'page.settings.twofaUpdated': '✓ Configuración de dos factores actualizada.',
 	'page.settings.testEmail': 'Enviar correo de prueba',
 	'page.settings.testNtfy': 'Enviar push de prueba',
 	'page.settings.testSent': 'Notificación de prueba enviada.',
@@ -793,6 +823,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.setPassword': 'Establecer contraseña',
 	'page.admin.saveProfile': 'Guardar perfil',
 	'page.admin.saveCompanions': 'Guardar compañeros',
+	'page.admin.securitySection': 'Seguridad',
+	'page.admin.require2faLabel': 'Requerir autenticación de dos factores',
+	'page.admin.require2faOff': 'Desactivado',
+	'page.admin.require2faAdmins': 'Solo admins',
+	'page.admin.require2faEveryone': 'Todos',
+	'page.admin.require2faHelp':
+		'Obliga a los usuarios a configurar 2FA. Los usuarios OIDC están exentos.',
+	'page.admin.resetTwofa': 'Restablecer dos factores',
+	'page.admin.twofaReset': '✓ Dos factores restablecido para este usuario.',
 
 	// Page: Caretaker log
 	'page.log.title': 'Registrar actividad',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -830,6 +830,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.require2faEveryone': 'Todos',
 	'page.admin.require2faHelp':
 		'Obliga a los usuarios a configurar 2FA. Los usuarios OIDC están exentos.',
+	'page.admin.require2faNoKey':
+		'Establece TWOFA_ENC_KEY para habilitar la aplicación de dos factores.',
 	'page.admin.resetTwofa': 'Restablecer dos factores',
 	'page.admin.twofaReset': '✓ Dos factores restablecido para este usuario.',
 

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -833,6 +833,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.require2faEveryone': 'Tout le monde',
 	'page.admin.require2faHelp':
 		'Oblige les utilisateurs à configurer la 2FA. Les utilisateurs OIDC sont exemptés.',
+	'page.admin.require2faNoKey':
+		"Définissez TWOFA_ENC_KEY pour activer l'application de la double authentification.",
 	'page.admin.resetTwofa': 'Réinitialiser deux facteurs',
 	'page.admin.twofaReset': '✓ Deux facteurs réinitialisé pour cet utilisateur.',
 

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -301,6 +301,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.twofaUnavailable':
 		"L'authentification à deux facteurs n'est pas disponible. Définissez TWOFA_ENC_KEY pour l'activer.",
 	'page.settings.twofaUpdated': '✓ Paramètres à deux facteurs mis à jour.',
+	'page.settings.reenrollNote':
+		"Désactivez d'abord l'authentification à deux facteurs pour configurer un nouvel appareil.",
 	'page.settings.testEmail': 'Envoyer un e-mail de test',
 	'page.settings.testNtfy': 'Envoyer un push de test',
 	'page.settings.testSent': 'Notification de test envoyée.',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -204,6 +204,19 @@ const messages: Record<keyof Messages, string> = {
 	'layout.caretaker.requiresActiveShift': 'nécessite une garde active',
 	'layout.caretaker.shiftCalendarEvent': 'Garde EinVault',
 
+	// Page: 2FA
+	'page.twofa.title': 'Authentification à deux facteurs',
+	'page.twofa.codeLabel': "Code d'authentification",
+	'page.twofa.help':
+		"Saisissez le code à 6 chiffres de votre application d'authentification ou un code de secours.",
+	'page.twofa.invalidCode': 'Code invalide ou expiré.',
+	'page.twofa.submit': 'Vérifier',
+	'page.twofa.cannotDisableEnforced':
+		"Votre administrateur exige l'authentification à deux facteurs, elle ne peut donc pas être désactivée.",
+	'page.twofa.setupRequiredTitle': 'Authentification à deux facteurs requise',
+	'page.twofa.setupRequiredBody':
+		"Votre administrateur exige l'authentification à deux facteurs sur votre compte. Configurez-la pour continuer.",
+
 	// Page: settings
 	'page.settings.title': 'Paramètres',
 	'page.settings.subtitle': 'Gérez votre compte.',
@@ -270,6 +283,24 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.ntfyTopicLabel': 'Sujet ntfy',
 	'page.settings.ntfyTopicHint':
 		"Les notifications push couvrent les rappels dus et les alertes de garde pour ce que vous pouvez voir dans EinVault. Elles sont envoyées à ce sujet sur le serveur ntfy configuré par votre administrateur. Choisissez un nom long et aléatoire ; quiconque le connaît peut s'y abonner. Laissez vide pour désactiver les push.",
+	'page.settings.securityCard': 'Sécurité',
+	'page.settings.twofaOn': "L'authentification à deux facteurs est activée.",
+	'page.settings.twofaOff':
+		"Ajoutez une deuxième étape à la connexion avec une application d'authentification.",
+	'page.settings.enable2fa': "Activer l'authentification à deux facteurs",
+	'page.settings.scanQr': "Scannez ce code QR avec votre application d'authentification.",
+	'page.settings.manualKey': 'Ou saisissez cette clé manuellement :',
+	'page.settings.confirmCode': 'Saisissez le code à 6 chiffres pour confirmer',
+	'page.settings.confirmEnable': 'Confirmer',
+	'page.settings.backupCodesTitle': 'Sauvegardez vos codes de secours',
+	'page.settings.backupCodesIntro':
+		"Conservez-les en lieu sûr. Chaque code fonctionne une fois si vous perdez votre application d'authentification.",
+	'page.settings.backupCodesSaved': "J'ai sauvegardé mes codes de secours",
+	'page.settings.regenBackup': 'Régénérer les codes de secours',
+	'page.settings.disable2fa': "Désactiver l'authentification à deux facteurs",
+	'page.settings.twofaUnavailable':
+		"L'authentification à deux facteurs n'est pas disponible. Définissez TWOFA_ENC_KEY pour l'activer.",
+	'page.settings.twofaUpdated': '✓ Paramètres à deux facteurs mis à jour.',
 	'page.settings.testEmail': 'Envoyer un e-mail de test',
 	'page.settings.testNtfy': 'Envoyer un push de test',
 	'page.settings.testSent': 'Notification de test envoyée.',
@@ -795,6 +826,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.setPassword': 'Définir le mot de passe',
 	'page.admin.saveProfile': 'Enregistrer le profil',
 	'page.admin.saveCompanions': 'Enregistrer les compagnons',
+	'page.admin.securitySection': 'Sécurité',
+	'page.admin.require2faLabel': "Exiger l'authentification à deux facteurs",
+	'page.admin.require2faOff': 'Désactivé',
+	'page.admin.require2faAdmins': 'Admins seulement',
+	'page.admin.require2faEveryone': 'Tout le monde',
+	'page.admin.require2faHelp':
+		'Oblige les utilisateurs à configurer la 2FA. Les utilisateurs OIDC sont exemptés.',
+	'page.admin.resetTwofa': 'Réinitialiser deux facteurs',
+	'page.admin.twofaReset': '✓ Deux facteurs réinitialisé pour cet utilisateur.',
 
 	// Page: Caretaker log
 	'page.log.title': 'Enregistrer une activité',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -826,6 +826,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.require2faEveryone': 'Tutti',
 	'page.admin.require2faHelp':
 		'Obbliga gli utenti a configurare la 2FA. Gli utenti OIDC sono esenti.',
+	'page.admin.require2faNoKey':
+		"Imposta TWOFA_ENC_KEY per abilitare l'applicazione della doppia autenticazione.",
 	'page.admin.resetTwofa': 'Reimposta due fattori',
 	'page.admin.twofaReset': '✓ Due fattori reimpostato per questo utente.',
 

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -299,6 +299,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.twofaUnavailable':
 		"L'autenticazione a due fattori non è disponibile. Imposta TWOFA_ENC_KEY per attivarla.",
 	'page.settings.twofaUpdated': '✓ Impostazioni a due fattori aggiornate.',
+	'page.settings.reenrollNote':
+		"Disattiva prima l'autenticazione a due fattori per configurare un nuovo dispositivo.",
 	'page.settings.testEmail': 'Invia e-mail di prova',
 	'page.settings.testNtfy': 'Invia push di prova',
 	'page.settings.testSent': 'Notifica di prova inviata.',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -202,6 +202,19 @@ const messages: Record<keyof Messages, string> = {
 	'layout.caretaker.requiresActiveShift': 'richiede un turno attivo',
 	'layout.caretaker.shiftCalendarEvent': 'Turno EinVault',
 
+	// Page: 2FA
+	'page.twofa.title': 'Autenticazione a due fattori',
+	'page.twofa.codeLabel': 'Codice di autenticazione',
+	'page.twofa.help':
+		'Inserisci il codice a 6 cifre dalla tua app di autenticazione o un codice di backup.',
+	'page.twofa.invalidCode': 'Codice non valido o scaduto.',
+	'page.twofa.submit': 'Verifica',
+	'page.twofa.cannotDisableEnforced':
+		"Il tuo amministratore richiede l'autenticazione a due fattori, pertanto non può essere disattivata.",
+	'page.twofa.setupRequiredTitle': 'Autenticazione a due fattori richiesta',
+	'page.twofa.setupRequiredBody':
+		"Il tuo amministratore richiede l'autenticazione a due fattori sul tuo account. Configurala per continuare.",
+
 	// Page: settings
 	'page.settings.title': 'Impostazioni',
 	'page.settings.subtitle': 'Gestisci il tuo account.',
@@ -268,6 +281,24 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.ntfyTopicLabel': 'Argomento ntfy',
 	'page.settings.ntfyTopicHint':
 		'Le notifiche push coprono i promemoria in scadenza e gli avvisi di turno per ciò che puoi vedere in EinVault. Vanno a questo argomento sul server ntfy configurato dal tuo amministratore. Scegli un nome lungo e casuale; chiunque lo conosca può iscriversi. Lascia vuoto per disattivare i push.',
+	'page.settings.securityCard': 'Sicurezza',
+	'page.settings.twofaOn': "L'autenticazione a due fattori è attiva.",
+	'page.settings.twofaOff':
+		"Aggiungi un secondo passaggio all'accesso con un'app di autenticazione.",
+	'page.settings.enable2fa': "Attiva l'autenticazione a due fattori",
+	'page.settings.scanQr': 'Scansiona questo codice QR con la tua app di autenticazione.',
+	'page.settings.manualKey': 'Oppure inserisci questa chiave manualmente:',
+	'page.settings.confirmCode': 'Inserisci il codice a 6 cifre per confermare',
+	'page.settings.confirmEnable': 'Conferma',
+	'page.settings.backupCodesTitle': 'Salva i tuoi codici di backup',
+	'page.settings.backupCodesIntro':
+		'Conservali in un posto sicuro. Ogni codice funziona una volta se perdi il tuo autenticatore.',
+	'page.settings.backupCodesSaved': 'Ho salvato i miei codici di backup',
+	'page.settings.regenBackup': 'Rigenera codici di backup',
+	'page.settings.disable2fa': "Disattiva l'autenticazione a due fattori",
+	'page.settings.twofaUnavailable':
+		"L'autenticazione a due fattori non è disponibile. Imposta TWOFA_ENC_KEY per attivarla.",
+	'page.settings.twofaUpdated': '✓ Impostazioni a due fattori aggiornate.',
 	'page.settings.testEmail': 'Invia e-mail di prova',
 	'page.settings.testNtfy': 'Invia push di prova',
 	'page.settings.testSent': 'Notifica di prova inviata.',
@@ -788,6 +819,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.setPassword': 'Imposta password',
 	'page.admin.saveProfile': 'Salva profilo',
 	'page.admin.saveCompanions': 'Salva compagni',
+	'page.admin.securitySection': 'Sicurezza',
+	'page.admin.require2faLabel': "Richiedi l'autenticazione a due fattori",
+	'page.admin.require2faOff': 'Disattivata',
+	'page.admin.require2faAdmins': 'Solo admin',
+	'page.admin.require2faEveryone': 'Tutti',
+	'page.admin.require2faHelp':
+		'Obbliga gli utenti a configurare la 2FA. Gli utenti OIDC sono esenti.',
+	'page.admin.resetTwofa': 'Reimposta due fattori',
+	'page.admin.twofaReset': '✓ Due fattori reimpostato per questo utente.',
 
 	// Page: Caretaker log
 	'page.log.title': 'Registra attività',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -301,6 +301,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.twofaUnavailable':
 		'A autenticação de dois fatores não está disponível. Defina TWOFA_ENC_KEY para a ativar.',
 	'page.settings.twofaUpdated': '✓ Definições de dois fatores atualizadas.',
+	'page.settings.reenrollNote':
+		'Desative primeiro a autenticação de dois fatores para configurar um novo dispositivo.',
 	'page.settings.testEmail': 'Enviar e-mail de teste',
 	'page.settings.testNtfy': 'Enviar push de teste',
 	'page.settings.testSent': 'Notificação de teste enviada.',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -203,6 +203,19 @@ const messages: Record<keyof Messages, string> = {
 	'layout.caretaker.requiresActiveShift': 'requer turno ativo',
 	'layout.caretaker.shiftCalendarEvent': 'Turno EinVault',
 
+	// Page: 2FA
+	'page.twofa.title': 'Autenticação de dois fatores',
+	'page.twofa.codeLabel': 'Código de autenticação',
+	'page.twofa.help':
+		'Introduza o código de 6 dígitos da sua app autenticadora ou um código de recuperação.',
+	'page.twofa.invalidCode': 'Código inválido ou expirado.',
+	'page.twofa.submit': 'Verificar',
+	'page.twofa.cannotDisableEnforced':
+		'O seu administrador exige autenticação de dois fatores, pelo que não pode ser desativada.',
+	'page.twofa.setupRequiredTitle': 'Autenticação de dois fatores obrigatória',
+	'page.twofa.setupRequiredBody':
+		'O seu administrador exige autenticação de dois fatores na sua conta. Configure-a para continuar.',
+
 	// Page: settings
 	'page.settings.title': 'Definições',
 	'page.settings.subtitle': 'Gerir a sua conta.',
@@ -270,6 +283,24 @@ const messages: Record<keyof Messages, string> = {
 	'page.settings.ntfyTopicLabel': 'Tópico ntfy',
 	'page.settings.ntfyTopicHint':
 		'As notificações push cobrem lembretes vencidos e alertas de turno do que você pode ver no EinVault. Vão para este tópico no servidor ntfy configurado pelo seu administrador. Escolha um nome longo e aleatório; qualquer pessoa que o conheça pode se inscrever. Deixe vazio para desativar os push.',
+	'page.settings.securityCard': 'Segurança',
+	'page.settings.twofaOn': 'A autenticação de dois fatores está ativa.',
+	'page.settings.twofaOff':
+		'Adicione um segundo passo no início de sessão com uma app autenticadora.',
+	'page.settings.enable2fa': 'Ativar autenticação de dois fatores',
+	'page.settings.scanQr': 'Digitalize este código QR com a sua app autenticadora.',
+	'page.settings.manualKey': 'Ou introduza esta chave manualmente:',
+	'page.settings.confirmCode': 'Introduza o código de 6 dígitos para confirmar',
+	'page.settings.confirmEnable': 'Confirmar',
+	'page.settings.backupCodesTitle': 'Guarde os seus códigos de recuperação',
+	'page.settings.backupCodesIntro':
+		'Guarde-os num lugar seguro. Cada código funciona uma vez se perder o seu autenticador.',
+	'page.settings.backupCodesSaved': 'Guardei os meus códigos de recuperação',
+	'page.settings.regenBackup': 'Regenerar códigos de recuperação',
+	'page.settings.disable2fa': 'Desativar autenticação de dois fatores',
+	'page.settings.twofaUnavailable':
+		'A autenticação de dois fatores não está disponível. Defina TWOFA_ENC_KEY para a ativar.',
+	'page.settings.twofaUpdated': '✓ Definições de dois fatores atualizadas.',
 	'page.settings.testEmail': 'Enviar e-mail de teste',
 	'page.settings.testNtfy': 'Enviar push de teste',
 	'page.settings.testSent': 'Notificação de teste enviada.',
@@ -791,6 +822,15 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.setPassword': 'Definir palavra-passe',
 	'page.admin.saveProfile': 'Salvar perfil',
 	'page.admin.saveCompanions': 'Salvar companheiros',
+	'page.admin.securitySection': 'Segurança',
+	'page.admin.require2faLabel': 'Exigir autenticação de dois fatores',
+	'page.admin.require2faOff': 'Desativado',
+	'page.admin.require2faAdmins': 'Apenas admins',
+	'page.admin.require2faEveryone': 'Todos',
+	'page.admin.require2faHelp':
+		'Obriga os utilizadores a configurar 2FA. Os utilizadores OIDC estão isentos.',
+	'page.admin.resetTwofa': 'Redefinir dois fatores',
+	'page.admin.twofaReset': '✓ Dois fatores redefinido para este utilizador.',
 
 	// Page: Caretaker log
 	'page.log.title': 'Registar atividade',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -829,6 +829,8 @@ const messages: Record<keyof Messages, string> = {
 	'page.admin.require2faEveryone': 'Todos',
 	'page.admin.require2faHelp':
 		'Obriga os utilizadores a configurar 2FA. Os utilizadores OIDC estão isentos.',
+	'page.admin.require2faNoKey':
+		'Defina TWOFA_ENC_KEY para ativar a imposição da autenticação de dois fatores.',
 	'page.admin.resetTwofa': 'Redefinir dois fatores',
 	'page.admin.twofaReset': '✓ Dois fatores redefinido para este utilizador.',
 

--- a/src/lib/server/app-settings.test.ts
+++ b/src/lib/server/app-settings.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { db, schema } from '$lib/server/db';
+import { getAppSettings, setRequire2fa } from './app-settings';
+
+beforeAll(async () => {
+	await db
+		.insert(schema.users)
+		.values({ id: 'some-admin-id', username: 'admin', displayName: 'Admin', role: 'admin' });
+});
+
+describe('app-settings', () => {
+	it('defaults require2fa to off and persists a change', async () => {
+		expect((await getAppSettings()).require2fa).toBe('off');
+		await setRequire2fa('everyone', 'some-admin-id');
+		expect((await getAppSettings()).require2fa).toBe('everyone');
+	});
+});

--- a/src/lib/server/app-settings.ts
+++ b/src/lib/server/app-settings.ts
@@ -3,14 +3,25 @@ import { eq } from 'drizzle-orm';
 
 export type Require2fa = 'off' | 'admins' | 'everyone';
 const SINGLETON = 'singleton';
+const CACHE_TTL_MS = 10_000;
+
+let cache: { value: { require2fa: Require2fa }; at: number } | null = null;
 
 export async function getAppSettings(): Promise<{ require2fa: Require2fa }> {
+	if (cache && Date.now() - cache.at < CACHE_TTL_MS) {
+		return cache.value;
+	}
 	const row = await db.query.appSettings.findFirst({
 		where: eq(schema.appSettings.id, SINGLETON)
 	});
-	if (row) return { require2fa: row.require2fa };
-	await db.insert(schema.appSettings).values({ id: SINGLETON }).onConflictDoNothing();
-	return { require2fa: 'off' };
+	const value: { require2fa: Require2fa } = row
+		? { require2fa: row.require2fa }
+		: { require2fa: 'off' };
+	if (!row) {
+		await db.insert(schema.appSettings).values({ id: SINGLETON }).onConflictDoNothing();
+	}
+	cache = { value, at: Date.now() };
+	return value;
 }
 
 export async function setRequire2fa(value: Require2fa, updatedBy: string): Promise<void> {
@@ -21,4 +32,5 @@ export async function setRequire2fa(value: Require2fa, updatedBy: string): Promi
 			target: schema.appSettings.id,
 			set: { require2fa: value, updatedAt: new Date(), updatedBy }
 		});
+	cache = { value: { require2fa: value }, at: Date.now() };
 }

--- a/src/lib/server/app-settings.ts
+++ b/src/lib/server/app-settings.ts
@@ -1,0 +1,24 @@
+import { db, schema } from '$lib/server/db';
+import { eq } from 'drizzle-orm';
+
+export type Require2fa = 'off' | 'admins' | 'everyone';
+const SINGLETON = 'singleton';
+
+export async function getAppSettings(): Promise<{ require2fa: Require2fa }> {
+	const row = await db.query.appSettings.findFirst({
+		where: eq(schema.appSettings.id, SINGLETON)
+	});
+	if (row) return { require2fa: row.require2fa };
+	await db.insert(schema.appSettings).values({ id: SINGLETON }).onConflictDoNothing();
+	return { require2fa: 'off' };
+}
+
+export async function setRequire2fa(value: Require2fa, updatedBy: string): Promise<void> {
+	await db
+		.insert(schema.appSettings)
+		.values({ id: SINGLETON, require2fa: value, updatedAt: new Date(), updatedBy })
+		.onConflictDoUpdate({
+			target: schema.appSettings.id,
+			set: { require2fa: value, updatedAt: new Date(), updatedBy }
+		});
+}

--- a/src/lib/server/auth/enrollment.test.ts
+++ b/src/lib/server/auth/enrollment.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { TOTP, Secret } from 'otpauth';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: new Proxy({} as Record<string, string | undefined>, {
+		get: (_t, k: string) => process.env[k]
+	})
+}));
+
+beforeAll(() => {
+	process.env.TWOFA_ENC_KEY = Buffer.from(new Uint8Array(32).fill(9)).toString('base64');
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function codeFor(secret: string, timestamp = Date.now()): string {
+	return new TOTP({ secret: Secret.fromBase32(secret), digits: 6, period: 30 }).generate({
+		timestamp
+	});
+}
+
+describe('enrollment', () => {
+	it('begins, confirms, disables', async () => {
+		const { db, schema } = await import('$lib/server/db');
+		const { beginEnrollment, confirmEnrollment, disableTwoFactor } = await import('./enrollment');
+		await db
+			.insert(schema.users)
+			.values({ id: 'u1', username: 'u1', displayName: 'U1', role: 'member' });
+
+		// Pin time so confirm and the replay-guard step are deterministic
+		const baseTs = Date.now();
+		vi.useFakeTimers();
+		vi.setSystemTime(baseTs);
+
+		const { manualKey } = await beginEnrollment('u1', 'u1');
+
+		const codes = await confirmEnrollment('u1', codeFor(manualKey, baseTs));
+		expect(codes).toHaveLength(10);
+
+		let row = await db.query.users.findFirst({ where: eq(schema.users.id, 'u1') });
+		expect(row?.totpEnabledAt).toBeTruthy();
+
+		// Advance 60 s so disableTwoFactor's internal Date.now() lands on a later
+		// step than the one stored as totpLastStep — avoiding the replay guard.
+		vi.setSystemTime(baseTs + 60_000);
+		const okDisable = await disableTwoFactor('u1', codeFor(manualKey, baseTs + 60_000));
+		expect(okDisable).toBe(true);
+
+		row = await db.query.users.findFirst({ where: eq(schema.users.id, 'u1') });
+		expect(row?.totpSecret).toBeNull();
+	});
+});

--- a/src/lib/server/auth/enrollment.ts
+++ b/src/lib/server/auth/enrollment.ts
@@ -1,0 +1,84 @@
+import { db, schema } from '$lib/server/db';
+import { eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import {
+	generateSecret,
+	provisioningUri,
+	verifyCode,
+	generateBackupCodes,
+	hashBackupCode
+} from './totp';
+import { encryptSecret, decryptSecret } from './totp-crypto';
+import QRCode from 'qrcode';
+
+/** Begin: store a pending (encrypted) secret, return QR + manual key. */
+export async function beginEnrollment(userId: string, accountName: string) {
+	const secret = generateSecret();
+	await db
+		.update(schema.users)
+		.set({ totpSecret: encryptSecret(secret), totpEnabledAt: null, totpLastStep: null })
+		.where(eq(schema.users.id, userId));
+	const uri = provisioningUri(secret, accountName);
+	const qr = await QRCode.toDataURL(uri, { margin: 1, width: 220 });
+	return { manualKey: secret, qr };
+}
+
+/** Confirm: verify a code against the pending secret, enable, return backup codes (once). */
+export async function confirmEnrollment(userId: string, code: string): Promise<string[] | null> {
+	const user = await db.query.users.findFirst({ where: eq(schema.users.id, userId) });
+	if (!user?.totpSecret) return null;
+	const res = verifyCode(decryptSecret(user.totpSecret), code);
+	if (!res.valid) return null;
+	const codes = generateBackupCodes();
+	await db.transaction((tx) => {
+		tx.update(schema.users)
+			.set({ totpEnabledAt: new Date(), totpLastStep: res.step })
+			.where(eq(schema.users.id, userId))
+			.run();
+		tx.delete(schema.totpBackupCodes).where(eq(schema.totpBackupCodes.userId, userId)).run();
+		tx.insert(schema.totpBackupCodes)
+			.values(codes.map((c) => ({ id: randomUUID(), userId, codeHash: hashBackupCode(c) })))
+			.run();
+	});
+	return codes;
+}
+
+export async function regenerateBackupCodes(userId: string): Promise<string[]> {
+	const codes = generateBackupCodes();
+	await db.transaction((tx) => {
+		tx.delete(schema.totpBackupCodes).where(eq(schema.totpBackupCodes.userId, userId)).run();
+		tx.insert(schema.totpBackupCodes)
+			.values(codes.map((c) => ({ id: randomUUID(), userId, codeHash: hashBackupCode(c) })))
+			.run();
+	});
+	return codes;
+}
+
+/** Disable: verify a fresh code first (caller enforces enforcement policy). */
+export async function disableTwoFactor(userId: string, code: string): Promise<boolean> {
+	const user = await db.query.users.findFirst({ where: eq(schema.users.id, userId) });
+	if (!user?.totpSecret) return false;
+	const res = verifyCode(decryptSecret(user.totpSecret), code, {
+		lastStep: user.totpLastStep ?? undefined
+	});
+	if (!res.valid) return false;
+	await db.transaction((tx) => {
+		tx.update(schema.users)
+			.set({ totpSecret: null, totpEnabledAt: null, totpLastStep: null })
+			.where(eq(schema.users.id, userId))
+			.run();
+		tx.delete(schema.totpBackupCodes).where(eq(schema.totpBackupCodes.userId, userId)).run();
+	});
+	return true;
+}
+
+/** Admin reset: no code required (escape hatch). */
+export async function adminResetTwoFactor(userId: string): Promise<void> {
+	await db.transaction((tx) => {
+		tx.update(schema.users)
+			.set({ totpSecret: null, totpEnabledAt: null, totpLastStep: null })
+			.where(eq(schema.users.id, userId))
+			.run();
+		tx.delete(schema.totpBackupCodes).where(eq(schema.totpBackupCodes.userId, userId)).run();
+	});
+}

--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -54,7 +54,9 @@ export async function validateAuth(event: RequestEvent, { refreshCookie = true }
 			notifyReminderEmail: user.notifyReminderEmail ?? false,
 			notifyShiftEmail: user.notifyShiftEmail ?? false,
 			ntfyTopic: user.ntfyTopic ?? null,
-			avatarPath: user.avatarPath ?? null
+			avatarPath: user.avatarPath ?? null,
+			totpEnabled: user.totpEnabledAt != null,
+			isOidc: user.oidcSubject != null
 		}
 	};
 }

--- a/src/lib/server/auth/rate-limit.ts
+++ b/src/lib/server/auth/rate-limit.ts
@@ -1,0 +1,30 @@
+// In-process only; resets on restart. Good enough for brute-force slowdown.
+// Does not coordinate across multiple processes — intentional for single-instance deployments.
+const buckets = new Map<string, { count: number; resetAt: number }>();
+
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+let lastCleanup = Date.now();
+
+export function checkRateLimit(key: string, limit = 5, windowMs = 15 * 60 * 1000): boolean {
+	const now = Date.now();
+
+	if (now - lastCleanup > CLEANUP_INTERVAL_MS) {
+		for (const [k, val] of buckets) {
+			if (now > val.resetAt) buckets.delete(k);
+		}
+		lastCleanup = now;
+	}
+
+	const b = buckets.get(key);
+	if (!b || now > b.resetAt) {
+		buckets.set(key, { count: 1, resetAt: now + windowMs });
+		return true;
+	}
+	if (b.count >= limit) return false;
+	b.count++;
+	return true;
+}
+
+export function clearRateLimit(key: string): void {
+	buckets.delete(key);
+}

--- a/src/lib/server/auth/totp-crypto.test.ts
+++ b/src/lib/server/auth/totp-crypto.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: new Proxy({} as Record<string, string | undefined>, {
+		get: (_t, key: string) => process.env[key]
+	})
+}));
+
+beforeAll(() => {
+	process.env.TWOFA_ENC_KEY = Buffer.from(new Uint8Array(32).fill(7)).toString('base64');
+});
+
+describe('totp-crypto', () => {
+	it('round-trips a secret', async () => {
+		const { encryptSecret, decryptSecret } = await import('./totp-crypto');
+		const plain = 'JBSWY3DPEHPK3PXP';
+		const stored = encryptSecret(plain);
+		expect(stored).not.toContain(plain);
+		expect(decryptSecret(stored)).toBe(plain);
+	});
+
+	it('rejects tampered ciphertext', async () => {
+		const { encryptSecret, decryptSecret } = await import('./totp-crypto');
+		const stored = encryptSecret('JBSWY3DPEHPK3PXP');
+		const [iv, ct, tag] = stored.split(':');
+		const flipped = `${iv}:${ct.slice(0, -2)}aa:${tag}`;
+		expect(() => decryptSecret(flipped)).toThrow();
+	});
+
+	it('throws a clear error when the key is missing', async () => {
+		delete process.env.TWOFA_ENC_KEY;
+		const mod = await import('./totp-crypto');
+		expect(() => mod.encryptSecret('x')).toThrow(/TWOFA_ENC_KEY/);
+		process.env.TWOFA_ENC_KEY = Buffer.from(new Uint8Array(32).fill(7)).toString('base64');
+	});
+});

--- a/src/lib/server/auth/totp-crypto.ts
+++ b/src/lib/server/auth/totp-crypto.ts
@@ -1,0 +1,34 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { env } from '$env/dynamic/private';
+
+function key(): Buffer {
+	const raw = env.TWOFA_ENC_KEY;
+	if (!raw) throw new Error('TWOFA_ENC_KEY is not set; 2FA secret encryption is unavailable.');
+	const buf = Buffer.from(raw, 'base64');
+	if (buf.length !== 32) throw new Error('TWOFA_ENC_KEY must be 32 bytes (base64-encoded).');
+	return buf;
+}
+
+/** Returns "iv:ciphertext:authTag", each base64. */
+export function encryptSecret(plain: string): string {
+	const iv = randomBytes(12);
+	const cipher = createCipheriv('aes-256-gcm', key(), iv);
+	const ct = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+	const tag = cipher.getAuthTag();
+	return `${iv.toString('base64')}:${ct.toString('base64')}:${tag.toString('base64')}`;
+}
+
+export function decryptSecret(stored: string): string {
+	const [ivB64, ctB64, tagB64] = stored.split(':');
+	if (!ivB64 || !ctB64 || !tagB64) throw new Error('Malformed encrypted TOTP secret.');
+	const decipher = createDecipheriv('aes-256-gcm', key(), Buffer.from(ivB64, 'base64'));
+	decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+	return Buffer.concat([decipher.update(Buffer.from(ctB64, 'base64')), decipher.final()]).toString(
+		'utf8'
+	);
+}
+
+export function isTwoFactorConfigured(): boolean {
+	const raw = env.TWOFA_ENC_KEY;
+	return !!raw && Buffer.from(raw, 'base64').length === 32;
+}

--- a/src/lib/server/auth/totp.test.ts
+++ b/src/lib/server/auth/totp.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { TOTP, Secret } from 'otpauth';
+import {
+	generateSecret,
+	provisioningUri,
+	verifyCode,
+	generateBackupCodes,
+	hashBackupCode,
+	normalizeBackupCode
+} from './totp';
+
+function codeFor(secret: string, timestamp: number): string {
+	return new TOTP({ secret: Secret.fromBase32(secret), digits: 6, period: 30 }).generate({
+		timestamp
+	});
+}
+
+describe('totp', () => {
+	it('generates a Base32 secret and a provisioning URI', () => {
+		const s = generateSecret();
+		expect(s).toMatch(/^[A-Z2-7]+$/);
+		expect(provisioningUri(s, 'jet')).toMatch(/^otpauth:\/\/totp\/EinVault:jet\?/);
+	});
+
+	it('verifies a current code and rejects a wrong one', () => {
+		const s = generateSecret();
+		const now = 1_700_000_000_000;
+		const ok = verifyCode(s, codeFor(s, now), { at: now });
+		expect(ok.valid).toBe(true);
+		expect(typeof ok.step).toBe('number');
+		expect(verifyCode(s, '000000', { at: now }).valid).toBe(false);
+	});
+
+	it('tolerates one step of drift but not two', () => {
+		const s = generateSecret();
+		const now = 1_700_000_000_000;
+		expect(verifyCode(s, codeFor(s, now - 30_000), { at: now }).valid).toBe(true);
+		expect(verifyCode(s, codeFor(s, now - 90_000), { at: now }).valid).toBe(false);
+	});
+
+	it('rejects a step at or below lastStep (replay guard)', () => {
+		const s = generateSecret();
+		const now = 1_700_000_000_000;
+		const first = verifyCode(s, codeFor(s, now), { at: now });
+		expect(first.valid).toBe(true);
+		const replay = verifyCode(s, codeFor(s, now), { at: now, lastStep: first.step });
+		expect(replay.valid).toBe(false);
+	});
+
+	it('generates 10 unique backup codes that hash and normalize stably', () => {
+		const codes = generateBackupCodes();
+		expect(codes).toHaveLength(10);
+		expect(new Set(codes).size).toBe(10);
+		expect(codes[0]).toMatch(/^[a-z0-9]{5}-[a-z0-9]{5}$/);
+		expect(hashBackupCode(codes[0])).toBe(
+			hashBackupCode(normalizeBackupCode(codes[0].toUpperCase()))
+		);
+	});
+});

--- a/src/lib/server/auth/totp.ts
+++ b/src/lib/server/auth/totp.ts
@@ -1,0 +1,69 @@
+import { TOTP, Secret } from 'otpauth';
+import { createHash, randomBytes } from 'node:crypto';
+
+const ISSUER = 'EinVault';
+const PERIOD = 30;
+const DIGITS = 6;
+
+export function generateSecret(): string {
+	return new Secret({ size: 20 }).base32;
+}
+
+export function provisioningUri(secret: string, accountName: string): string {
+	return new TOTP({
+		issuer: ISSUER,
+		label: accountName,
+		secret: Secret.fromBase32(secret),
+		digits: DIGITS,
+		period: PERIOD
+	}).toString();
+}
+
+export interface VerifyResult {
+	valid: boolean;
+	/** The matched time step (counter), for the replay guard. -1 when invalid. */
+	step: number;
+}
+
+/**
+ * Verify a 6-digit code with one step of drift tolerance. When `lastStep` is
+ * given, a matched step <= lastStep is treated as a replay and rejected.
+ */
+export function verifyCode(
+	secret: string,
+	code: string,
+	opts: { at?: number; lastStep?: number } = {}
+): VerifyResult {
+	const at = opts.at ?? Date.now();
+	const totp = new TOTP({
+		secret: Secret.fromBase32(secret),
+		digits: DIGITS,
+		period: PERIOD
+	});
+	const delta = totp.validate({ token: code.replace(/\s/g, ''), window: 1, timestamp: at });
+	if (delta === null) return { valid: false, step: -1 };
+	const step = Math.floor(at / 1000 / PERIOD) + delta;
+	if (opts.lastStep !== undefined && step <= opts.lastStep) return { valid: false, step: -1 };
+	return { valid: true, step };
+}
+
+// --- Backup codes ---
+
+const ALPHABET = 'abcdefghjkmnpqrstuvwxyz23456789'; // no ambiguous chars
+
+export function generateBackupCodes(n = 10): string[] {
+	const codes = new Set<string>();
+	while (codes.size < n) {
+		const raw = Array.from(randomBytes(10), (b) => ALPHABET[b % ALPHABET.length]).join('');
+		codes.add(`${raw.slice(0, 5)}-${raw.slice(5, 10)}`);
+	}
+	return [...codes];
+}
+
+export function normalizeBackupCode(code: string): string {
+	return code.trim().toLowerCase().replace(/\s/g, '');
+}
+
+export function hashBackupCode(code: string): string {
+	return createHash('sha256').update(normalizeBackupCode(code)).digest('hex');
+}

--- a/src/lib/server/auth/two-factor-actions.ts
+++ b/src/lib/server/auth/two-factor-actions.ts
@@ -1,7 +1,8 @@
 import { fail } from '@sveltejs/kit';
 import type { Locale } from '$lib/i18n';
 import { t } from '$lib/i18n';
-import { isTwoFactorConfigured } from './totp-crypto';
+import { isTwoFactorConfigured, decryptSecret } from './totp-crypto';
+import { verifyCode } from './totp';
 import {
 	beginEnrollment,
 	confirmEnrollment,
@@ -10,6 +11,8 @@ import {
 } from './enrollment';
 import { getAppSettings } from '$lib/server/app-settings';
 import { requiresTwoFactor } from './two-factor';
+import { db, schema } from '$lib/server/db';
+import { eq } from 'drizzle-orm';
 
 interface TwoFactorActionContext {
 	user: {
@@ -17,6 +20,7 @@ interface TwoFactorActionContext {
 		username: string;
 		role: 'admin' | 'member' | 'caretaker';
 		isOidc: boolean;
+		totpEnabled: boolean;
 	};
 	request: Request;
 	locale: Locale;
@@ -25,6 +29,9 @@ interface TwoFactorActionContext {
 export async function totpBegin({ user, locale }: TwoFactorActionContext) {
 	if (!isTwoFactorConfigured()) {
 		return fail(400, { totpError: t(locale, 'page.settings.twofaUnavailable') });
+	}
+	if (user.totpEnabled) {
+		return fail(400, { totpError: t(locale, 'page.settings.reenrollNote') });
 	}
 	const { qr, manualKey } = await beginEnrollment(user.id, user.username);
 	return { totpQr: qr, totpManualKey: manualKey };
@@ -40,7 +47,19 @@ export async function totpConfirm({ user, request, locale }: TwoFactorActionCont
 	return { totpBackupCodes: codes, totpSuccess: true };
 }
 
-export async function totpRegenerate({ user }: TwoFactorActionContext) {
+export async function totpRegenerate({ user, request, locale }: TwoFactorActionContext) {
+	const data = await request.formData();
+	const code = String(data.get('code') ?? '');
+	const row = await db.query.users.findFirst({ where: eq(schema.users.id, user.id) });
+	if (!row?.totpSecret) {
+		return fail(400, { totpError: t(locale, 'page.twofa.invalidCode') });
+	}
+	const result = verifyCode(decryptSecret(row.totpSecret), code, {
+		lastStep: row.totpLastStep ?? undefined
+	});
+	if (!result.valid) {
+		return fail(400, { totpError: t(locale, 'page.twofa.invalidCode') });
+	}
 	const codes = await regenerateBackupCodes(user.id);
 	return { totpBackupCodes: codes };
 }

--- a/src/lib/server/auth/two-factor-actions.ts
+++ b/src/lib/server/auth/two-factor-actions.ts
@@ -1,0 +1,60 @@
+import { fail } from '@sveltejs/kit';
+import type { Locale } from '$lib/i18n';
+import { t } from '$lib/i18n';
+import { isTwoFactorConfigured } from './totp-crypto';
+import {
+	beginEnrollment,
+	confirmEnrollment,
+	regenerateBackupCodes,
+	disableTwoFactor
+} from './enrollment';
+import { getAppSettings } from '$lib/server/app-settings';
+import { requiresTwoFactor } from './two-factor';
+
+interface TwoFactorActionContext {
+	user: {
+		id: string;
+		username: string;
+		role: 'admin' | 'member' | 'caretaker';
+		isOidc: boolean;
+	};
+	request: Request;
+	locale: Locale;
+}
+
+export async function totpBegin({ user, locale }: TwoFactorActionContext) {
+	if (!isTwoFactorConfigured()) {
+		return fail(400, { totpError: t(locale, 'page.settings.twofaUnavailable') });
+	}
+	const { qr, manualKey } = await beginEnrollment(user.id, user.username);
+	return { totpQr: qr, totpManualKey: manualKey };
+}
+
+export async function totpConfirm({ user, request, locale }: TwoFactorActionContext) {
+	const data = await request.formData();
+	const code = String(data.get('code') ?? '');
+	const codes = await confirmEnrollment(user.id, code);
+	if (codes === null) {
+		return fail(400, { totpError: t(locale, 'page.twofa.invalidCode') });
+	}
+	return { totpBackupCodes: codes, totpSuccess: true };
+}
+
+export async function totpRegenerate({ user }: TwoFactorActionContext) {
+	const codes = await regenerateBackupCodes(user.id);
+	return { totpBackupCodes: codes };
+}
+
+export async function totpDisable({ user, request, locale }: TwoFactorActionContext) {
+	const { require2fa } = await getAppSettings();
+	if (requiresTwoFactor({ role: user.role, isOidc: user.isOidc, totpEnabled: false }, require2fa)) {
+		return fail(400, { totpError: t(locale, 'page.twofa.cannotDisableEnforced') });
+	}
+	const data = await request.formData();
+	const code = String(data.get('code') ?? '');
+	const ok = await disableTwoFactor(user.id, code);
+	if (!ok) {
+		return fail(400, { totpError: t(locale, 'page.twofa.invalidCode') });
+	}
+	return { totpSuccess: true };
+}

--- a/src/lib/server/auth/two-factor.test.ts
+++ b/src/lib/server/auth/two-factor.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { requiresTwoFactor } from './two-factor';
+
+const base = { role: 'member' as const, isOidc: false, totpEnabled: false };
+
+describe('requiresTwoFactor', () => {
+	it('off requires nobody', () => {
+		expect(requiresTwoFactor(base, 'off')).toBe(false);
+	});
+	it('admins requires admins only', () => {
+		expect(requiresTwoFactor({ ...base, role: 'admin' }, 'admins')).toBe(true);
+		expect(requiresTwoFactor({ ...base, role: 'member' }, 'admins')).toBe(false);
+	});
+	it('everyone requires all password users', () => {
+		expect(requiresTwoFactor({ ...base, role: 'caretaker' }, 'everyone')).toBe(true);
+	});
+	it('exempts oidc users', () => {
+		expect(requiresTwoFactor({ ...base, role: 'admin', isOidc: true }, 'everyone')).toBe(false);
+	});
+	it('returns false once enrolled', () => {
+		expect(requiresTwoFactor({ ...base, totpEnabled: true }, 'everyone')).toBe(false);
+	});
+});

--- a/src/lib/server/auth/two-factor.ts
+++ b/src/lib/server/auth/two-factor.ts
@@ -1,0 +1,105 @@
+import type { Cookies } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import type { Require2fa } from '$lib/server/app-settings';
+
+export function requiresTwoFactor(
+	user: { role: 'admin' | 'member' | 'caretaker'; isOidc: boolean; totpEnabled: boolean },
+	require2fa: Require2fa
+): boolean {
+	if (require2fa === 'off') return false;
+	if (user.isOidc) return false;
+	if (user.totpEnabled) return false;
+	if (require2fa === 'admins') return user.role === 'admin';
+	return true; // 'everyone'
+}
+
+// --- Pending-MFA signed cookie (HMAC, mirrors oidc-state.ts) ---
+
+const COOKIE_NAME = 'einvault_mfa_pending';
+const TTL_MS = 5 * 60 * 1000;
+
+function b64url(bytes: Uint8Array): string {
+	return btoa(String.fromCharCode(...bytes))
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '');
+}
+function b64urlDecode(s: string): Uint8Array {
+	const bin = atob(s.replace(/-/g, '+').replace(/_/g, '/'));
+	return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+}
+
+let _key: Promise<CryptoKey> | null = null;
+function getKey(): Promise<CryptoKey> {
+	if (_key) return _key;
+	_key = (async () => {
+		const secret = env.OIDC_STATE_SECRET; // reuse the existing app HMAC secret
+		if (!secret && process.env.NODE_ENV === 'production') {
+			throw new Error('[2fa] OIDC_STATE_SECRET is required in production for the MFA cookie.');
+		}
+		const material = secret
+			? await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret))
+			: crypto.getRandomValues(new Uint8Array(32));
+		return crypto.subtle.importKey('raw', material, { name: 'HMAC', hash: 'SHA-256' }, false, [
+			'sign',
+			'verify'
+		]);
+	})();
+	return _key;
+}
+
+export async function setPendingMfaCookie(
+	cookies: Cookies,
+	userId: string,
+	secure: boolean
+): Promise<void> {
+	const payload = b64url(
+		new TextEncoder().encode(JSON.stringify({ userId, exp: Date.now() + TTL_MS }))
+	);
+	const sigBuf = await crypto.subtle.sign(
+		'HMAC',
+		await getKey(),
+		new TextEncoder().encode(payload)
+	);
+	cookies.set(COOKIE_NAME, `${payload}.${b64url(new Uint8Array(sigBuf))}`, {
+		path: '/auth/2fa',
+		httpOnly: true,
+		sameSite: 'strict',
+		secure,
+		maxAge: TTL_MS / 1000
+	});
+}
+
+export function clearPendingMfaCookie(cookies: Cookies, secure: boolean): void {
+	cookies.set(COOKIE_NAME, '', {
+		path: '/auth/2fa',
+		httpOnly: true,
+		sameSite: 'strict',
+		secure,
+		maxAge: 0
+	});
+}
+
+export async function readPendingMfaCookie(cookies: Cookies): Promise<{ userId: string } | null> {
+	const raw = cookies.get(COOKIE_NAME);
+	if (!raw) return null;
+	const dot = raw.lastIndexOf('.');
+	if (dot === -1) return null;
+	const payload = raw.slice(0, dot);
+	const sig = raw.slice(dot + 1);
+	const sigBytes = b64urlDecode(sig);
+	const ok = await crypto.subtle.verify(
+		'HMAC',
+		await getKey(),
+		sigBytes.buffer as ArrayBuffer,
+		new TextEncoder().encode(payload)
+	);
+	if (!ok) return null;
+	try {
+		const { userId, exp } = JSON.parse(new TextDecoder().decode(b64urlDecode(payload)));
+		if (typeof userId !== 'string' || typeof exp !== 'number' || Date.now() > exp) return null;
+		return { userId };
+	} catch {
+		return null;
+	}
+}

--- a/src/lib/server/auth/two-factor.ts
+++ b/src/lib/server/auth/two-factor.ts
@@ -33,13 +33,19 @@ let _key: Promise<CryptoKey> | null = null;
 function getKey(): Promise<CryptoKey> {
 	if (_key) return _key;
 	_key = (async () => {
-		const secret = env.OIDC_STATE_SECRET; // reuse the existing app HMAC secret
-		if (!secret && process.env.NODE_ENV === 'production') {
-			throw new Error('[2fa] OIDC_STATE_SECRET is required in production for the MFA cookie.');
+		// Sign the MFA challenge cookie with a key derived from TWOFA_ENC_KEY, which
+		// is always set when 2FA is in use. Independent of OIDC. The label gives
+		// domain separation from the AES-GCM secret-encryption use of the same key.
+		const raw = env.TWOFA_ENC_KEY;
+		if (!raw) {
+			throw new Error('[2fa] TWOFA_ENC_KEY is required for the MFA challenge cookie.');
 		}
-		const material = secret
-			? await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret))
-			: crypto.getRandomValues(new Uint8Array(32));
+		const keyBytes = Buffer.from(raw, 'base64');
+		const labeled = new Uint8Array([
+			...keyBytes,
+			...new TextEncoder().encode('einvault-mfa-cookie-v1')
+		]);
+		const material = await crypto.subtle.digest('SHA-256', labeled);
 		return crypto.subtle.importKey('raw', material, { name: 'HMAC', hash: 'SHA-256' }, false, [
 			'sign',
 			'verify'

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -53,7 +53,11 @@ export const users = sqliteTable(
 		// Profile photo — mirrors the companion avatar columns.
 		avatarPath: text('avatar_path'),
 		avatarProvider: text('avatar_provider'),
-		avatarStorageKey: text('avatar_storage_key')
+		avatarStorageKey: text('avatar_storage_key'),
+		// --- 2FA (TOTP) ---
+		totpSecret: text('totp_secret'),
+		totpEnabledAt: integer('totp_enabled_at', { mode: 'timestamp' }),
+		totpLastStep: integer('totp_last_step')
 	},
 	(t) => [
 		uniqueIndex('users_oidc_idx').on(t.oidcIssuer, t.oidcSubject),
@@ -61,6 +65,27 @@ export const users = sqliteTable(
 		uniqueIndex('users_calendar_feed_token_idx').on(t.calendarFeedToken)
 	]
 );
+
+export const totpBackupCodes = sqliteTable('totp_backup_codes', {
+	id: text('id').primaryKey(),
+	userId: text('user_id')
+		.notNull()
+		.references(() => users.id, { onDelete: 'cascade' }),
+	codeHash: text('code_hash').notNull(),
+	usedAt: integer('used_at', { mode: 'timestamp' }),
+	createdAt: integer('created_at', { mode: 'timestamp' })
+		.notNull()
+		.default(sql`(unixepoch())`)
+});
+
+export const appSettings = sqliteTable('app_settings', {
+	id: text('id').primaryKey().default('singleton'),
+	require2fa: text('require_2fa', { enum: ['off', 'admins', 'everyone'] })
+		.notNull()
+		.default('off'),
+	updatedAt: integer('updated_at', { mode: 'timestamp' }),
+	updatedBy: text('updated_by').references(() => users.id, { onDelete: 'set null' })
+});
 
 export const sessions = sqliteTable(
 	'sessions',
@@ -449,6 +474,8 @@ export const caretakerShifts = sqliteTable(
 // type exports
 
 export type User = typeof users.$inferSelect;
+export type TotpBackupCode = typeof totpBackupCodes.$inferSelect;
+export type AppSettings = typeof appSettings.$inferSelect;
 export type Session = typeof sessions.$inferSelect;
 export type PasswordResetToken = typeof passwordResetTokens.$inferSelect;
 export type NotificationOutboxRow = typeof notificationOutbox.$inferSelect;
@@ -481,6 +508,7 @@ export const usersRelations = relations(users, ({ many }) => ({
 	sessions: many(sessions),
 	passwordResetTokens: many(passwordResetTokens),
 	notificationOutbox: many(notificationOutbox),
+	totpBackupCodes: many(totpBackupCodes),
 	companionCaretakers: many(companionCaretakers),
 	shifts: many(caretakerShifts),
 	loggedJournalEntries: many(journalEntries, { relationName: 'journalLogger' }),
@@ -491,6 +519,10 @@ export const usersRelations = relations(users, ({ many }) => ({
 	loggedWeightEntries: many(weightEntries),
 	loggedReminders: many(reminders, { relationName: 'reminderLogger' }),
 	completedReminders: many(reminders, { relationName: 'reminderCompleter' })
+}));
+
+export const totpBackupCodesRelations = relations(totpBackupCodes, ({ one }) => ({
+	user: one(users, { fields: [totpBackupCodes.userId], references: [users.id] })
 }));
 
 export const companionCaretakersRelations = relations(companionCaretakers, ({ one }) => ({

--- a/src/lib/server/env.ts
+++ b/src/lib/server/env.ts
@@ -368,6 +368,16 @@ function readSmtpConfig(): { config: SmtpConfig | null; missing: string[] } {
 const smtpResult = readSmtpConfig();
 export const SMTP_CONFIG = smtpResult.config;
 
+export function logTwoFactorBootStatus(): void {
+	import('$lib/server/auth/totp-crypto').then(({ isTwoFactorConfigured }) => {
+		console.info(
+			isTwoFactorConfigured()
+				? '[einvault] 2FA available (TWOFA_ENC_KEY set)'
+				: '[einvault] 2FA unavailable: set TWOFA_ENC_KEY to enable two-factor authentication'
+		);
+	});
+}
+
 export function logSmtpBootStatus(): void {
 	if (smtpResult.missing.length > 0 && smtpResult.missing.length < SMTP_REQUIRED_VARS.length) {
 		console.warn(

--- a/src/routes/(app)/(admin)/admin/users/+page.server.ts
+++ b/src/routes/(app)/(admin)/admin/users/+page.server.ts
@@ -7,17 +7,26 @@ import { generateId } from '$lib/server/utils';
 import bcrypt from 'bcryptjs';
 import { invalidateAllUserSessions } from '$lib/server/auth/session';
 import { parseRole, EMAIL_RE } from '$lib/server/validation';
+import { getAppSettings, setRequire2fa } from '$lib/server/app-settings';
+import type { Require2fa } from '$lib/server/app-settings';
+import { adminResetTwoFactor } from '$lib/server/auth/enrollment';
+import { isTwoFactorConfigured } from '$lib/server/auth/totp-crypto';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
 	if (locals.user.role !== 'admin') error(403, t(locals.locale, 'error.forbidden'));
 
-	const users = await db.query.users.findMany({
+	const rawUsers = await db.query.users.findMany({
 		orderBy: (u, { asc }) => [asc(u.createdAt)],
 		columns: {
 			passwordHash: false
 		}
 	});
+
+	const users = rawUsers.map((u) => ({
+		...u,
+		totpEnabled: u.totpEnabledAt != null
+	}));
 
 	const companions = await db.query.companions.findMany({
 		where: eq(schema.companions.isActive, true),
@@ -30,7 +39,18 @@ export const load: PageServerLoad = async ({ locals }) => {
 		orderBy: (s, { asc }) => [asc(s.startAt)]
 	});
 
-	return { users, companions, assignments, shifts, currentUserId: locals.user.id };
+	const { require2fa } = await getAppSettings();
+	const twoFactorAvailable = isTwoFactorConfigured();
+
+	return {
+		users,
+		companions,
+		assignments,
+		shifts,
+		currentUserId: locals.user.id,
+		require2fa,
+		twoFactorAvailable
+	};
 };
 
 export const actions: Actions = {
@@ -285,6 +305,32 @@ export const actions: Actions = {
 		}
 
 		return { editSuccess: true };
+	},
+
+	setRequire2fa: async ({ request, locals }) => {
+		if (locals.user?.role !== 'admin') error(403, t(locals.locale, 'error.forbidden'));
+
+		const data = await request.formData();
+		const value = String(data.get('value') ?? '');
+
+		if (value !== 'off' && value !== 'admins' && value !== 'everyone') {
+			return fail(400, { require2faError: 'Invalid value.' });
+		}
+
+		await setRequire2fa(value as Require2fa, locals.user.id);
+		return { require2faSuccess: true };
+	},
+
+	resetTwoFactor: async ({ request, locals }) => {
+		if (locals.user?.role !== 'admin') error(403, t(locals.locale, 'error.forbidden'));
+
+		const data = await request.formData();
+		const userId = String(data.get('userId') ?? '');
+
+		if (!userId) return fail(400, { twofaResetError: t(locals.locale, 'error.missingUserId') });
+
+		await adminResetTwoFactor(userId);
+		return { twofaResetSuccess: true };
 	},
 
 	assignCompanions: async ({ request, locals }) => {

--- a/src/routes/(app)/(admin)/admin/users/+page.svelte
+++ b/src/routes/(app)/(admin)/admin/users/+page.svelte
@@ -151,7 +151,7 @@
 					</Select>
 					<p class="text-xs text-muted-foreground">
 						{#if !data.twoFactorAvailable}
-							Set <code class="font-mono">TWOFA_ENC_KEY</code> to enable two-factor enforcement.
+							{t(locale, 'page.admin.require2faNoKey')}
 						{:else}
 							{t(locale, 'page.admin.require2faHelp')}
 						{/if}

--- a/src/routes/(app)/(admin)/admin/users/+page.svelte
+++ b/src/routes/(app)/(admin)/admin/users/+page.svelte
@@ -9,7 +9,7 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Select } from '$lib/components/ui/select/index.js';
-	import { Plus, Users } from '@lucide/svelte';
+	import { Plus, Users, ShieldCheck } from '@lucide/svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import UserManageDrawer from '$lib/components/admin/UserManageDrawer.svelte';
 	import { t, getLocale } from '$lib/i18n';
@@ -116,6 +116,50 @@
 			</CardContent>
 		</Card>
 	{/if}
+
+	<!-- Security section -->
+	<PageHeader title={t(locale, 'page.admin.securitySection')} tint="primary">
+		{#snippet icon()}<ShieldCheck class="h-5 w-5" />{/snippet}
+	</PageHeader>
+
+	{#if form?.require2faSuccess}
+		<Alert variant="success" class="-mt-2">
+			<AlertDescription>{t(locale, 'common.saved')}</AlertDescription>
+		</Alert>
+	{/if}
+
+	<Card>
+		<CardContent class="pt-5">
+			<form method="POST" action="?/setRequire2fa" use:enhance class="space-y-3">
+				<div class="space-y-1.5">
+					<Label for="require2fa">{t(locale, 'page.admin.require2faLabel')}</Label>
+					<Select
+						id="require2fa"
+						name="value"
+						disabled={!data.twoFactorAvailable}
+						onchange={(e) => (e.currentTarget as HTMLSelectElement).form?.requestSubmit()}
+					>
+						<option value="off" selected={data.require2fa === 'off'}
+							>{t(locale, 'page.admin.require2faOff')}</option
+						>
+						<option value="admins" selected={data.require2fa === 'admins'}
+							>{t(locale, 'page.admin.require2faAdmins')}</option
+						>
+						<option value="everyone" selected={data.require2fa === 'everyone'}
+							>{t(locale, 'page.admin.require2faEveryone')}</option
+						>
+					</Select>
+					<p class="text-xs text-muted-foreground">
+						{#if !data.twoFactorAvailable}
+							Set <code class="font-mono">TWOFA_ENC_KEY</code> to enable two-factor enforcement.
+						{:else}
+							{t(locale, 'page.admin.require2faHelp')}
+						{/if}
+					</p>
+				</div>
+			</form>
+		</CardContent>
+	</Card>
 
 	<!-- User list -->
 	<Card class="divide-y divide-border">

--- a/src/routes/(app)/(admin)/admin/users/+page.svelte
+++ b/src/routes/(app)/(admin)/admin/users/+page.svelte
@@ -9,7 +9,7 @@
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 	import { Select } from '$lib/components/ui/select/index.js';
-	import { Plus, Users, ShieldCheck } from '@lucide/svelte';
+	import { Plus, Users } from '@lucide/svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import UserManageDrawer from '$lib/components/admin/UserManageDrawer.svelte';
 	import { t, getLocale } from '$lib/i18n';
@@ -118,18 +118,17 @@
 	{/if}
 
 	<!-- Security section -->
-	<PageHeader title={t(locale, 'page.admin.securitySection')} tint="primary">
-		{#snippet icon()}<ShieldCheck class="h-5 w-5" />{/snippet}
-	</PageHeader>
-
 	{#if form?.require2faSuccess}
-		<Alert variant="success" class="-mt-2">
+		<Alert variant="success">
 			<AlertDescription>{t(locale, 'common.saved')}</AlertDescription>
 		</Alert>
 	{/if}
 
 	<Card>
-		<CardContent class="pt-5">
+		<CardHeader>
+			<CardTitle>{t(locale, 'page.admin.securitySection')}</CardTitle>
+		</CardHeader>
+		<CardContent class="pt-0">
 			<form method="POST" action="?/setRequire2fa" use:enhance class="space-y-3">
 				<div class="space-y-1.5">
 					<Label for="require2fa">{t(locale, 'page.admin.require2faLabel')}</Label>

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -15,18 +15,6 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		redirect(302, '/care');
 	}
 
-	const { getAppSettings } = await import('$lib/server/app-settings');
-	const { requiresTwoFactor } = await import('$lib/server/auth/two-factor');
-	const { require2fa } = await getAppSettings();
-	if (
-		requiresTwoFactor(
-			{ role: locals.user.role, isOidc: locals.user.isOidc, totpEnabled: locals.user.totpEnabled },
-			require2fa
-		)
-	) {
-		redirect(302, '/2fa-setup');
-	}
-
 	const [companions, archivedCompanions] = await Promise.all([
 		db.query.companions.findMany({
 			where: eq(schema.companions.isActive, true),

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -15,6 +15,18 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		redirect(302, '/care');
 	}
 
+	const { getAppSettings } = await import('$lib/server/app-settings');
+	const { requiresTwoFactor } = await import('$lib/server/auth/two-factor');
+	const { require2fa } = await getAppSettings();
+	if (
+		requiresTwoFactor(
+			{ role: locals.user.role, isOidc: locals.user.isOidc, totpEnabled: locals.user.totpEnabled },
+			require2fa
+		)
+	) {
+		redirect(302, '/2fa-setup');
+	}
+
 	const [companions, archivedCompanions] = await Promise.all([
 		db.query.companions.findMany({
 			where: eq(schema.companions.isActive, true),

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -45,6 +45,16 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 	const calUser = await db.query.users.findFirst({ where: eq(schema.users.id, locals.user.id) });
 
+	const { isTwoFactorConfigured } = await import('$lib/server/auth/totp-crypto');
+	const { getAppSettings } = await import('$lib/server/app-settings');
+	const { requiresTwoFactor } = await import('$lib/server/auth/two-factor');
+	const { require2fa } = await getAppSettings();
+	const twoFactorAvailable = isTwoFactorConfigured();
+	const twoFactorEnforced = requiresTwoFactor(
+		{ role: locals.user.role, isOidc: locals.user.isOidc, totpEnabled: false },
+		require2fa
+	);
+
 	return {
 		user: locals.user,
 		companions,
@@ -53,7 +63,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 		mailEnabled: isMailEnabled(),
 		ntfyEnabled: isNtfyEnabled(),
 		calendarFeedAvailable: CALENDAR_FEED_ENABLED,
-		calendarFeedEnabled: calUser?.calendarFeedToken != null
+		calendarFeedEnabled: calUser?.calendarFeedToken != null,
+		twoFactorAvailable,
+		twoFactorEnforced
 	};
 };
 

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -17,6 +17,12 @@ import { t, SUPPORTED_LOCALES } from '$lib/i18n';
 import type { Locale } from '$lib/i18n';
 import { REMINDER_UNDO_SECONDS_DEFAULT, CALENDAR_FEED_ENABLED } from '$lib/server/env';
 import { enableFeedToken, disableFeedToken } from '$lib/server/calendarToken';
+import {
+	totpBegin,
+	totpConfirm,
+	totpRegenerate,
+	totpDisable
+} from '$lib/server/auth/two-factor-actions';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -158,5 +164,25 @@ export const actions: Actions = {
 		if (!locals.user) return fail(401);
 		await disableFeedToken(locals.user.id);
 		return { calendarDisabled: true };
+	},
+
+	totpBegin: async ({ locals, request }) => {
+		if (!locals.user) return fail(401);
+		return totpBegin({ user: locals.user, request, locale: locals.locale });
+	},
+
+	totpConfirm: async ({ locals, request }) => {
+		if (!locals.user) return fail(401);
+		return totpConfirm({ user: locals.user, request, locale: locals.locale });
+	},
+
+	totpRegenerate: async ({ locals, request }) => {
+		if (!locals.user) return fail(401);
+		return totpRegenerate({ user: locals.user, request, locale: locals.locale });
+	},
+
+	totpDisable: async ({ locals, request }) => {
+		if (!locals.user) return fail(401);
+		return totpDisable({ user: locals.user, request, locale: locals.locale });
 	}
 };

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -8,6 +8,7 @@
 	import ReminderUndoCard from '$lib/components/settings/ReminderUndoCard.svelte';
 	import NotificationsCard from '$lib/components/settings/NotificationsCard.svelte';
 	import DefaultRecurrenceCard from '$lib/components/settings/DefaultRecurrenceCard.svelte';
+	import SecurityCard from '$lib/components/settings/SecurityCard.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { t, getLocale } from '$lib/i18n';
 	import type { Theme } from '$lib/theme';
@@ -83,4 +84,11 @@
 			calendarFeedEnabled={data.calendarFeedEnabled}
 		/>
 	{/if}
+
+	<SecurityCard
+		totpEnabled={data.user?.totpEnabled ?? false}
+		available={data.twoFactorAvailable}
+		enforced={data.twoFactorEnforced}
+		{form}
+	/>
 </div>

--- a/src/routes/(caretaker)/+layout.server.ts
+++ b/src/routes/(caretaker)/+layout.server.ts
@@ -12,18 +12,6 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		redirect(302, '/');
 	}
 
-	const { getAppSettings } = await import('$lib/server/app-settings');
-	const { requiresTwoFactor } = await import('$lib/server/auth/two-factor');
-	const { require2fa } = await getAppSettings();
-	if (
-		requiresTwoFactor(
-			{ role: locals.user.role, isOidc: locals.user.isOidc, totpEnabled: locals.user.totpEnabled },
-			require2fa
-		)
-	) {
-		redirect(302, '/2fa-setup');
-	}
-
 	const assignments = await db.query.companionCaretakers.findMany({
 		where: eq(schema.companionCaretakers.userId, locals.user.id)
 	});

--- a/src/routes/(caretaker)/+layout.server.ts
+++ b/src/routes/(caretaker)/+layout.server.ts
@@ -12,6 +12,18 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		redirect(302, '/');
 	}
 
+	const { getAppSettings } = await import('$lib/server/app-settings');
+	const { requiresTwoFactor } = await import('$lib/server/auth/two-factor');
+	const { require2fa } = await getAppSettings();
+	if (
+		requiresTwoFactor(
+			{ role: locals.user.role, isOidc: locals.user.isOidc, totpEnabled: locals.user.totpEnabled },
+			require2fa
+		)
+	) {
+		redirect(302, '/2fa-setup');
+	}
+
 	const assignments = await db.query.companionCaretakers.findMany({
 		where: eq(schema.companionCaretakers.userId, locals.user.id)
 	});

--- a/src/routes/(caretaker)/care/settings/+page.server.ts
+++ b/src/routes/(caretaker)/care/settings/+page.server.ts
@@ -17,6 +17,12 @@ import { REMINDER_UNDO_SECONDS_DEFAULT, CALENDAR_FEED_ENABLED } from '$lib/serve
 import { isMailEnabled } from '$lib/server/mail';
 import { isNtfyEnabled } from '$lib/server/notify/ntfy';
 import { enableFeedToken, disableFeedToken } from '$lib/server/calendarToken';
+import {
+	totpBegin,
+	totpConfirm,
+	totpRegenerate,
+	totpDisable
+} from '$lib/server/auth/two-factor-actions';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
@@ -120,5 +126,25 @@ export const actions: Actions = {
 		if (!locals.user) return fail(401);
 		await disableFeedToken(locals.user.id);
 		return { calendarDisabled: true };
+	},
+
+	totpBegin: async ({ locals, request }) => {
+		if (!locals.user) return fail(401);
+		return totpBegin({ user: locals.user, request, locale: locals.locale });
+	},
+
+	totpConfirm: async ({ locals, request }) => {
+		if (!locals.user) return fail(401);
+		return totpConfirm({ user: locals.user, request, locale: locals.locale });
+	},
+
+	totpRegenerate: async ({ locals, request }) => {
+		if (!locals.user) return fail(401);
+		return totpRegenerate({ user: locals.user, request, locale: locals.locale });
+	},
+
+	totpDisable: async ({ locals, request }) => {
+		if (!locals.user) return fail(401);
+		return totpDisable({ user: locals.user, request, locale: locals.locale });
 	}
 };

--- a/src/routes/(caretaker)/care/settings/+page.server.ts
+++ b/src/routes/(caretaker)/care/settings/+page.server.ts
@@ -28,6 +28,17 @@ export const load: PageServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(302, '/auth/login');
 	const upcomingShifts = await getUpcomingShifts(locals.user.id);
 	const calUser = await db.query.users.findFirst({ where: eq(schema.users.id, locals.user.id) });
+
+	const { isTwoFactorConfigured } = await import('$lib/server/auth/totp-crypto');
+	const { getAppSettings } = await import('$lib/server/app-settings');
+	const { requiresTwoFactor } = await import('$lib/server/auth/two-factor');
+	const { require2fa } = await getAppSettings();
+	const twoFactorAvailable = isTwoFactorConfigured();
+	const twoFactorEnforced = requiresTwoFactor(
+		{ role: locals.user.role, isOidc: locals.user.isOidc, totpEnabled: false },
+		require2fa
+	);
+
 	return {
 		user: locals.user,
 		upcomingShifts,
@@ -35,7 +46,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 		mailEnabled: isMailEnabled(),
 		ntfyEnabled: isNtfyEnabled(),
 		calendarFeedAvailable: CALENDAR_FEED_ENABLED,
-		calendarFeedEnabled: calUser?.calendarFeedToken != null
+		calendarFeedEnabled: calUser?.calendarFeedToken != null,
+		twoFactorAvailable,
+		twoFactorEnforced
 	};
 };
 

--- a/src/routes/(caretaker)/care/settings/+page.svelte
+++ b/src/routes/(caretaker)/care/settings/+page.svelte
@@ -12,6 +12,7 @@
 	import CalendarFeedCard from '$lib/components/settings/CalendarFeedCard.svelte';
 	import ReminderUndoCard from '$lib/components/settings/ReminderUndoCard.svelte';
 	import NotificationsCard from '$lib/components/settings/NotificationsCard.svelte';
+	import SecurityCard from '$lib/components/settings/SecurityCard.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { t, getLocale, type MessageKey } from '$lib/i18n';
 	import type { Theme } from '$lib/theme';
@@ -212,4 +213,11 @@
 			calendarFeedEnabled={data.calendarFeedEnabled}
 		/>
 	{/if}
+
+	<SecurityCard
+		totpEnabled={data.user?.totpEnabled ?? false}
+		available={data.twoFactorAvailable}
+		enforced={data.twoFactorEnforced}
+		{form}
+	/>
 </div>

--- a/src/routes/2fa-setup/+page.server.ts
+++ b/src/routes/2fa-setup/+page.server.ts
@@ -31,12 +31,9 @@ export const actions: Actions = {
 
 	totpConfirm: async ({ locals, request }) => {
 		if (!locals.user) redirect(302, '/auth/login');
-		const result = await totpConfirm({ user: locals.user, request, locale: locals.locale });
-		// totpConfirm returns { totpSuccess: true, totpBackupCodes } on success, or fail() on error.
-		// On success, redirect away — the user is now enrolled and the gate won't fire again.
-		if (result && typeof result === 'object' && 'totpSuccess' in result && result.totpSuccess) {
-			redirect(302, '/');
-		}
-		return result;
+		// Return the result (including the one-time backup codes) so the page can
+		// show them. The user is now enrolled; the central gate clears on their
+		// next request, so the "Continue" link to / works.
+		return totpConfirm({ user: locals.user, request, locale: locals.locale });
 	}
 };

--- a/src/routes/2fa-setup/+page.server.ts
+++ b/src/routes/2fa-setup/+page.server.ts
@@ -1,0 +1,42 @@
+import { redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { getAppSettings } from '$lib/server/app-settings';
+import { requiresTwoFactor } from '$lib/server/auth/two-factor';
+import { isTwoFactorConfigured } from '$lib/server/auth/totp-crypto';
+import { totpBegin, totpConfirm } from '$lib/server/auth/two-factor-actions';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	if (!locals.user) {
+		redirect(302, '/auth/login');
+	}
+	if (!isTwoFactorConfigured()) {
+		redirect(302, '/');
+	}
+	const { require2fa } = await getAppSettings();
+	const required = requiresTwoFactor(
+		{ role: locals.user.role, isOidc: locals.user.isOidc, totpEnabled: locals.user.totpEnabled },
+		require2fa
+	);
+	if (!required) {
+		redirect(302, '/');
+	}
+	return {};
+};
+
+export const actions: Actions = {
+	totpBegin: async ({ locals, request }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+		return totpBegin({ user: locals.user, request, locale: locals.locale });
+	},
+
+	totpConfirm: async ({ locals, request }) => {
+		if (!locals.user) redirect(302, '/auth/login');
+		const result = await totpConfirm({ user: locals.user, request, locale: locals.locale });
+		// totpConfirm returns { totpSuccess: true, totpBackupCodes } on success, or fail() on error.
+		// On success, redirect away — the user is now enrolled and the gate won't fire again.
+		if (result && typeof result === 'object' && 'totpSuccess' in result && result.totpSuccess) {
+			redirect(302, '/');
+		}
+		return result;
+	}
+};

--- a/src/routes/2fa-setup/+page.svelte
+++ b/src/routes/2fa-setup/+page.svelte
@@ -4,11 +4,16 @@
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
 	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import BackupCodes from '$lib/components/BackupCodes.svelte';
 	import { t, getLocale } from '$lib/i18n';
 	import AuthBackdrop from '$lib/components/auth/AuthBackdrop.svelte';
 
 	let { form }: { form: ActionData } = $props();
 	const locale = getLocale();
+
+	const backupCodes = $derived(
+		(form as Record<string, unknown> | null)?.totpBackupCodes as string[] | undefined
+	);
 </script>
 
 <svelte:head>
@@ -25,21 +30,10 @@
 			{t(locale, 'page.twofa.setupRequiredBody')}
 		</p>
 
-		{#if (form as Record<string, unknown>)?.totpBackupCodes}
+		{#if backupCodes}
 			<!-- Enrolled: show the one-time backup codes once -->
-			{@const backupCodes = (form as Record<string, unknown>).totpBackupCodes as string[]}
-			<p class="text-sm font-medium text-foreground mb-1">
-				{t(locale, 'page.settings.backupCodesTitle')}
-			</p>
-			<p class="text-xs text-muted-foreground mb-3">
-				{t(locale, 'page.settings.backupCodesIntro')}
-			</p>
-			<ul class="grid grid-cols-2 gap-1.5 rounded-md bg-muted p-3 mb-4 font-mono text-sm">
-				{#each backupCodes as code (code)}
-					<li class="text-center">{code}</li>
-				{/each}
-			</ul>
-			<Button href="/" class="w-full">{t(locale, 'page.settings.backupCodesSaved')}</Button>
+			<BackupCodes codes={backupCodes} />
+			<Button href="/" class="w-full mt-4">{t(locale, 'page.settings.backupCodesSaved')}</Button>
 		{:else if form?.totpQr}
 			<!-- Mid-enroll: QR shown, awaiting confirmation -->
 			<p class="text-sm text-muted-foreground mb-3">{t(locale, 'page.settings.scanQr')}</p>

--- a/src/routes/2fa-setup/+page.svelte
+++ b/src/routes/2fa-setup/+page.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import type { ActionData } from './$types';
+	import { enhance } from '$app/forms';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import { t, getLocale } from '$lib/i18n';
+	import AuthBackdrop from '$lib/components/auth/AuthBackdrop.svelte';
+
+	let { form }: { form: ActionData } = $props();
+	const locale = getLocale();
+</script>
+
+<svelte:head>
+	<title>{t(locale, 'page.twofa.setupRequiredTitle')} | EinVault</title>
+</svelte:head>
+
+<AuthBackdrop linkLabel={t(locale, 'aria.goToSignIn')}>
+	<div class="rounded-2xl border border-border bg-card p-6 shadow-2xl animate-slide-up">
+		<h1 class="font-display text-xl font-bold text-foreground mb-4 text-center">
+			{t(locale, 'page.twofa.setupRequiredTitle')}
+		</h1>
+
+		<p class="text-sm text-muted-foreground mb-6 text-center">
+			{t(locale, 'page.twofa.setupRequiredBody')}
+		</p>
+
+		{#if form?.totpQr}
+			<!-- Mid-enroll: QR shown, awaiting confirmation -->
+			<p class="text-sm text-muted-foreground mb-3">{t(locale, 'page.settings.scanQr')}</p>
+			<img
+				src={String(form.totpQr)}
+				alt=""
+				class="w-40 h-40 rounded-md border border-border mb-3"
+			/>
+			<p class="text-sm text-muted-foreground mb-1">{t(locale, 'page.settings.manualKey')}</p>
+			<code class="block font-mono text-xs bg-muted rounded px-2 py-1 mb-4 break-all">
+				{String(form.totpManualKey ?? '')}
+			</code>
+
+			{#if (form as Record<string, unknown>)?.totpError}
+				<Alert variant="coral" class="mb-3">
+					<AlertDescription>{String((form as Record<string, unknown>).totpError)}</AlertDescription>
+				</Alert>
+			{/if}
+
+			<form
+				method="POST"
+				action="?/totpConfirm"
+				use:enhance={() =>
+					async ({ update }) =>
+						update({ reset: false })}
+				class="space-y-3"
+			>
+				<div class="space-y-1.5">
+					<Label for="totp-confirm-code">{t(locale, 'page.settings.confirmCode')}</Label>
+					<Input
+						id="totp-confirm-code"
+						name="code"
+						type="text"
+						inputmode="numeric"
+						pattern="[0-9]*"
+						maxlength={6}
+						autocomplete="one-time-code"
+						aria-label={t(locale, 'page.settings.confirmCode')}
+						class="max-w-[180px]"
+					/>
+				</div>
+				<Button type="submit">{t(locale, 'page.settings.confirmEnable')}</Button>
+			</form>
+		{:else}
+			<!-- Initial state: prompt to begin enrollment -->
+			{#if form?.totpError}
+				<Alert variant="coral" class="mb-4">
+					<AlertDescription>{String(form.totpError)}</AlertDescription>
+				</Alert>
+			{/if}
+
+			<form
+				method="POST"
+				action="?/totpBegin"
+				use:enhance={() =>
+					async ({ update }) =>
+						update({ reset: false })}
+			>
+				<Button type="submit" class="w-full">{t(locale, 'page.settings.enable2fa')}</Button>
+			</form>
+		{/if}
+
+		<div class="mt-6 text-center">
+			<a href="/auth/logout" class="text-xs text-muted-foreground hover:text-primary underline">
+				{t(locale, 'nav.signOut')}
+			</a>
+		</div>
+	</div>
+</AuthBackdrop>

--- a/src/routes/2fa-setup/+page.svelte
+++ b/src/routes/2fa-setup/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type { ActionData } from './$types';
-	import { enhance } from '$app/forms';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
@@ -26,7 +25,22 @@
 			{t(locale, 'page.twofa.setupRequiredBody')}
 		</p>
 
-		{#if form?.totpQr}
+		{#if (form as Record<string, unknown>)?.totpBackupCodes}
+			<!-- Enrolled: show the one-time backup codes once -->
+			{@const backupCodes = (form as Record<string, unknown>).totpBackupCodes as string[]}
+			<p class="text-sm font-medium text-foreground mb-1">
+				{t(locale, 'page.settings.backupCodesTitle')}
+			</p>
+			<p class="text-xs text-muted-foreground mb-3">
+				{t(locale, 'page.settings.backupCodesIntro')}
+			</p>
+			<ul class="grid grid-cols-2 gap-1.5 rounded-md bg-muted p-3 mb-4 font-mono text-sm">
+				{#each backupCodes as code (code)}
+					<li class="text-center">{code}</li>
+				{/each}
+			</ul>
+			<Button href="/" class="w-full">{t(locale, 'page.settings.backupCodesSaved')}</Button>
+		{:else if form?.totpQr}
 			<!-- Mid-enroll: QR shown, awaiting confirmation -->
 			<p class="text-sm text-muted-foreground mb-3">{t(locale, 'page.settings.scanQr')}</p>
 			<img
@@ -45,14 +59,7 @@
 				</Alert>
 			{/if}
 
-			<form
-				method="POST"
-				action="?/totpConfirm"
-				use:enhance={() =>
-					async ({ update }) =>
-						update({ reset: false })}
-				class="space-y-3"
-			>
+			<form method="POST" action="?/totpConfirm" class="space-y-3">
 				<div class="space-y-1.5">
 					<Label for="totp-confirm-code">{t(locale, 'page.settings.confirmCode')}</Label>
 					<Input
@@ -77,21 +84,17 @@
 				</Alert>
 			{/if}
 
-			<form
-				method="POST"
-				action="?/totpBegin"
-				use:enhance={() =>
-					async ({ update }) =>
-						update({ reset: false })}
-			>
+			<form method="POST" action="?/totpBegin">
 				<Button type="submit" class="w-full">{t(locale, 'page.settings.enable2fa')}</Button>
 			</form>
 		{/if}
 
 		<div class="mt-6 text-center">
-			<a href="/auth/logout" class="text-xs text-muted-foreground hover:text-primary underline">
-				{t(locale, 'nav.signOut')}
-			</a>
+			<form method="POST" action="/auth/logout">
+				<button type="submit" class="text-xs text-muted-foreground underline hover:text-primary">
+					{t(locale, 'nav.signOut')}
+				</button>
+			</form>
 		</div>
 	</div>
 </AuthBackdrop>

--- a/src/routes/auth/2fa/+page.server.ts
+++ b/src/routes/auth/2fa/+page.server.ts
@@ -1,0 +1,80 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { db, schema } from '$lib/server/db';
+import { and, eq, isNull } from 'drizzle-orm';
+import { t } from '$lib/i18n';
+import {
+	createSession,
+	generateSessionToken,
+	SESSION_COOKIE_NAME,
+	makeSessionCookieOptions
+} from '$lib/server/auth/session';
+import { isSecureRequest } from '$lib/server/auth';
+import { readPendingMfaCookie, clearPendingMfaCookie } from '$lib/server/auth/two-factor';
+import { decryptSecret } from '$lib/server/auth/totp-crypto';
+import { verifyCode, hashBackupCode } from '$lib/server/auth/totp';
+import { checkRateLimit, clearRateLimit } from '$lib/server/auth/rate-limit';
+
+export const load: PageServerLoad = async ({ cookies }) => {
+	const pending = await readPendingMfaCookie(cookies);
+	if (!pending) redirect(302, '/auth/login');
+	return {};
+};
+
+export const actions: Actions = {
+	default: async ({ request, cookies, getClientAddress, locals }) => {
+		const locale = locals.locale;
+		const secure = isSecureRequest(request);
+		const pending = await readPendingMfaCookie(cookies);
+		if (!pending) redirect(302, '/auth/login');
+
+		const rlKey = `2fa:${pending.userId}:${getClientAddress()}`;
+		if (!checkRateLimit(rlKey)) {
+			clearPendingMfaCookie(cookies, secure);
+			return fail(429, { error: t(locale, 'error.tooManyLoginAttempts') });
+		}
+
+		const input = String((await request.formData()).get('code') ?? '').trim();
+		const user = await db.query.users.findFirst({ where: eq(schema.users.id, pending.userId) });
+		if (!user || !user.totpSecret || !user.isActive) redirect(302, '/auth/login');
+
+		let ok = false;
+		if (/^\d{6}$/.test(input.replace(/\s/g, ''))) {
+			const res = verifyCode(decryptSecret(user.totpSecret), input, {
+				lastStep: user.totpLastStep ?? undefined
+			});
+			if (res.valid) {
+				ok = true;
+				await db
+					.update(schema.users)
+					.set({ totpLastStep: res.step })
+					.where(eq(schema.users.id, user.id));
+			}
+		} else if (input) {
+			const hash = hashBackupCode(input);
+			const code = await db.query.totpBackupCodes.findFirst({
+				where: and(
+					eq(schema.totpBackupCodes.userId, user.id),
+					eq(schema.totpBackupCodes.codeHash, hash),
+					isNull(schema.totpBackupCodes.usedAt)
+				)
+			});
+			if (code) {
+				ok = true;
+				await db
+					.update(schema.totpBackupCodes)
+					.set({ usedAt: new Date() })
+					.where(eq(schema.totpBackupCodes.id, code.id));
+			}
+		}
+
+		if (!ok) return fail(401, { error: t(locale, 'page.twofa.invalidCode') });
+
+		clearRateLimit(rlKey);
+		clearPendingMfaCookie(cookies, secure);
+		const token = generateSessionToken();
+		const session = await createSession(token, user.id);
+		cookies.set(SESSION_COOKIE_NAME, token, makeSessionCookieOptions(session.expiresAt, secure));
+		redirect(302, user.role === 'caretaker' ? '/care' : '/');
+	}
+};

--- a/src/routes/auth/2fa/+page.svelte
+++ b/src/routes/auth/2fa/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import type { ActionData } from './$types';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+	import { t, getLocale } from '$lib/i18n';
+	import AuthBackdrop from '$lib/components/auth/AuthBackdrop.svelte';
+
+	let { form }: { form: ActionData } = $props();
+	let loading = $state(false);
+	const locale = getLocale();
+</script>
+
+<svelte:head>
+	<title>{t(locale, 'page.twofa.title')} | EinVault</title>
+</svelte:head>
+
+<AuthBackdrop linkLabel={t(locale, 'aria.goToSignIn')}>
+	<div class="rounded-2xl border border-border bg-card p-6 shadow-2xl animate-slide-up">
+		<h1 class="font-display text-xl font-bold text-foreground mb-4 text-center">
+			{t(locale, 'page.twofa.title')}
+		</h1>
+		<form method="POST" onsubmit={() => (loading = true)} class="space-y-4">
+			{#if form?.error}
+				<Alert variant="coral">
+					<AlertDescription>{form.error}</AlertDescription>
+				</Alert>
+			{/if}
+
+			<p class="text-sm text-muted-foreground">{t(locale, 'page.twofa.help')}</p>
+
+			<div class="space-y-1.5">
+				<Label for="code">{t(locale, 'page.twofa.codeLabel')}</Label>
+				<Input
+					id="code"
+					name="code"
+					type="text"
+					autocomplete="one-time-code"
+					inputmode="numeric"
+					required
+				/>
+			</div>
+
+			<Button type="submit" class="w-full" disabled={loading}>
+				{t(locale, 'page.twofa.submit')}
+			</Button>
+		</form>
+
+		<div class="mt-4 text-center">
+			<a href="/auth/login" class="text-xs text-muted-foreground hover:text-primary underline">
+				{t(locale, 'aria.goToSignIn')}
+			</a>
+		</div>
+	</div>
+</AuthBackdrop>

--- a/src/routes/auth/login/+page.server.ts
+++ b/src/routes/auth/login/+page.server.ts
@@ -11,42 +11,9 @@ import {
 	makeSessionCookieOptions
 } from '$lib/server/auth/session';
 import { isSecureRequest } from '$lib/server/auth';
+import { checkRateLimit, clearRateLimit } from '$lib/server/auth/rate-limit';
 import { eq } from 'drizzle-orm';
 import bcrypt from 'bcryptjs';
-
-// NOTE: This rate limiter is in-process memory only. State resets on server restart and
-// does not coordinate across multiple processes. It is intentional for a single-instance
-// deployment; revisit before horizontal scaling.
-const loginAttempts = new Map<string, { count: number; resetAt: number }>();
-const MAX_ATTEMPTS = 10;
-const WINDOW_MS = 15 * 60 * 1000;
-const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
-
-let lastCleanup = Date.now();
-
-function checkRateLimit(ip: string): boolean {
-	const now = Date.now();
-
-	if (now - lastCleanup > CLEANUP_INTERVAL_MS) {
-		for (const [key, val] of loginAttempts) {
-			if (now > val.resetAt) loginAttempts.delete(key);
-		}
-		lastCleanup = now;
-	}
-
-	const record = loginAttempts.get(ip);
-	if (!record || now > record.resetAt) {
-		loginAttempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
-		return true;
-	}
-	if (record.count >= MAX_ATTEMPTS) return false;
-	record.count++;
-	return true;
-}
-
-function clearRateLimit(ip: string) {
-	loginAttempts.delete(ip);
-}
 
 const OIDC_ERROR_KEYS = {
 	oidc_not_provisioned: 'error.oidc.notProvisioned',
@@ -80,7 +47,7 @@ export const actions: Actions = {
 		const ip = getClientAddress();
 		const locale = locals.locale;
 
-		if (!checkRateLimit(ip)) {
+		if (!checkRateLimit(ip, 10)) {
 			return fail(429, { error: t(locale, 'error.tooManyLoginAttempts') });
 		}
 

--- a/src/routes/auth/login/+page.server.ts
+++ b/src/routes/auth/login/+page.server.ts
@@ -83,6 +83,12 @@ export const actions: Actions = {
 			.set({ lastLoginAt: new Date() })
 			.where(eq(schema.users.id, user.id));
 
+		if (user.totpEnabledAt) {
+			const { setPendingMfaCookie } = await import('$lib/server/auth/two-factor');
+			await setPendingMfaCookie(cookies, user.id, isSecureRequest(request));
+			redirect(302, '/auth/2fa');
+		}
+
 		const token = generateSessionToken();
 		const session = await createSession(token, user.id);
 

--- a/tests/e2e/twofactor.spec.ts
+++ b/tests/e2e/twofactor.spec.ts
@@ -1,0 +1,370 @@
+import { test as base, expect, type Browser, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { TOTP, Secret } from 'otpauth';
+import { createSeededDb, SEED } from '../lib/seed';
+import { startAppServer, type AppServer } from '../lib/app-server';
+import { getFreePort } from '../lib/ports';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+
+const ENC_KEY = Buffer.from(new Uint8Array(32).fill(11)).toString('base64');
+
+// ---------------------------------------------------------------------------
+// Module-level shared server — boots once, torn down via afterAll
+// ---------------------------------------------------------------------------
+
+let sharedServer: AppServer | null = null;
+let sharedDir: string | null = null;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Derive a TOTP code from a Base32 key.
+ * @param offset – extra seconds to add to the current timestamp (use 30 to get the next period).
+ */
+function deriveCode(base32Key: string, offset = 0): string {
+	const totp = new TOTP({ secret: Secret.fromBase32(base32Key), digits: 6, period: 30 });
+	return totp.generate({ timestamp: Date.now() + offset * 1000 });
+}
+
+/** Log in via the standard password form; does NOT wait for redirect. */
+async function fillLogin(page: Page, username: string, password: string): Promise<void> {
+	await page.getByLabel('Username').fill(username);
+	await page.getByLabel('Password').fill(password);
+	await page.getByRole('button', { name: 'Sign in' }).click();
+}
+
+/** Open a fresh browser context pre-pointed at the test server. */
+function newCtx(browser: Browser, baseURL: string) {
+	return browser.newContext({ baseURL });
+}
+
+// ---------------------------------------------------------------------------
+// Fixture that reuses the module-level shared server
+// ---------------------------------------------------------------------------
+
+interface TwoFactorWorld {
+	server: AppServer;
+}
+
+const test = base.extend<TwoFactorWorld>({
+	server: async ({}, use) => {
+		if (!sharedServer) {
+			throw new Error('Shared server not started — did beforeAll run?');
+		}
+		await use(sharedServer);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('2FA @desktop', () => {
+	test.describe.configure({ mode: 'serial' });
+
+	// Persistent state across serial tests within this file
+	let enrolledKey = '';
+	let firstBackupCode = '';
+
+	test.beforeAll(async () => {
+		const dir = path.join(REPO_ROOT, '.test-data', `2fa-shared-${Date.now()}`);
+		sharedDir = dir;
+		const appPort = await getFreePort();
+		const dbPath = createSeededDb(dir);
+		sharedServer = await startAppServer({
+			dbPath,
+			env: {
+				PORT: String(appPort),
+				TWOFA_ENC_KEY: ENC_KEY,
+				OIDC_STATE_SECRET: 'test-2fa-secret'
+			}
+		});
+	});
+
+	test.afterAll(async () => {
+		if (sharedServer) {
+			await sharedServer.stop();
+			sharedServer = null;
+		}
+		if (sharedDir) {
+			fs.rmSync(sharedDir, { recursive: true, force: true });
+			sharedDir = null;
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// 1. Enroll
+	// -------------------------------------------------------------------------
+	test('1. enroll member via settings', async ({ server, browser }) => {
+		const ctx = await newCtx(browser, server.baseURL);
+		const page = await ctx.newPage();
+
+		// Log in
+		await page.goto('/auth/login');
+		await fillLogin(page, SEED.member.username, SEED.password);
+		await expect(page).not.toHaveURL(/\/auth\//, { timeout: 10_000 });
+
+		// Navigate to settings
+		await page.goto('/settings');
+		await expect(page).toHaveURL(/settings/, { timeout: 10_000 });
+
+		// Click "Enable two-factor authentication"
+		await page.getByRole('button', { name: /enable two-factor authentication/i }).click();
+
+		// QR image + manual key must appear
+		await expect(page.locator('img[alt=""]').first()).toBeVisible({ timeout: 10_000 });
+		const keyEl = page.locator('code').first();
+		await expect(keyEl).toBeVisible();
+		const key = (await keyEl.textContent())!.trim();
+		expect(key.length).toBeGreaterThan(10);
+		enrolledKey = key;
+
+		// Fill the confirm-code input and submit (scroll into view first)
+		const code = deriveCode(key);
+		const confirmInput = page.getByLabel(/enter the 6-digit code to confirm/i);
+		await confirmInput.scrollIntoViewIfNeeded();
+		await confirmInput.fill(code);
+		await page.getByRole('button', { name: /^Confirm$/i }).click();
+
+		// Backup codes should appear (10 codes matching xxxxx-xxxxx)
+		const codePattern = /[a-z0-9]{5}-[a-z0-9]{5}/;
+		const codeEls = page.locator('text=/[a-z0-9]{5}-[a-z0-9]{5}/');
+		await expect(codeEls.first()).toBeVisible({ timeout: 10_000 });
+		const count = await codeEls.count();
+		expect(count).toBeGreaterThanOrEqual(10);
+
+		// Save first backup code
+		firstBackupCode = (await codeEls.first().textContent())!.trim();
+		expect(firstBackupCode).toMatch(codePattern);
+
+		await ctx.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// 2. Challenge with TOTP code
+	// -------------------------------------------------------------------------
+	test('2. login challenged with TOTP; code passes', async ({ server, browser }) => {
+		const ctx = await newCtx(browser, server.baseURL);
+		const page = await ctx.newPage();
+
+		await page.goto('/auth/login');
+		await fillLogin(page, SEED.member.username, SEED.password);
+
+		// Must land on /auth/2fa
+		await expect(page).toHaveURL(/\/auth\/2fa/, { timeout: 10_000 });
+
+		// Submit a fresh TOTP code — use the next period (+30s) to avoid replay rejection
+		// since the confirm step in test 1 consumed the current period's code.
+		const code = deriveCode(enrolledKey, 30);
+		await page.getByRole('textbox').fill(code);
+		await page.getByRole('button', { name: /verify/i }).click();
+
+		// Must leave /auth/2fa and land on /
+		await expect(page).not.toHaveURL(/\/auth\/2fa/, { timeout: 10_000 });
+		await expect(page).not.toHaveURL(/\/auth\/login/, { timeout: 10_000 });
+
+		await ctx.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// 3. Backup code – single-use
+	// -------------------------------------------------------------------------
+	test('3a. backup code works once', async ({ server, browser }) => {
+		const ctx = await newCtx(browser, server.baseURL);
+		const page = await ctx.newPage();
+
+		await page.goto('/auth/login');
+		await fillLogin(page, SEED.member.username, SEED.password);
+		await expect(page).toHaveURL(/\/auth\/2fa/, { timeout: 10_000 });
+
+		await page.getByRole('textbox').fill(firstBackupCode);
+		await page.getByRole('button', { name: /verify/i }).click();
+
+		// Should succeed and land off /auth/2fa
+		await expect(page).not.toHaveURL(/\/auth\/2fa/, { timeout: 10_000 });
+		await expect(page).not.toHaveURL(/\/auth\/login/, { timeout: 10_000 });
+
+		await ctx.close();
+	});
+
+	test('3b. same backup code rejected on second use', async ({ server, browser }) => {
+		const ctx = await newCtx(browser, server.baseURL);
+		const page = await ctx.newPage();
+
+		await page.goto('/auth/login');
+		await fillLogin(page, SEED.member.username, SEED.password);
+		await expect(page).toHaveURL(/\/auth\/2fa/, { timeout: 10_000 });
+
+		// Re-submit the already-used backup code
+		await page.getByRole('textbox').fill(firstBackupCode);
+		await page.getByRole('button', { name: /verify/i }).click();
+
+		// Must stay on /auth/2fa with an error
+		await expect(page).toHaveURL(/\/auth\/2fa/, { timeout: 10_000 });
+		await expect(page.locator('[role="alert"]')).toBeVisible({ timeout: 5_000 });
+
+		await ctx.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// 4. Wrong code
+	// -------------------------------------------------------------------------
+	test('4. wrong code is rejected', async ({ server, browser }) => {
+		const ctx = await newCtx(browser, server.baseURL);
+		const page = await ctx.newPage();
+
+		await page.goto('/auth/login');
+		await fillLogin(page, SEED.member.username, SEED.password);
+		await expect(page).toHaveURL(/\/auth\/2fa/, { timeout: 10_000 });
+
+		await page.getByRole('textbox').fill('000000');
+		await page.getByRole('button', { name: /verify/i }).click();
+
+		// Must stay on /auth/2fa with error visible
+		await expect(page).toHaveURL(/\/auth\/2fa/, { timeout: 10_000 });
+		await expect(page.locator('[role="alert"]')).toBeVisible({ timeout: 5_000 });
+
+		await ctx.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// 5. Enforcement: admin enables "everyone", caretaker forced to enroll
+	// -------------------------------------------------------------------------
+	test('5. enforcement: caretaker forced to /2fa-setup when everyone required', async ({
+		server,
+		browser
+	}) => {
+		// Step A: log in as admin (spike, not yet enrolled) and set require2fa = everyone.
+		// Note: admin spike has no 2FA — after setting "everyone" the admin themselves
+		// would be bounced to /2fa-setup on next navigation. We switch to the caretaker
+		// context immediately after the toggle and never revisit the admin session.
+		const adminCtx = await newCtx(browser, server.baseURL);
+		const adminPage = await adminCtx.newPage();
+
+		await adminPage.goto('/auth/login');
+		await fillLogin(adminPage, SEED.admin.username, SEED.password);
+		await expect(adminPage).not.toHaveURL(/\/auth\//, { timeout: 10_000 });
+
+		await adminPage.goto('/admin/users');
+		await expect(adminPage).toHaveURL(/admin\/users/, { timeout: 10_000 });
+
+		// Change the require-2fa select to "Everyone".
+		// The select has onchange → requestSubmit, which POSTs and reloads.
+		// After reload the admin themselves (no 2FA) will be redirected to /2fa-setup
+		// by the enforcement gate. That's expected — we just need the DB write to have
+		// happened, so wait for any navigation away from /admin/users.
+		const select = adminPage.locator('select#require2fa');
+		await select.selectOption('everyone');
+		// Either we see a success alert (briefly) or we get redirected — either way
+		// wait for a page-level change.
+		await adminPage.waitForURL(/\/admin\/users|\/2fa-setup/, { timeout: 10_000 });
+
+		await adminCtx.close();
+
+		// Step B: caretaker (faye) logs in — has no 2FA — must be gated at /2fa-setup
+		const careCtx = await newCtx(browser, server.baseURL);
+		const carePage = await careCtx.newPage();
+
+		await carePage.goto('/auth/login');
+		await fillLogin(carePage, SEED.caretaker.username, SEED.password);
+		// Caretaker lands on /care after login normally, but enforcement should redirect to /2fa-setup
+		await expect(carePage).toHaveURL(/\/2fa-setup/, { timeout: 15_000 });
+
+		// Page should show setup-required heading
+		await expect(
+			carePage.getByRole('heading', { name: /two-factor authentication required/i })
+		).toBeVisible({ timeout: 5_000 });
+
+		// Click "Enable two-factor authentication" / begin button
+		await carePage.getByRole('button', { name: /enable two-factor authentication/i }).click();
+
+		// QR + manual key must appear
+		await expect(carePage.locator('img').first()).toBeVisible({ timeout: 10_000 });
+		const keyEl = carePage.locator('code').first();
+		await expect(keyEl).toBeVisible();
+		const careKey = (await keyEl.textContent())!.trim();
+		expect(careKey.length).toBeGreaterThan(10);
+
+		// Confirm with a valid code
+		const confirmInput = carePage.getByLabel(/enter the 6-digit code to confirm/i);
+		await confirmInput.scrollIntoViewIfNeeded();
+		await confirmInput.fill(deriveCode(careKey));
+		await carePage.getByRole('button', { name: /^Confirm$/i }).click();
+
+		// After successful enrollment at /2fa-setup the server redirects to /
+		// Caretakers redirect to /care
+		await expect(carePage).not.toHaveURL(/\/2fa-setup/, { timeout: 15_000 });
+		await expect(carePage).not.toHaveURL(/\/auth\//, { timeout: 10_000 });
+
+		await careCtx.close();
+	});
+
+	// -------------------------------------------------------------------------
+	// 6. Admin reset of member 2FA
+	// -------------------------------------------------------------------------
+	test('6. admin can reset member 2FA', async ({ server, browser }) => {
+		// Admin (spike) must first enroll themselves because "everyone" enforcement is on
+		// (set in test 5). Spike logs in → gets bounced to /2fa-setup.
+		const adminCtx = await newCtx(browser, server.baseURL);
+		const adminPage = await adminCtx.newPage();
+
+		await adminPage.goto('/auth/login');
+		await fillLogin(adminPage, SEED.admin.username, SEED.password);
+		// With enforcement on, admin should be gated at /2fa-setup
+		await expect(adminPage).toHaveURL(/\/2fa-setup/, { timeout: 15_000 });
+
+		await adminPage.getByRole('button', { name: /enable two-factor authentication/i }).click();
+		await expect(adminPage.locator('img').first()).toBeVisible({ timeout: 10_000 });
+		const adminKeyEl = adminPage.locator('code').first();
+		const adminKey = (await adminKeyEl.textContent())!.trim();
+		const adminConfirm = adminPage.getByLabel(/enter the 6-digit code to confirm/i);
+		await adminConfirm.scrollIntoViewIfNeeded();
+		await adminConfirm.fill(deriveCode(adminKey));
+		await adminPage.getByRole('button', { name: /^Confirm$/i }).click();
+		await expect(adminPage).not.toHaveURL(/\/2fa-setup/, { timeout: 10_000 });
+
+		// Now navigate to /admin/users and open the member (Jet) drawer.
+		// Admin will be challenged at /auth/2fa since they just enrolled.
+		// But wait — the /2fa-setup flow redirects directly to / creating a full session,
+		// so there's no pending MFA cookie — they're already logged in.
+		await adminPage.goto('/admin/users');
+		await expect(adminPage).toHaveURL(/admin\/users/, { timeout: 10_000 });
+
+		// Find and click the Manage button for Jet
+		const jetManageBtn = adminPage
+			.locator('div')
+			.filter({ hasText: /\bJet\b/ })
+			.getByRole('button', { name: /manage/i })
+			.first();
+		await jetManageBtn.click();
+
+		// Reset two-factor button should be visible (member has 2FA enabled)
+		await expect(adminPage.getByRole('button', { name: /reset two-factor/i })).toBeVisible({
+			timeout: 10_000
+		});
+		await adminPage.getByRole('button', { name: /reset two-factor/i }).click();
+
+		// Success feedback in the drawer
+		await expect(
+			adminPage.locator('[role="alert"]').filter({ hasText: /two-factor reset/i })
+		).toBeVisible({ timeout: 10_000 });
+
+		await adminCtx.close();
+
+		// Member (jet) should now be sent to /2fa-setup (enforcement is still "everyone")
+		// since their 2FA was cleared by the admin reset.
+		const memberCtx = await newCtx(browser, server.baseURL);
+		const memberPage = await memberCtx.newPage();
+
+		await memberPage.goto('/auth/login');
+		await fillLogin(memberPage, SEED.member.username, SEED.password);
+
+		// With enforcement on and 2FA cleared, member should be redirected to /2fa-setup
+		await expect(memberPage).toHaveURL(/\/2fa-setup/, { timeout: 15_000 });
+
+		await memberCtx.close();
+	});
+});

--- a/tests/e2e/twofactor.spec.ts
+++ b/tests/e2e/twofactor.spec.ts
@@ -296,8 +296,9 @@ test.describe('2FA @desktop', () => {
 		await confirmInput.fill(deriveCode(careKey));
 		await carePage.getByRole('button', { name: /^Confirm$/i }).click();
 
-		// After successful enrollment at /2fa-setup the server redirects to /
-		// Caretakers redirect to /care
+		// Enrollment shows the one-time backup codes; acknowledge to continue.
+		await expect(carePage.getByText(/save your backup codes/i)).toBeVisible({ timeout: 10_000 });
+		await carePage.getByRole('link', { name: /saved my backup codes/i }).click();
 		await expect(carePage).not.toHaveURL(/\/2fa-setup/, { timeout: 15_000 });
 		await expect(carePage).not.toHaveURL(/\/auth\//, { timeout: 10_000 });
 
@@ -326,6 +327,8 @@ test.describe('2FA @desktop', () => {
 		await adminConfirm.scrollIntoViewIfNeeded();
 		await adminConfirm.fill(deriveCode(adminKey));
 		await adminPage.getByRole('button', { name: /^Confirm$/i }).click();
+		await expect(adminPage.getByText(/save your backup codes/i)).toBeVisible({ timeout: 10_000 });
+		await adminPage.getByRole('link', { name: /saved my backup codes/i }).click();
 		await expect(adminPage).not.toHaveURL(/\/2fa-setup/, { timeout: 10_000 });
 
 		// Now navigate to /admin/users and open the member (Jet) drawer.

--- a/tests/e2e/twofactor.spec.ts
+++ b/tests/e2e/twofactor.spec.ts
@@ -79,8 +79,9 @@ test.describe('2FA @desktop', () => {
 			dbPath,
 			env: {
 				PORT: String(appPort),
-				TWOFA_ENC_KEY: ENC_KEY,
-				OIDC_STATE_SECRET: 'test-2fa-secret'
+				// Deliberately NO OIDC_STATE_SECRET: 2FA must work without it
+				// (the MFA cookie key derives from TWOFA_ENC_KEY).
+				TWOFA_ENC_KEY: ENC_KEY
 			}
 		});
 	});

--- a/tests/e2e/twofactor.spec.ts
+++ b/tests/e2e/twofactor.spec.ts
@@ -50,6 +50,7 @@ interface TwoFactorWorld {
 }
 
 const test = base.extend<TwoFactorWorld>({
+	// eslint-disable-next-line no-empty-pattern
 	server: async ({}, use) => {
 		if (!sharedServer) {
 			throw new Error('Shared server not started — did beforeAll run?');


### PR DESCRIPTION
Adds optional per-user TOTP 2FA plus an admin enforcement toggle. Closes #116.

## What this adds

- **Per-user 2FA**: enable in Settings > Security (scan QR or enter the key, confirm a code), get 10 one-time backup codes. Login then prompts for a 6-digit code or a backup code at `/auth/2fa`.
- **Admin enforcement**: a site setting (Admin > Users > Security) with Off / Admins only / Everyone. Required users who have not enrolled are sent to a forced setup page on their next request.
- **Recovery**: single-use backup codes, or an admin "Reset two-factor" in the user drawer.
- **OIDC exempt**: app-level TOTP is for password logins; SSO MFA stays the identity provider's job.

## Security model

- TOTP secret encrypted at rest (AES-256-GCM) with a new `TWOFA_ENC_KEY` (generate with `openssl rand -base64 32`). 2FA is unavailable until it is set.
- Replay guard on the TOTP step, single-use hashed backup codes, rate limiting on login and the challenge.
- Enforcement is applied centrally in the request hook (covers `/api/*` and every route), not only in layout loads.
- Re-enrollment and backup-code regeneration require a fresh code; password reset does not bypass 2FA.

A security pass during development found and fixed three issues (a central-enforcement bypass, a re-enroll step-up gap, and a backup-regen step-up gap). The MFA challenge cookie derives its key from `TWOFA_ENC_KEY`, so 2FA does not depend on any OIDC variable.

## Config / docs

New env var `TWOFA_ENC_KEY` documented in the README (with a Table of Contents entry and env table row), `.env.example`, and both compose files.

## Tests

Unit tests cover the crypto, TOTP/backup-code, enforcement-scope, and cookie logic. A dedicated e2e (`tests/e2e/twofactor.spec.ts`, booted without `OIDC_STATE_SECRET`) covers enroll, challenge, backup-code single-use, wrong-code, enforcement interstitial, and admin reset. check, lint, unit, build, and the 2FA e2e are green.