### PR TITLE
Open reminder modal from the Next vet dashboard stat (#143)

### DIFF
--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -642,7 +642,13 @@
 						>{t(locale, 'page.dashboard.nextVet')}</span
 					>
 					{#if nextReminder}
-						<span class="text-base font-bold text-foreground truncate">{nextReminder.title}</span>
+						<button
+							type="button"
+							onclick={() => nextReminder && openDetail({ kind: 'reminder', item: nextReminder })}
+							class="text-base font-bold text-foreground truncate text-left rounded-md px-1 py-0.5 -mx-1 hover:bg-accent transition-colors"
+						>
+							{nextReminder.title}
+						</button>
 					{:else}
 						<span class="text-base font-bold text-muted-foreground italic">—</span>
 					{/if}

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -54,3 +54,18 @@ test('mobile exposes Documents on a companion page @mobile', async ({ asMember }
 	await docs.first().click();
 	await expect(asMember).toHaveURL(`/${COMP}/documents`, { timeout: 8_000 });
 });
+
+// The "Next vet" hero stat surfaces the soonest vet/vaccination reminder.
+// It should open that reminder's detail modal, like the sibling weight stat.
+test('Next vet stat opens the reminder detail modal (#143)', async ({ asMember }) => {
+	await asMember.goto(`/${COMP}`);
+
+	// seed-reminder-1: the soonest vet reminder for Ein.
+	const nextVet = asMember.getByRole('button', { name: 'Annual checkup', exact: true });
+	await expect(nextVet).toBeVisible({ timeout: 8_000 });
+	await nextVet.click();
+
+	const dialog = asMember.getByRole('dialog');
+	await expect(dialog).toBeVisible();
+	await expect(dialog.getByRole('heading', { name: 'Annual checkup' })).toBeVisible();
+});


### PR DESCRIPTION
## Change

The companion dashboard's **Next vet** hero stat surfaces the soonest vet/vaccination reminder, but rendered it as plain text. This makes it a button that opens that reminder's detail modal, matching the sibling **Latest weight** stat (and the upcoming-reminders list, which already opens the same modal).

## Test

Added a `dashboard.spec.ts` test: load the dashboard, click the Next vet stat, assert the reminder detail modal opens with the reminder's title. Full dashboard spec passes (desktop + mobile).

Fixes #143.