### PR TITLE
Fix(immich): support Immich v3 alongside v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,7 +146,7 @@ ORIGIN=https://einvault.yourdomain.com
 
 # API key. Generate in Immich under Account Settings → API Keys. Required
 # permissions: asset.read (list assets), asset.view (fetch thumbnails and
-# image bytes), and album.read (only if IMMICH_ALBUM_ID is set below).
+# image bytes). Works with Immich v2 and v3 servers.
 # IMMICH_API_KEY=
 
 # Optional: restrict the picker to a single album. When set, the picker only

--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ Downloads use short-lived presigned URLs (the app issues a 302 redirect). Access
 
 ### Immich integration (optional)
 
-When `IMMICH_URL` and `IMMICH_API_KEY` are set, members and admins get a "Pick from Immich" option on the journal photo and companion avatar flows. The chosen asset stays in Immich; EinVault stores only a reference and proxies reads through the server using the API key. EinVault never uploads to Immich and never deletes assets from it. Caretakers cannot use the picker.
+When `IMMICH_URL` and `IMMICH_API_KEY` are set, members and admins get a "Pick from Immich" option on the journal photo and companion avatar flows. The chosen asset stays in Immich; EinVault stores only a reference and proxies reads through the server using the API key. EinVault never uploads to Immich and never deletes assets from it. Caretakers cannot use the picker. Immich v2 and v3 servers are supported. Only assets with timeline visibility appear in the picker; archived and locked assets are excluded.
 
-|                   | Default | Description                                                                                                                                                                                  |
-| ----------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `IMMICH_URL`      | —       | Base URL of your Immich server, e.g. `http://immich.local:2283`. No trailing slash. Required if `IMMICH_API_KEY` is set.                                                                     |
-| `IMMICH_API_KEY`  | —       | API key. Required permissions: `asset.read`, `asset.view`, plus `album.read` if `IMMICH_ALBUM_ID` is set. Generate in Immich → Account Settings → API Keys. Required if `IMMICH_URL` is set. |
-| `IMMICH_ALBUM_ID` | —       | If set, the picker only shows assets in this album. If unset, the picker shows the user's most recent assets across the whole library.                                                       |
+|                   | Default | Description                                                                                                                                   |
+| ----------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `IMMICH_URL`      | —       | Base URL of your Immich server, e.g. `http://immich.local:2283`. No trailing slash. Required if `IMMICH_API_KEY` is set.                      |
+| `IMMICH_API_KEY`  | —       | API key. Required permissions: `asset.read`, `asset.view`. Generate in Immich → Account Settings → API Keys. Required if `IMMICH_URL` is set. |
+| `IMMICH_ALBUM_ID` | —       | If set, the picker only shows assets in this album. If unset, the picker shows the user's most recent assets across the whole library.        |
 
 ### Documents
 

