### PR TITLE
Fix reminder edit form reopening after save (#133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # EinVault
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.0.1-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
+[![Version](https://img.shields.io/badge/version-1.0.2-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
 
 EinVault is a private, self-hosted companion health and care tracker built for homelabs. Track health records, daily activities, and care schedules for your animal companions. All data stays on your hardware. No cloud, no telemetry, no external accounts.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "einvault",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "einvault",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"dependencies": {
 				"@fontsource-variable/bricolage-grotesque": "^5.2.10",
 				"@fontsource-variable/geist-mono": "5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "einvault",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",

--- a/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/reminders/+page.svelte
@@ -111,13 +111,24 @@
 
 	let editingId = $state<string | null>(null);
 
+	// Open the edit form once per `?edit=` deep link. The guard is load-bearing:
+	// without it, saving re-runs the load (new `data.reminders`), the effect
+	// re-fires while `edit` is still in the URL, and the form pops back open.
+	// Stripping the param keeps a reload from reopening it too.
+	let lastEditDeepLink = '';
 	$effect(() => {
 		const editId = page.url.searchParams.get('edit');
-		if (!editId || !data.reminders.length) return;
+		if (!editId || editId === lastEditDeepLink || !data.reminders.length) return;
+		lastEditDeepLink = editId;
 		const match = data.reminders.find((r) => r.id === editId);
 		if (match) {
 			tick().then(() => startEdit(match));
 		}
+		tick().then(() => {
+			const url = new URL(page.url);
+			url.searchParams.delete('edit');
+			history.replaceState(history.state, '', url.pathname + url.search);
+		});
 	});
 
 	$effect(() => {

--- a/tests/e2e/reminders.spec.ts
+++ b/tests/e2e/reminders.spec.ts
@@ -233,4 +233,24 @@ test.describe('reminders', () => {
 		// Cross-check: the overdue item is NOT in the upcoming group.
 		await expect(groupAfter('Overdue').getByText('e2e-upcoming-grp')).toHaveCount(0);
 	});
+
+	test('editing a reminder via the ?edit deep link does not reopen after saving (#133)', async ({
+		asMember
+	}) => {
+		// The dashboard reminder modal's "Edit in Reminders" button links here.
+		await asMember.goto(`${BASE}?edit=seed-reminder-1`);
+
+		const titleInput = asMember.locator('#edit-title-seed-reminder-1');
+		await expect(titleInput).toBeVisible({ timeout: 8_000 });
+
+		// Save without changing anything so other specs that read this seed
+		// reminder's title are unaffected.
+		await asMember.getByRole('button', { name: 'Save', exact: true }).click();
+
+		// The inline edit form must close and stay closed. It used to pop right
+		// back open because the post-save reload re-fired the ?edit effect.
+		await expect(titleInput).toHaveCount(0, { timeout: 8_000 });
+		await asMember.waitForTimeout(800);
+		await expect(titleInput).toHaveCount(0);
+	});
 });


### PR DESCRIPTION
## Problem
Opening a reminder's detail modal and clicking **Edit in Reminders** navigates to `/{companion}/reminders?edit={id}`, which opens the inline edit form. Clicking **Save** persisted the change but immediately reopened the edit form.

## Cause
The `?edit=` handler was an `$effect` with no guard and no cleanup, unlike the sibling `?detail=` effect. Saving runs the form action's `update()`, which reloads `data.reminders`; the new array re-triggers the effect while `edit` is still in the URL, so it calls `startEdit` again and the form pops back open.

## Fix
Mirror the `?detail=` deep-link pattern: a one-shot `lastEditDeepLink` guard so the effect handles each `edit` id once, plus stripping the `edit` param from the URL so a reload doesn't reopen it either.

## Test
Added an e2e regression test (`#133`): open `?edit=seed-reminder-1`, save without changes, assert the inline edit form closes and stays closed. Confirmed it **fails** on the pre-fix code and **passes** after. Full reminders e2e suite green; `npm run check`/`lint` clean.

Fixes #133.