### PR TITLE
Chore: bump version to 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # EinVault
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.0.4-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
+[![Version](https://img.shields.io/badge/version-1.0.5-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
 
 EinVault is a private, self-hosted companion health and care tracker built for homelabs. Track health records, daily activities, and care schedules for your animal companions. All data stays on your hardware. No cloud, no telemetry, no external accounts.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "einvault",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "einvault",
-			"version": "1.0.4",
+			"version": "1.0.5",
 			"dependencies": {
 				"@fontsource-variable/bricolage-grotesque": "^5.2.10",
 				"@fontsource-variable/geist-mono": "5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "einvault",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",


### PR DESCRIPTION
Bump patch version `1.0.4` → `1.0.5`.

- `package.json` + `package-lock.json` version
- README version badge

Covers the demo caretaker shift fix (#158, merged in #159).