### PR TITLE
Fix(demo): extend caretaker shift past refresh interval

### DIFF
--- a/src/lib/server/db/demo-seed.ts
+++ b/src/lib/server/db/demo-seed.ts
@@ -189,10 +189,19 @@ export function seedUsers(db: BetterSQLite3Database<typeof schema>): void {
  * weight entries, daily events, and reminders. All date-sensitive rows
  * are anchored to `now` so re-anchoring works cleanly.
  */
-export function seedContent(db: BetterSQLite3Database<typeof schema>, opts: { now: number }): void {
+export function seedContent(
+	db: BetterSQLite3Database<typeof schema>,
+	opts: { now: number; shiftEndHours?: number }
+): void {
 	const now = opts.now;
 	const day = 24 * 60 * 60 * 1000;
 	const hour = 60 * 60 * 1000;
+	// How far past `now` the active caretaker shift runs. Defaults to 8h: long
+	// enough for the on-shift experience, short enough that it won't overlap a
+	// shift a test adds for tomorrow. The demo refresh path passes a value that
+	// covers its 24h reseed interval so visitors never land on the off-shift
+	// experience between refreshes (issue #158).
+	const shiftEndHours = opts.shiftEndHours ?? 8;
 
 	const ein = SEED.companions.ein.id;
 	const edward = SEED.companions.edward.id;
@@ -206,14 +215,13 @@ export function seedContent(db: BetterSQLite3Database<typeof schema>, opts: { no
 
 	db.insert(schema.companionCaretakers).values({ companionId: ein, userId: faye }).run();
 
-	// Active shift so the caretaker can see their companion. Runs past the 24h
-	// demo refresh interval so visitors always land on the on-shift experience.
+	// Active shift so the caretaker can see their companion.
 	db.insert(schema.caretakerShifts)
 		.values({
 			id: 'seed-shift-active',
 			userId: faye,
 			startAt: new Date(now - 1 * hour),
-			endAt: new Date(now + 25 * hour)
+			endAt: new Date(now + shiftEndHours * hour)
 		})
 		.run();
 
@@ -846,7 +854,9 @@ export function refreshDemoContent(db: SeedDb, demoMode: boolean, dataDir: strin
 		// companions cascade to: journalEntries -> journalPhotos, healthEvents,
 		// weightEntries, dailyEvents, reminders
 		tx.delete(schema.companions).run();
-		seedContent(tx as never, { now });
+		// Shift runs past the 24h reseed interval so the caretaker stays on-shift
+		// for the whole window between refreshes (issue #158).
+		seedContent(tx as never, { now, shiftEndHours: 25 });
 	});
 	copyDemoPhotoFiles(join(dataDir, 'uploads'), now);
 }

--- a/src/lib/server/db/demo-seed.ts
+++ b/src/lib/server/db/demo-seed.ts
@@ -206,13 +206,14 @@ export function seedContent(db: BetterSQLite3Database<typeof schema>, opts: { no
 
 	db.insert(schema.companionCaretakers).values({ companionId: ein, userId: faye }).run();
 
-	// Active shift so the caretaker can see their companion.
+	// Active shift so the caretaker can see their companion. Runs past the 24h
+	// demo refresh interval so visitors always land on the on-shift experience.
 	db.insert(schema.caretakerShifts)
 		.values({
 			id: 'seed-shift-active',
 			userId: faye,
 			startAt: new Date(now - 1 * hour),
-			endAt: new Date(now + 8 * hour)
+			endAt: new Date(now + 25 * hour)
 		})
 		.run();
 


### PR DESCRIPTION
## Summary

Demo caretaker shift ended at `now + 8h`, but demo content reseeds every 24h (`DEMO_REFRESH_INTERVAL_MS`). That left a 16h window where visitors exploring the caretaker experience landed off-shift.

Extend the shift `endAt` to `now + 25h` so it always covers the full refresh interval with overlap.

Closes #158

## Testing

- `npm run test:unit -- demo-seed` (9/9 pass)