### PR TITLE
1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 # EinVault
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.0.3-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
+[![Version](https://img.shields.io/badge/version-1.0.4-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
 
 EinVault is a private, self-hosted companion health and care tracker built for homelabs. Track health records, daily activities, and care schedules for your animal companions. All data stays on your hardware. No cloud, no telemetry, no external accounts.
+
+Want a look before you self-host? There's a read-only demo at **[demo.einvault.app](https://demo.einvault.app)**. Pick a role and explore; nothing you do there sticks.
 
 ## Contents
 


### PR DESCRIPTION
## Summary

Release prep for 1.0.4. The version was already bumped to 1.0.4 in #150; this catches up the bits that lagged:

- README version badge 1.0.3 → 1.0.4.
- Adds a short blurb near the top linking the read-only demo at [demo.einvault.app](https://demo.einvault.app).

No code or schema changes.
