### PR TITLE
Run on Node 26; bump better-sqlite3 to 12.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # pkgmeta: zero out the version field so version-bump commits don't invalidate
 # the npm ci layer in deps; nothing in the install depends on the real version.
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS pkgmeta
+FROM node:26-alpine@sha256:3ad34ca6292aec4a91d8ddeb9229e29d9c2f689efd0dd242860889ac71842eba AS pkgmeta
 
 WORKDIR /meta
 
@@ -22,7 +22,7 @@ RUN node -e "const fs = require('fs'); \
 
 
 # deps
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS deps
+FROM node:26-alpine@sha256:3ad34ca6292aec4a91d8ddeb9229e29d9c2f689efd0dd242860889ac71842eba AS deps
 
 WORKDIR /build
 
@@ -36,7 +36,7 @@ RUN npm ci --ignore-scripts \
 
 
 # builder
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
+FROM node:26-alpine@sha256:3ad34ca6292aec4a91d8ddeb9229e29d9c2f689efd0dd242860889ac71842eba AS builder
 
 WORKDIR /build
 
@@ -51,7 +51,7 @@ RUN npm prune --omit=dev
 
 
 # runner
-FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS runner
+FROM node:26-alpine@sha256:3ad34ca6292aec4a91d8ddeb9229e29d9c2f689efd0dd242860889ac71842eba AS runner
 
 WORKDIR /app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@touch4it/ical-timezones": "^1.9.0",
 				"aws4fetch": "^1.0.20",
 				"bcryptjs": "^3.0.3",
-				"better-sqlite3": "^12.8.0",
+				"better-sqlite3": "^12.10.1",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
 				"drizzle-orm": "^0.45.2",
@@ -3709,9 +3709,9 @@
 			}
 		},
 		"node_modules/better-sqlite3": {
-			"version": "12.10.0",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
-			"integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+			"version": "12.10.1",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.1.tgz",
+			"integrity": "sha512-HfFtzCqnSfwB3+HroF6PSKzyh+7RfNMGPCzHFUZXRlvrPCb4P3cvxKZNN43Sr7IrkofqQZM+gIvffGpA8VvqgA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"@touch4it/ical-timezones": "^1.9.0",
 		"aws4fetch": "^1.0.20",
 		"bcryptjs": "^3.0.3",
-		"better-sqlite3": "^12.8.0",
+		"better-sqlite3": "^12.10.1",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"drizzle-orm": "^0.45.2",


### PR DESCRIPTION
Bumps the Docker runtime from `node:24-alpine` to `node:26-alpine` and the `better-sqlite3` native module to the version that supports it. Supersedes #134, which bumped the base image alone and would not compile.

## Why both changes ship together
`better-sqlite3` uses node-gyp / V8 headers, so it builds per Node version. 12.10.0 added Node 26 support (prebuilds + source). On the old 12.8.0 pin, `npm rebuild better-sqlite3` against Node 26 would fail, so the runtime bump can't land without it. Bundling them keeps the runtime from ever shipping without its enabling dependency.

`sharp` needs no change: it ships N-API prebuilts that are ABI-stable across Node majors, so 0.34.5 already runs on Node 26.

## Verified on Node 26 (local docker build + smoke test)
- Image builds clean; `better-sqlite3` 12.10.1 and `sharp` 0.34.5 both compile against Node 26.
- Container boots as **Node v26.3.0**, runs migrations on first boot (23 tables), `better-sqlite3` read **and** write confirmed, `/api/health` returns 200.
- Unit tests (209) pass; `npm run lint` and `npm run check` clean.

## Kept: the libssl/libcrypto upgrade
`RUN apk upgrade --no-cache libcrypto3 libssl3` stays. Base `node:26-alpine` (Alpine 3.24.0) still ships **3.5.6-r0**; the repo offers **3.5.7-r0** (the CVE-2026-45447 fix), so the upgrade still does real work. Revisit once the base reaches 3.5.7-r0.

Closes #134.