### PR TITLE
Fix(docker): patch ffmpeg for CVE-2026-8461

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,11 @@ WORKDIR /app
 # libx264 for H.264 encode. Adds ~100-150MB to the image.
 RUN apk add --no-cache ffmpeg
 
-# Pull in OS security fixes published after the pinned base digest. Currently
-# covers CVE-2026-45447 (libcrypto3/libssl3 3.5.7-r0); no-ops once the node
-# base image catches up. Keep targeted so the layer stays deterministic-ish.
-RUN apk upgrade --no-cache libcrypto3 libssl3
+# Pull in OS security fixes published after the pinned base digest. Covers
+# CVE-2026-45447 (libcrypto3/libssl3 3.5.7-r0) and CVE-2026-8461 (ffmpeg
+# 8.1.2-r0); each no-ops once the node base image catches up. Keep targeted so
+# the layer stays deterministic-ish.
+RUN apk upgrade --no-cache libcrypto3 libssl3 ffmpeg
 
 # Strip npm, npx, corepack, and the bundled yarn from the runtime image. The
 # app starts with `node build` and never invokes a package manager at runtime;


### PR DESCRIPTION
## Problem

The Release workflow's Trivy scan fails on `main`: ffmpeg `8.1.1-r0` in the runner image is flagged HIGH for **CVE-2026-8461** (out-of-bounds write in libavcodec). Reported as 8 HIGH findings — one CVE across all 8 ffmpeg subpackages. Both arch builds fail, skipping `promote`/`merge`.

Not introduced by recent dependency bumps; an OS-package fix (`8.1.2-r0`, Alpine 3.24) landed in the Trivy DB after the pinned base digest.

## Fix

Add `ffmpeg` to the existing targeted `apk upgrade` in the runner stage, matching the established pattern for OS fixes published after the pinned base digest. The `ffmpeg` meta-package pulls all 8 subpackages to `8.1.2-r0`. No-ops once `node:26-alpine` catches up.