### PR TITLE
Fix(quick-log): log directly when only one companion is targetable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # EinVault
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.1.0-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
+[![Version](https://img.shields.io/badge/version-1.1.1-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
 
 EinVault is a private, self-hosted companion health and care tracker built for homelabs. Track health records, daily activities, and care schedules for your animal companions. All data stays on your hardware. No cloud, no telemetry, no external accounts.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "einvault",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "einvault",
-			"version": "1.1.0",
+			"version": "1.1.1",
 			"dependencies": {
 				"@asteasolutions/zod-to-openapi": "^8.5.0",
 				"@fontsource-variable/bricolage-grotesque": "^5.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "einvault",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",

--- a/src/lib/components/log/QuickLogButtons.svelte
+++ b/src/lib/components/log/QuickLogButtons.svelte
@@ -40,6 +40,7 @@
 	let selectedIds = $state<string[]>([]);
 	let remember = $state(true);
 	let executedId = $state<string | null>(null);
+	let submittingId = $state<string | null>(null);
 
 	function toggle(button: QuickLogButton) {
 		if (openId === button.id) {
@@ -74,17 +75,50 @@
 
 		<div class="flex flex-wrap gap-2">
 			{#each buttons as button (button.id)}
-				<button
-					type="button"
-					onclick={() => toggle(button)}
-					class="inline-flex items-center gap-1.5 rounded-xl border px-3 py-2 text-sm font-medium transition-colors
-					{openId === button.id
-						? 'bg-primary/10 border-primary/30 text-primary'
-						: 'border-border bg-card text-foreground hover:bg-accent hover:text-accent-foreground'}"
-				>
-					<span>{ACTIVITY_ICONS[button.type] ?? '📝'}</span>
-					<span>{button.name}</span>
-				</button>
+				{#if button.companionIds.length === 1}
+					<!-- Single target → nothing to pick; log directly on click (#175). -->
+					<form
+						method="POST"
+						{action}
+						class="contents"
+						use:enhance={() => {
+							submittingId = button.id;
+							executedId = null;
+							return async ({ result, update }) => {
+								submittingId = null;
+								await update({ reset: false });
+								if (result.type === 'success') {
+									executedId = button.id;
+									openId = null;
+								}
+							};
+						}}
+					>
+						<input type="hidden" name="quickLogId" value={button.id} />
+						<input type="hidden" name="companionIds" value={button.companionIds[0]} />
+						<button
+							type="submit"
+							disabled={submittingId === button.id}
+							title={t(locale, 'quickLog.execute.logNow', { name: button.name })}
+							class="inline-flex items-center gap-1.5 rounded-xl border border-border bg-card px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-60"
+						>
+							<span>{ACTIVITY_ICONS[button.type] ?? '📝'}</span>
+							<span>{button.name}</span>
+						</button>
+					</form>
+				{:else}
+					<button
+						type="button"
+						onclick={() => toggle(button)}
+						class="inline-flex items-center gap-1.5 rounded-xl border px-3 py-2 text-sm font-medium transition-colors
+						{openId === button.id
+							? 'bg-primary/10 border-primary/30 text-primary'
+							: 'border-border bg-card text-foreground hover:bg-accent hover:text-accent-foreground'}"
+					>
+						<span>{ACTIVITY_ICONS[button.type] ?? '📝'}</span>
+						<span>{button.name}</span>
+					</button>
+				{/if}
 			{/each}
 		</div>
 

--- a/tests/e2e/quick-log.spec.ts
+++ b/tests/e2e/quick-log.spec.ts
@@ -51,7 +51,10 @@ test.describe('member quick log', () => {
 		const submit = asMember.getByRole('button', { name: /^Log / });
 		await expect(submit).toBeDisabled();
 
-		await asMember.locator(`input[name="companionIds"][value="${EIN}"]`).click({ force: true });
+		// Scope to the daily log form: single-target custom quick log pills carry
+		// hidden companionIds inputs of their own elsewhere on the dashboard.
+		const dailyForm = asMember.locator('form', { has: asMember.locator('textarea[name="notes"]') });
+		await dailyForm.locator(`input[name="companionIds"][value="${EIN}"]`).click({ force: true });
 		await asMember.locator('textarea[name="notes"]').fill('e2e dashboard treat');
 		await asMember.locator('input[name="type"][value="treat"]').click({ force: true });
 		await submit.click();

--- a/tests/e2e/quick-logs.spec.ts
+++ b/tests/e2e/quick-logs.spec.ts
@@ -92,6 +92,27 @@ test.describe('custom quick logs', () => {
 		await expect(asAdmin.getByText('Evening walk')).toBeVisible();
 	});
 
+	test('quick log with a single assigned companion logs in one click', async ({ asMember }) => {
+		// Create assigned to Ein only (uncheck Edward).
+		await asMember.goto('/settings/quick-logs');
+		await asMember.getByRole('button', { name: 'Add quick log' }).click();
+		await asMember.locator('input[name="name"]').fill('Sardine snack');
+		await asMember.locator('label').filter({ hasText: /Treat/i }).first().click();
+		await asMember.locator('label').filter({ hasText: 'Edward' }).first().click();
+		await asMember.locator('textarea[name="note"]').fill('ate one sardine');
+		await asMember.getByRole('button', { name: 'Save', exact: true }).click();
+		await expect(asMember.getByText('Sardine snack')).toBeVisible();
+
+		// One click on the companion page logs it — no target picker step.
+		await asMember.goto(`/${EIN}`);
+		await asMember.getByRole('button', { name: /Sardine snack/ }).click();
+		await expect(asMember.getByText(/Activity logged/)).toBeVisible();
+		await expect(asMember.getByRole('button', { name: /Log Sardine snack/ })).toHaveCount(0);
+
+		// Recent activity timeline picks up the entry without a reload.
+		await expect(asMember.getByText('ate one sardine').first()).toBeVisible();
+	});
+
 	test('caretaker manages quick logs scoped to assigned companions', async ({ asCaretaker }) => {
 		await asCaretaker.goto('/care/settings/quick-logs');
 		await asCaretaker.getByRole('button', { name: 'Add quick log' }).click();
@@ -103,13 +124,18 @@ test.describe('custom quick logs', () => {
 		);
 
 		await asCaretaker.locator('input[name="name"]').fill('Care walk');
+		await asCaretaker.locator('textarea[name="note"]').fill('around the park');
 		await asCaretaker.getByRole('button', { name: 'Save', exact: true }).click();
 		await expect(asCaretaker.getByText('Care walk')).toBeVisible();
 
-		// The button renders on the care page (seeded caretaker is on shift) and executes.
+		// The button renders on the care page (seeded caretaker is on shift). With a
+		// single assigned companion it logs in one click — no target picker step.
 		await asCaretaker.goto(`/care/${EIN}`);
 		await asCaretaker.getByRole('button', { name: /Care walk/ }).click();
-		await asCaretaker.getByRole('button', { name: /Log Care walk/ }).click();
 		await expect(asCaretaker.getByText(/Activity logged/)).toBeVisible();
+		await expect(asCaretaker.getByRole('button', { name: /Log Care walk/ })).toHaveCount(0);
+
+		// Today's activity refreshes in place (no reload).
+		await expect(asCaretaker.getByText('around the park').first()).toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary

Closes #175.

- Quick log buttons whose visible companion set (`button.companionIds`) has exactly one entry now log immediately on click: the pill renders as a direct-submit form with hidden `quickLogId` and `companionIds` inputs, so there is no picker panel with nothing to pick. The pill is disabled while submitting and reuses the existing success/error banners.
- Buttons with two or more targetable companions keep the current panel flow, including the remember checkbox.
- No server changes: `handleQuickLogExecute` already accepts a single companion id, and the `remember` field is simply omitted (nothing to remember for one target).
- The Recent Activity feed already refreshed without a reload via `enhance`'s default `invalidateAll` in `update({ reset: false })`; e2e assertions now pin that behavior on both the member timeline and the caretaker Today's activity list.

## Tests

- New e2e case: member quick log assigned to a single companion logs in one click and the activity timeline picks up the note without a reload.
- Caretaker e2e case updated to the one-click flow with a feed-refresh assertion.
- Dashboard daily-log e2e locator scoped to the daily form: single-target pills now carry always-rendered hidden `companionIds` inputs, which collided with the old page-wide selector under strict mode.

Verified: `npm run check` and `npm run lint` clean, 321 unit tests pass, both quick log e2e specs pass (8/8) against a fresh build.