--- a/src/lib/server/storage/immich.test.ts
+++ b/src/lib/server/storage/immich.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { startImmichFake, makeImmichAsset, type ImmichFake } from '../../../../tests/fakes/immich';
+import { createImmichClient, type ImmichClient } from './immich';
+
+// The fake mimics Immich v3: album responses carry no assets[], search
+// validates integers and honors albumIds/visibility/type. The same request
+// surface exists on v2, so passing here means the client works on both.
+describe('createImmichClient listAssets', () => {
+	let fake: ImmichFake;
+	let client: ImmichClient;
+	const ALBUM_ID = 'album-1';
+
+	beforeAll(async () => {
+		fake = await startImmichFake();
+		client = createImmichClient({ url: fake.url, apiKey: fake.apiKey, albumId: null });
+	});
+	afterAll(async () => {
+		await fake.stop();
+	});
+	beforeEach(() => {
+		fake.reset();
+	});
+
+	it('album mode returns only assets belonging to the album', async () => {
+		fake.setAssets([makeImmichAsset('in-1'), makeImmichAsset('in-2'), makeImmichAsset('out-1')]);
+		fake.setAlbum(ALBUM_ID, ['in-1', 'in-2']);
+
+		const { items, hasNextPage } = await client.listAssets({
+			page: 1,
+			pageSize: 10,
+			albumId: ALBUM_ID
+		});
+		expect(items.map((a) => a.id)).toEqual(['in-1', 'in-2']);
+		expect(hasNextPage).toBe(false);
+	});
+
+	it('album mode paginates server-side', async () => {
+		fake.setAssets([makeImmichAsset('a1'), makeImmichAsset('a2'), makeImmichAsset('a3')]);
+		fake.setAlbum(ALBUM_ID, ['a1', 'a2', 'a3']);
+
+		const page1 = await client.listAssets({ page: 1, pageSize: 2, albumId: ALBUM_ID });
+		expect(page1.items.map((a) => a.id)).toEqual(['a1', 'a2']);
+		expect(page1.hasNextPage).toBe(true);
+
+		const page2 = await client.listAssets({ page: 2, pageSize: 2, albumId: ALBUM_ID });
+		expect(page2.items.map((a) => a.id)).toEqual(['a3']);
+		expect(page2.hasNextPage).toBe(false);
+	});
+
+	it('album mode excludes videos via the server-side type filter', async () => {
+		fake.setAssets([makeImmichAsset('img'), makeImmichAsset('vid', { type: 'VIDEO' })]);
+		fake.setAlbum(ALBUM_ID, ['img', 'vid']);
+
+		const { items } = await client.listAssets({ page: 1, pageSize: 10, albumId: ALBUM_ID });
+		expect(items.map((a) => a.id)).toEqual(['img']);
+	});
+
+	it('excludes archived assets in album mode despite v3 widened search defaults', async () => {
+		fake.setAssets([
+			makeImmichAsset('shown'),
+			makeImmichAsset('hidden', { visibility: 'archive' })
+		]);
+		fake.setAlbum(ALBUM_ID, ['shown', 'hidden']);
+
+		const { items } = await client.listAssets({ page: 1, pageSize: 10, albumId: ALBUM_ID });
+		expect(items.map((a) => a.id)).toEqual(['shown']);
+	});
+
+	it('excludes archived assets in search mode despite v3 widened search defaults', async () => {
+		fake.setAssets([
+			makeImmichAsset('shown'),
+			makeImmichAsset('hidden', { visibility: 'archive' })
+		]);
+
+		const { items } = await client.listAssets({ page: 1, pageSize: 10 });
+		expect(items.map((a) => a.id)).toEqual(['shown']);
+	});
+
+	it('search mode paginates via Immich nextPage', async () => {
+		fake.setAssets([makeImmichAsset('a1'), makeImmichAsset('a2'), makeImmichAsset('a3')]);
+
+		const page1 = await client.listAssets({ page: 1, pageSize: 2 });
+		expect(page1.items.map((a) => a.id)).toEqual(['a1', 'a2']);
+		expect(page1.hasNextPage).toBe(true);
+
+		const page2 = await client.listAssets({ page: 2, pageSize: 2 });
+		expect(page2.items.map((a) => a.id)).toEqual(['a3']);
+		expect(page2.hasNextPage).toBe(false);
+	});
+});

--- a/src/lib/server/storage/immich.ts
+++ b/src/lib/server/storage/immich.ts
@@ -10,10 +10,6 @@ export const ASSET_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-
 // should reply in well under a second; a hung Immich must not stall workers.
 const DEFAULT_TIMEOUT_MS = 8_000;
 
-// Soft cap for album-mode listAssets. Immich's /albums/{id} returns every
-// asset in one shot, so a very large album would blow up memory.
-const ALBUM_ASSET_CAP = 5_000;
-
 export function immichKey(assetId: string): string {
 	return `${KEY_PREFIX}${assetId}`;
 }
@@ -138,10 +134,6 @@ interface ImmichSearchResponse {
 	};
 }
 
