### PR TITLE
Fix(docker): upgrade ffmpeg sub-libraries for CVE-2026-8461

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,9 +64,13 @@ RUN apk add --no-cache ffmpeg
 
 # Pull in OS security fixes published after the pinned base digest. Covers
 # CVE-2026-45447 (libcrypto3/libssl3 3.5.7-r0) and CVE-2026-8461 (ffmpeg
-# 8.1.2-r0); each no-ops once the node base image catches up. Keep targeted so
-# the layer stays deterministic-ish.
-RUN apk upgrade --no-cache libcrypto3 libssl3 ffmpeg
+# 8.1.2-r0); each no-ops once the node base image catches up. The ffmpeg sub-
+# libraries are separate packages with shared-object deps, so each must be
+# named explicitly. Keep targeted so the layer stays deterministic-ish.
+RUN apk upgrade --no-cache \
+	libcrypto3 libssl3 \
+	ffmpeg ffmpeg-libavcodec ffmpeg-libavdevice ffmpeg-libavfilter \
+	ffmpeg-libavformat ffmpeg-libavutil ffmpeg-libswresample ffmpeg-libswscale
 
 # Strip npm, npx, corepack, and the bundled yarn from the runtime image. The
 # app starts with `node build` and never invokes a package manager at runtime;


### PR DESCRIPTION
## Follow-up to #167

#167 added `ffmpeg` to the targeted `apk upgrade`, but the Release Trivy scan still failed — **7 HIGH** remaining for CVE-2026-8461. Only the `ffmpeg` meta-package upgraded to 8.1.2-r0; its sub-libraries (`ffmpeg-libavcodec`, `-libavdevice`, `-libavfilter`, `-libavformat`, `-libavutil`, `-libswresample`, `-libswscale`) stayed at 8.1.1-r0.

The sub-libraries are separate Alpine packages linked to the meta only by shared-object deps, so naming `ffmpeg` alone doesn't pull them. 8.1.2-r0 is available for all of them in the Alpine 3.24 repo.

## Fix

Name every ffmpeg package explicitly in the `apk upgrade` line so all 8 move to 8.1.2-r0.

Verification is the Release Trivy scan after merge (the scan does not run in PR CI).