### PR TITLE
Chore: bump version to 1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # EinVault
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.0.5-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
+[![Version](https://img.shields.io/badge/version-1.0.6-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
 
 EinVault is a private, self-hosted companion health and care tracker built for homelabs. Track health records, daily activities, and care schedules for your animal companions. All data stays on your hardware. No cloud, no telemetry, no external accounts.
 
@@ -54,7 +54,6 @@ Want a look before you self-host? There's a read-only demo at **[demo.einvault.a
 - **Reminders:** recurring and one-time reminders for medications, vaccinations, grooming, and more
 - **Search:** full-text search across journals, health, activity, reminders, documents, and media, with `@companion`, `#type`, and date-range filters (members and admins)
 - **Calendar feed:** subscribe to health events, reminders (with recurrence), and shifts from any calendar app or Home Assistant via a personal, revocable ICS URL
-- **Caretaker shifts:** schedule work shifts and export to calendar via iCalendar (.ics)
 - **Role-based access:** admins manage the app, members track health, caretakers log activities
 - **Self-contained:** single Docker container, SQLite database, no external dependencies
 - **Localization:** English, German, Spanish, French, Italian, and Portuguese (non-English translations are AI-generated and may contain errors)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "einvault",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "einvault",
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"dependencies": {
 				"@fontsource-variable/bricolage-grotesque": "^5.2.10",
 				"@fontsource-variable/geist-mono": "5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "einvault",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",


### PR DESCRIPTION
Bumps the patch version to 1.0.6 across `package.json`, `package-lock.json`, and the README version badge.

Also removes the redundant **Caretaker shifts** feature line from the README. The **Calendar feed** entry already covers subscribing to shifts via the ICS URL, making the standalone line duplicative.