-interface ImmichAlbumResponse {
-	assets?: ImmichAssetResponse[];
-}
-
 function summarize(a: ImmichAssetResponse): ImmichAssetSummary {
 	return {
 		id: a.id,
@@ -161,36 +153,11 @@ export function createImmichClient(config: ImmichConfig): ImmichClient {
 
 	return {
 		async listAssets({ page, pageSize, albumId }) {
-			// Album mode: fetch the album once, then page client-side. Immich's
-			// /albums/{id} endpoint returns all assets in one response, which is
-			// fine for typical homelab album sizes but capped here as a guard
-			// against giant albums.
-			if (albumId) {
-				const res = await fetch(`${config.url}/api/albums/${albumId}`, {
-					headers: headers(),
-					signal: timeoutSignal()
-				});
-				if (!res.ok) {
-					throw await logAndSanitize(`album=${albumId}`, res, 'Immich album fetch failed');
-				}
-				const body = (await res.json()) as ImmichAlbumResponse;
-				const raw = body.assets ?? [];
-				if (raw.length > ALBUM_ASSET_CAP) {
-					console.warn(
-						`[immich] album ${albumId} has ${raw.length} assets; capping picker to first ${ALBUM_ASSET_CAP}`
-					);
-				}
-				const all = raw
-					.slice(0, ALBUM_ASSET_CAP)
-					.filter((a) => a.type !== 'VIDEO')
-					.map(summarize);
-				const start = (page - 1) * pageSize;
-				const items = all.slice(start, start + pageSize);
-				return { items, hasNextPage: start + pageSize < all.length };
-			}
-
-			// No album: use the search endpoint, newest first. Pagination is
-			// handled by Immich.
+			// Single code path for Immich v2 and v3. v3 removed assets[] from
+			// /albums/{id}, but /search/metadata accepts an albumIds filter on
+			// both versions, so album mode is just a filtered search. visibility
+			// is pinned to 'timeline' because v3's search default widened to all
+			// visibilities and would otherwise surface archived assets.
 			const res = await fetch(`${config.url}/api/search/metadata`, {
 				method: 'POST',
 				headers: { ...headers(), 'Content-Type': 'application/json' },
@@ -198,12 +165,18 @@ export function createImmichClient(config: ImmichConfig): ImmichClient {
 					page,
 					size: pageSize,
 					type: 'IMAGE',
-					order: 'desc'
+					order: 'desc',
+					visibility: 'timeline',
+					...(albumId ? { albumIds: [albumId] } : {})
 				}),
 				signal: timeoutSignal()
 			});
 			if (!res.ok) {
-				throw await logAndSanitize('search', res, 'Immich search failed');
+				throw await logAndSanitize(
+					albumId ? `search album=${albumId}` : 'search',
+					res,
+					'Immich search failed'
+				);
 			}
 			const body = (await res.json()) as ImmichSearchResponse;
 			const items = (body.assets?.items ?? []).map(summarize);

--- a/tests/e2e/calendar.spec.ts
+++ b/tests/e2e/calendar.spec.ts
@@ -8,19 +8,27 @@ import { test, expect } from '../lib/fixtures';
 // hidden, so the first visible one is always the feed URL.
 async function enableAndGetUrl(page: Page, settingsPath: string): Promise<string> {
 	await page.goto(settingsPath);
-	await page.getByRole('button', { name: 'Enable calendar feed' }).click();
-	// After the form POST the page reloads. The readonly calendar URL input
-	// appears inside the revealed card section.
+	// With fullyParallel scheduling, an earlier calendar test in the same
+	// worker may have left the feed enabled — the card then shows the feed URL
+	// instead of the Enable button. The two states are mutually exclusive, so
+	// wait until either renders (isVisible alone would race hydration), then
+	// click Enable only when the feed is still disabled.
+	const enableButton = page.getByRole('button', { name: 'Enable calendar feed' });
 	const urlInput = page.locator('input[readonly].font-mono');
+	await expect(enableButton.or(urlInput)).toBeVisible({ timeout: 15_000 });
+	if (await enableButton.isVisible()) {
+		// After the form POST the page reloads and reveals the URL card.
+		await enableButton.click();
+	}
 	await expect(urlInput).toBeVisible({ timeout: 8_000 });
 	return await urlInput.inputValue();
 }
 
 // These tests mutate the shared asMember / asCaretaker user's calendar feed
-// token (enable/regenerate/disable). Playwright runs a single spec file's tests
-// serially in one worker by default, so they don't collide. Do NOT add
-// describe parallel mode or run this file with --repeat-each across workers:
-// duplicate copies would clobber each other's token on the same user.
+// token (enable/regenerate/disable). Tests from this file may run in any
+// order across workers (fullyParallel), but each worker has its own database,
+// so the only shared state is within a worker — which enableAndGetUrl
+// tolerates. Do NOT assume the feed is disabled at the start of a test.
 test.describe('calendar feed', () => {
 	test('member enable + fetch: 200 text/calendar with VCALENDAR wrapper', async ({
 		asMember,

--- a/tests/e2e/immich.spec.ts
+++ b/tests/e2e/immich.spec.ts
@@ -12,9 +12,10 @@ interface ImmichWorld {
 	fake: ImmichFake;
 }
 
-const test = base.extend<{ world: ImmichWorld }>({
-	// eslint-disable-next-line no-empty-pattern
-	world: async ({}, use, testInfo) => {
+const test = base.extend<{ albumId: string | undefined; world: ImmichWorld }>({
+	// Set via test.use({ albumId }) to boot the app in album mode.
+	albumId: [undefined, { option: true }],
+	world: async ({ albumId }, use, testInfo) => {
 		const dir = path.join(
 			REPO_ROOT,
 			'.test-data',
@@ -28,8 +29,9 @@ const test = base.extend<{ world: ImmichWorld }>({
 				dbPath,
 				env: {
 					IMMICH_URL: fake.url,
-					IMMICH_API_KEY: fake.apiKey
+					IMMICH_API_KEY: fake.apiKey,
 					// No IMMICH_ALBUM_ID → recent-assets (search/metadata) path
+					...(albumId ? { IMMICH_ALBUM_ID: albumId } : {})
 				}
 			});
 		} catch (err) {
@@ -129,6 +131,33 @@ test('journal photo from Immich', async ({ world, page }) => {
 	await page.reload();
 	const photoImgAfterReload = page.locator('img[src*="/api/photos/journal/"]');
 	await expect(photoImgAfterReload).toBeVisible({ timeout: 10_000 });
+});
+
+test.describe('album mode', () => {
+	const ALBUM_ID = '00000000-0000-0000-0000-00000000a1b0';
+	test.use({ albumId: ALBUM_ID });
+
+	test('picker lists only assets from the configured album', async ({ world, page }) => {
+		world.fake.setAssets(ASSETS);
+		world.fake.setAlbum(ALBUM_ID, [ASSET_ID_1, ASSET_ID_2]);
+
+		await login(page, world.server.baseURL, SEED.member.username);
+		await page.goto(world.server.baseURL + `/companions/${EIN_ID}/edit`);
+		await page
+			.getByRole('button', { name: /pick from immich/i })
+			.first()
+			.click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+		// Album members appear; the out-of-album asset must not.
+		await expect(dialog.locator(`img[src*="/api/immich/thumbnail/${ASSET_ID_1}"]`)).toBeVisible({
+			timeout: 10_000
+		});
+		await expect(dialog.locator(`img[src*="/api/immich/thumbnail/${ASSET_ID_2}"]`)).toBeVisible();
+		await expect(dialog.locator(`img[src*="/api/immich/thumbnail/${ASSET_ID_3}"]`)).toHaveCount(0);
+	});
 });
 
 test('caretaker is blocked from the Immich assets API', async ({ world, browser }) => {

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -62,8 +62,10 @@ test.describe('global search palette', () => {
 
 		await asMember.keyboard.type('Wellness checkup');
 
-		// Wait for the Health group heading to appear
-		await expect(asMember.getByText('Health')).toBeVisible({ timeout: 8_000 });
+		// Wait for the Health group heading inside the dialog. Scoped and exact:
+		// a bare getByText('Health') substring-matches rows like
+		// 'e2e-health-edit' that other specs leave in this worker's database.
+		await expect(dialog.getByText('Health', { exact: true })).toBeVisible({ timeout: 8_000 });
 
 		// The result should be visible
 		await expect(dialog.getByText('Wellness checkup')).toBeVisible({ timeout: 8_000 });

--- a/tests/fakes/immich.test.ts
+++ b/tests/fakes/immich.test.ts
@@ -29,9 +29,41 @@ describe('immich fake', () => {
 		expect(body.assets.nextPage).toBe('2');
 	});
 
-	it('serves album contents, single assets, and image bytes', async () => {
+	it('rejects non-integer page/size like v3 Zod validation', async () => {
+		const res = await fetch(`${fake.url}/api/search/metadata`, {
+			method: 'POST',
+			headers: { ...auth(), 'content-type': 'application/json' },
+			body: JSON.stringify({ page: 1.5, size: 2 })
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('filters search by albumIds and visibility', async () => {
+		fake.setAlbum('alb-1', ['a1', 'a3']);
+		const search = async (extra: object) => {
+			const res = await fetch(`${fake.url}/api/search/metadata`, {
+				method: 'POST',
+				headers: { ...auth(), 'content-type': 'application/json' },
+				body: JSON.stringify({ page: 1, size: 10, ...extra })
+			});
+			const body = (await res.json()) as { assets: { items: { id: string }[] } };
+			return body.assets.items.map((i) => i.id);
+		};
+		expect(await search({ albumIds: ['alb-1'] })).toEqual(['a1', 'a3']);
+		expect(await search({ albumIds: ['other'] })).toEqual([]);
+		// Omitting visibility returns everything (v3 widened default);
+		// visibility: 'timeline' hides the archived asset.
+		fake.setAssets([makeImmichAsset('a1'), makeImmichAsset('a2', { visibility: 'archive' })]);
+		expect(await search({})).toEqual(['a1', 'a2']);
+		expect(await search({ visibility: 'timeline' })).toEqual(['a1']);
+		fake.setAssets([makeImmichAsset('a1'), makeImmichAsset('a2'), makeImmichAsset('a3')]);
+	});
+
+	it('serves v3-shaped albums (no assets[]), single assets, and image bytes', async () => {
 		const album = await fetch(`${fake.url}/api/albums/alb-1`, { headers: auth() });
-		expect(((await album.json()) as { assets: unknown[] }).assets).toHaveLength(3);
+		const albumBody = (await album.json()) as { id: string; assets?: unknown[] };
+		expect(albumBody.id).toBe('alb-1');
+		expect(albumBody.assets).toBeUndefined();
 
 		const asset = await fetch(`${fake.url}/api/assets/a2`, { headers: auth() });
 		expect(((await asset.json()) as { id: string }).id).toBe('a2');

--- a/tests/fakes/immich.ts
+++ b/tests/fakes/immich.ts
@@ -1,15 +1,24 @@
 /**
  * Minimal Immich API fake for unit and e2e tests.
  *
+ * Mimics the Immich v3 API surface: /albums/{id} responses carry no assets[],
+ * /search/metadata validates page/size as integers (Zod-style) and honors the
+ * albumIds, type, and visibility filters. When visibility is omitted the fake
+ * returns assets of every visibility, matching v3's widened search default.
+ * The request surface it accepts is identical on v2, so a client that passes
+ * against this fake works on both.
+ *
  * App env wiring for specs that exercise Immich storage:
  *   STORAGE_BACKEND=immich
  *   IMMICH_URL=<fake.url>              (e.g. http://127.0.0.1:<port>)
  *   IMMICH_API_KEY=immich-test-key
- *   IMMICH_ALBUM_ID=<albumId>          (optional; omit to use search/metadata mode)
+ *   IMMICH_ALBUM_ID=<albumId>          (optional; omit for recent-assets mode)
  */
 
 import http from 'node:http';
 import type { Fake } from './types';
+
+export type ImmichVisibility = 'timeline' | 'archive' | 'hidden' | 'locked';
 
 export interface ImmichAsset {
 	id: string;
@@ -19,13 +28,16 @@ export interface ImmichAsset {
 	thumbhash: string | null;
 	fileCreatedAt: string;
 	type: 'IMAGE' | 'VIDEO';
+	visibility: ImmichVisibility;
 }
 
 export interface ImmichFake extends Fake {
 	port: number;
 	apiKey: string;
-	/** Replace the asset library (also used for album contents). */
+	/** Replace the asset library. */
 	setAssets(assets: ImmichAsset[]): void;
+	/** Declare which asset ids belong to an album (for albumIds search filtering). */
+	setAlbum(albumId: string, assetIds: string[]): void;
 	/** Raw bytes served for thumbnail/original requests. */
 	imageBytes: Buffer;
 }
@@ -45,12 +57,14 @@ export function makeImmichAsset(id: string, overrides?: Partial<ImmichAsset>): I
 		thumbhash: null,
 		fileCreatedAt: '2026-01-01T00:00:00.000Z',
 		type: 'IMAGE',
+		visibility: 'timeline',
 		...overrides
 	};
 }
 
 export async function startImmichFake(apiKey = 'immich-test-key'): Promise<ImmichFake> {
 	let assets: ImmichAsset[] = [];
+	let albums = new Map<string, string[]>();
 
 	const server = http.createServer((req, res) => {
 		if (req.headers['x-api-key'] !== apiKey) {
@@ -68,11 +82,29 @@ export async function startImmichFake(apiKey = 'immich-test-key'): Promise<Immic
 				const body = JSON.parse(Buffer.concat(chunks).toString() || '{}') as {
 					page?: number;
 					size?: number;
+					type?: string;
+					visibility?: string;
+					albumIds?: string[];
 				};
 				const page = body.page ?? 1;
 				const size = body.size ?? 100;
-				const items = assets.slice((page - 1) * size, page * size);
-				const hasNext = page * size < assets.length;
+				if (!Number.isInteger(page) || !Number.isInteger(size)) {
+					json(400, { message: ['page must be an integer', 'size must be an integer'] });
+					return;
+				}
+				let pool = assets;
+				if (body.albumIds) {
+					const members = new Set(body.albumIds.flatMap((id) => albums.get(id) ?? []));
+					pool = pool.filter((a) => members.has(a.id));
+				}
+				if (body.type) {
+					pool = pool.filter((a) => a.type === body.type);
+				}
+				if (body.visibility) {
+					pool = pool.filter((a) => a.visibility === body.visibility);
+				}
+				const items = pool.slice((page - 1) * size, page * size);
+				const hasNext = page * size < pool.length;
 				json(200, { assets: { items, nextPage: hasNext ? String(page + 1) : null } });
 			});
 			return;
@@ -80,7 +112,8 @@ export async function startImmichFake(apiKey = 'immich-test-key'): Promise<Immic
 
 		const albumMatch = /^\/api\/albums\/([^/]+)$/.exec(url.pathname);
 		if (req.method === 'GET' && albumMatch) {
-			json(200, { id: albumMatch[1], assets });
+			// v3 album responses carry metadata only; assets[] was removed.
+			json(200, { id: albumMatch[1], albumName: 'fake album', assetCount: assets.length });
 			return;
 		}
 
@@ -126,8 +159,12 @@ export async function startImmichFake(apiKey = 'immich-test-key'): Promise<Immic
 		setAssets(next) {
 			assets = next;
 		},
+		setAlbum(albumId, assetIds) {
+			albums.set(albumId, assetIds);
+		},
 		reset() {
 			assets = [];
+			albums = new Map();
 		},
 		stop: () => new Promise((resolve) => server.close(() => resolve()))
 	};


### PR DESCRIPTION
Closes #170.

Immich v3 removed `assets[]` from album responses, which broke the album-scoped picker. Instead of branching on server version, album mode now lists assets through `POST /api/search/metadata` with an `albumIds` filter. That endpoint and filter exist on both v2 and v3 (verified against the published OpenAPI specs for v2.0.0 and v3.0.1), so a single code path serves both versions.

All search calls now pin `visibility: 'timeline'`. v3 widened the search default to every visibility, which would otherwise start surfacing archived assets in the picker.

## Changes

- `listAssets()` album mode switched from `GET /api/albums/{id}` to the filtered search path; the album asset cap and album response parsing are gone since pagination is now server-side in both modes.
- The API key no longer needs the `album.read` permission (`searchAssets` requires only `asset.read` on both versions). README and `.env.example` updated accordingly, plus a note on supported Immich versions.
- The test fake now mirrors the v3 API shape: album responses carry no `assets[]`, search honors `albumIds`/`type`/`visibility`, and non-integer `page`/`size` are rejected the way v3's Zod validation does.
- New unit tests cover the client against the fake (album filtering, pagination, archived and video exclusion), and a new e2e test runs the picker in album mode.
- Fixed two pre-existing e2e flakes that fullyParallel scheduling exposes: the calendar `enableAndGetUrl` helper now tolerates a feed already enabled by an earlier test in the same worker, and the search palette assertion for the Health group heading is dialog-scoped and exact so it cannot match `e2e-health-*` rows left by other specs.

## Testing

- Unit and e2e suites green (three consecutive full local runs).
- Smoke-tested against real Immich v2.7.5 and v3.0.1 instances with an API key scoped to `asset.read` + `asset.view`: library and album mode both return the expected assets on both versions.
- Manually verified the picker in all four combinations (v2/v3 crossed with library/album mode), including that archived assets stay hidden.

Behavior note: album mode now orders newest-first (matching library mode) instead of album order.
