### PR TITLE
Fix health/weight edit form reopening after save (#142)

### DIFF
--- a/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/health/+page.svelte
@@ -99,18 +99,30 @@
 	let deleteHealthId = $state('');
 	let deleteHealthForm = $state<HTMLFormElement | null>(null);
 
+	// Open the edit form once per `?edit=` deep link (from the dashboard
+	// weight/health detail modal). The guard is load-bearing: without it,
+	// saving re-runs the load (new `data`), the effect re-fires while `edit`
+	// is still in the URL, and the form pops back open. Stripping the param
+	// keeps a reload from reopening it too.
+	let lastEditDeepLink = '';
 	$effect(() => {
 		const editId = page.url.searchParams.get('edit');
-		if (!editId) return;
+		if (!editId || editId === lastEditDeepLink) return;
+		lastEditDeepLink = editId;
 		const weightMatch = data.weightEntries.find((e) => e.id === editId);
 		if (weightMatch) {
 			editingWeightId = editId;
-			return;
+		} else {
+			const healthMatch = data.healthEvents.find((e) => e.id === editId);
+			if (healthMatch) {
+				editingHealthId = editId;
+			}
 		}
-		const healthMatch = data.healthEvents.find((e) => e.id === editId);
-		if (healthMatch) {
-			editingHealthId = editId;
-		}
+		tick().then(() => {
+			const url = new URL(page.url);
+			url.searchParams.delete('edit');
+			history.replaceState(history.state, '', url.pathname + url.search);
+		});
 	});
 
 	$effect(() => {

--- a/tests/e2e/health.spec.ts
+++ b/tests/e2e/health.spec.ts
@@ -130,4 +130,24 @@ test.describe('health events and weight log', () => {
 		// Form should still be visible — no redirect/close occurred
 		await expect(asMember.getByRole('button', { name: 'Save Event' })).toBeVisible();
 	});
+
+	test('editing a weight entry via the ?edit deep link does not reopen after saving (#142)', async ({
+		asMember
+	}) => {
+		// The dashboard weight detail modal's "Edit" button links here.
+		await asMember.goto(`/${COMP}/health?edit=seed-weight-1`);
+
+		const weightInput = asMember.locator('#edit-weight-seed-weight-1');
+		await expect(weightInput).toBeVisible({ timeout: 8_000 });
+
+		// Save without changing anything so other specs that read this seed
+		// weight entry are unaffected.
+		await asMember.getByRole('button', { name: 'Save', exact: true }).click();
+
+		// The inline edit form must close and stay closed. It used to pop right
+		// back open because the post-save reload re-fired the ?edit effect.
+		await expect(weightInput).toHaveCount(0, { timeout: 8_000 });
+		await asMember.waitForTimeout(800);
+		await expect(weightInput).toHaveCount(0);
+	});
 });


### PR DESCRIPTION
## Problem

Issue #142 is the same bug as #133, on the health page. Opening a weight (or health event) detail modal from the dashboard and clicking **Edit** deep-links to `/<companion>/health?edit=<id>`, which opens the inline edit form. Clicking **Save** persists the change but the form immediately re-opens.

## Cause

The health page's `?edit=` `$effect` had no one-shot guard and never stripped the param. Saving re-runs the load, the effect re-fires while `edit` is still in the URL, and the form pops back open. Identical to the reminders bug fixed in #133.

## Fix

Apply the #133 pattern to `health/+page.svelte`: a `lastEditDeepLink` guard so the effect opens the form once per deep link, plus stripping the `edit` param via `history.replaceState`. The single effect handles both weight entries and health events, so this covers the weight case in #142 and the latent health-event case.

Swept `src/` for all `?edit=` consumers — only reminders (fixed in #133) and health (fixed here) exist. All instances handled.

## Test

Added an e2e test in `health.spec.ts` mirroring the #133 reminders test: deep-link to the edit form, save unchanged, assert the form closes and stays closed. Full health + reminders specs pass.

Fixes #142.