### PR TITLE
Fix mobile settings access and page header overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # EinVault
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.1.1-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
+[![Version](https://img.shields.io/badge/version-1.1.2-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
 
 EinVault is a private, self-hosted companion health and care tracker built for homelabs. Track health records, daily activities, and care schedules for your animal companions. All data stays on your hardware. No cloud, no telemetry, no external accounts.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "einvault",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "einvault",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"dependencies": {
 				"@asteasolutions/zod-to-openapi": "^8.5.0",
 				"@fontsource-variable/bricolage-grotesque": "^5.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "einvault",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",

--- a/src/lib/components/PageHeader.svelte
+++ b/src/lib/components/PageHeader.svelte
@@ -18,11 +18,14 @@
 	} = $props();
 </script>
 
-<div class="flex items-center gap-3">
+<div class="flex flex-wrap items-center gap-3">
 	<div class="h-9 w-9 rounded-xl flex items-center justify-center shrink-0 {pageIconClass(tint)}">
 		{@render icon()}
 	</div>
-	<div class="min-w-0 flex-1">
+	<!-- flex-auto (not flex-1): a 0% flex-basis would let the actions stay on
+	     the row while the title overflows over them; with basis auto the row
+	     wraps when title + actions don't fit. -->
+	<div class="min-w-0 flex-auto">
 		<h1 class="font-display text-2xl font-bold text-foreground">{title}</h1>
 		{#if subtitle}
 			<p class="text-sm text-muted-foreground">{subtitle}</p>

--- a/src/lib/components/shell/AppMobileNav.svelte
+++ b/src/lib/components/shell/AppMobileNav.svelte
@@ -63,8 +63,11 @@
 
 	let accountOpen = $state(false);
 
+	// Close the sheet on any navigation (e.g. browser back) so it never
+	// lingers over a page it wasn't opened on.
 	$effect(() => {
-		if (isCompanionContext) accountOpen = false;
+		void page.url.pathname;
+		accountOpen = false;
 	});
 
 	// Companion context nav tabs (4 + central FAB)
@@ -229,6 +232,22 @@
 		>
 			<Search class="h-5 w-5" />
 		</button>
+		{#if isCompanionContext && user}
+			<button
+				type="button"
+				onclick={() => (accountOpen = true)}
+				aria-label={t(locale, 'aria.openAccountMenu')}
+				aria-haspopup="dialog"
+				class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg transition-colors hover:bg-accent"
+			>
+				<UserAvatar
+					userId={user.id}
+					displayName={user.displayName}
+					avatarPath={user.avatarPath}
+					size="sm"
+				/>
+			</button>
+		{/if}
 	</div>
 </header>
 
@@ -351,6 +370,6 @@
 	</div>
 </nav>
 
-{#if user && !isCompanionContext}
+{#if user}
 	<AccountSheet {user} open={accountOpen} onclose={() => (accountOpen = false)} variant="sheet" />
 {/if}

--- a/src/lib/i18n/de.ts
+++ b/src/lib/i18n/de.ts
@@ -1013,6 +1013,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.closeSwitcher': 'Begleiterauswahl schließen',
 	'aria.accountMenu': 'Kontomenü',
 	'aria.closeAccountMenu': 'Kontomenü schließen',
+	'aria.openAccountMenu': 'Kontomenü öffnen',
 	'aria.searchResults': 'Suchergebnisse',
 	'theme.light': 'Hell',
 	'theme.dark': 'Dunkel',

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -990,6 +990,7 @@ const messages = {
 	'aria.closeSwitcher': 'Close companion switcher',
 	'aria.accountMenu': 'Account menu',
 	'aria.closeAccountMenu': 'Close account menu',
+	'aria.openAccountMenu': 'Open account menu',
 	'aria.searchResults': 'Search results',
 	'theme.light': 'Light',
 	'theme.dark': 'Dark',

--- a/src/lib/i18n/es.ts
+++ b/src/lib/i18n/es.ts
@@ -1008,6 +1008,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.closeSwitcher': 'Cerrar selector de compañero',
 	'aria.accountMenu': 'Menú de cuenta',
 	'aria.closeAccountMenu': 'Cerrar menú de cuenta',
+	'aria.openAccountMenu': 'Abrir menú de cuenta',
 	'aria.searchResults': 'Resultados de búsqueda',
 	'theme.light': 'Claro',
 	'theme.dark': 'Oscuro',

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -1014,6 +1014,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.closeSwitcher': 'Fermer le sélecteur de compagnon',
 	'aria.accountMenu': 'Menu du compte',
 	'aria.closeAccountMenu': 'Fermer le menu du compte',
+	'aria.openAccountMenu': 'Ouvrir le menu du compte',
 	'aria.searchResults': 'Résultats de recherche',
 	'theme.light': 'Clair',
 	'theme.dark': 'Sombre',

--- a/src/lib/i18n/it.ts
+++ b/src/lib/i18n/it.ts
@@ -1008,6 +1008,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.closeSwitcher': 'Chiudi selettore compagno',
 	'aria.accountMenu': 'Menu account',
 	'aria.closeAccountMenu': 'Chiudi menu account',
+	'aria.openAccountMenu': 'Apri menu account',
 	'aria.searchResults': 'Risultati di ricerca',
 	'theme.light': 'Chiaro',
 	'theme.dark': 'Scuro',

--- a/src/lib/i18n/pt.ts
+++ b/src/lib/i18n/pt.ts
@@ -1008,6 +1008,7 @@ const messages: Record<keyof Messages, string> = {
 	'aria.closeSwitcher': 'Fechar seletor de companheiro',
 	'aria.accountMenu': 'Menu da conta',
 	'aria.closeAccountMenu': 'Fechar menu da conta',
+	'aria.openAccountMenu': 'Abrir menu da conta',
 	'aria.searchResults': 'Resultados da pesquisa',
 	'theme.light': 'Claro',
 	'theme.dark': 'Escuro',

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -56,6 +56,55 @@ test('member You tab opens account sheet with Settings + Sign Out only @mobile',
 	await expect(sheet.getByRole('link', { name: 'Companions' })).toHaveCount(0);
 });
 
+test('companion page top bar avatar opens account sheet @mobile', async ({
+	asMember
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asMember.goto(`/${EIN}`);
+	const avatarButton = asMember.getByRole('button', { name: 'Open account menu' });
+	await expect(avatarButton).toBeVisible({ timeout: 8_000 });
+	await avatarButton.click();
+
+	const sheet = asMember.getByRole('dialog', { name: 'Account menu' });
+	await expect(sheet).toBeVisible({ timeout: 8_000 });
+	await expect(sheet.getByRole('link', { name: 'Settings' })).toBeVisible();
+	await expect(sheet.getByRole('button', { name: 'Sign Out' })).toBeVisible();
+});
+
+test('companion page account sheet Settings link navigates to /settings @mobile', async ({
+	asMember
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asMember.goto(`/${EIN}`);
+	await asMember.getByRole('button', { name: 'Open account menu' }).click();
+	const sheet = asMember.getByRole('dialog', { name: 'Account menu' });
+	await expect(sheet).toBeVisible({ timeout: 8_000 });
+	await sheet.getByRole('link', { name: 'Settings' }).click();
+	await expect(asMember).toHaveURL(/\/settings/, { timeout: 8_000 });
+});
+
+test('admin companion page account sheet shows Users and Companions @mobile', async ({
+	asAdmin
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asAdmin.goto(`/${EIN}`);
+	await asAdmin.getByRole('button', { name: 'Open account menu' }).click();
+	const sheet = asAdmin.getByRole('dialog', { name: 'Account menu' });
+	await expect(sheet).toBeVisible({ timeout: 8_000 });
+	await expect(sheet.getByRole('link', { name: 'Users' })).toBeVisible();
+	await expect(sheet.getByRole('link', { name: 'Companions' })).toBeVisible();
+});
+
+test('overview top bar has no avatar button — You tab is the account entry @mobile', async ({
+	asMember
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+	await asMember.goto('/');
+	const nav = asMember.getByRole('navigation', { name: 'Main navigation' });
+	await expect(nav.getByRole('button', { name: 'You' })).toBeVisible({ timeout: 8_000 });
+	await expect(asMember.getByRole('button', { name: 'Open account menu' })).toHaveCount(0);
+});
+
 test('admin You tab account sheet shows Users and Companions @mobile', async ({
 	asAdmin
 }, testInfo) => {

--- a/tests/e2e/paperless.spec.ts
+++ b/tests/e2e/paperless.spec.ts
@@ -120,6 +120,48 @@ test('search filters documents in the picker', async ({ world, page }) => {
 	await expect(page.getByRole('button', { name: /vaccination record/i })).toHaveCount(0);
 });
 
+test('mobile documents header: title and action buttons do not overlap @mobile', async ({
+	world,
+	page
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile', 'mobile only');
+
+	await login(page, world.server.baseURL, SEED.member.username);
+	await page.goto(world.server.baseURL + EIN_DOCS_URL);
+
+	const title = page.getByRole('heading', { name: 'Documents', exact: true });
+	await expect(title).toBeVisible({ timeout: 10_000 });
+	const paperlessButton = page.getByRole('button', { name: /add from paperless/i });
+	// The empty state repeats "Upload document" further down; the header button is first.
+	const uploadButton = page.getByRole('button', { name: 'Upload document' }).first();
+	await expect(paperlessButton).toBeVisible();
+	await expect(uploadButton).toBeVisible();
+
+	// ~500px was the worst case: both buttons fit beside a 0%-flex-basis title,
+	// which then overflowed its shrunk box and painted over them. The title's
+	// bounding box never intersects the buttons (only the ink does), so assert
+	// on text overflow as well as box separation.
+	for (const width of [393, 500, 620]) {
+		await page.setViewportSize({ width, height: 900 });
+
+		const overflows = await title.evaluate((el) => el.scrollWidth > el.clientWidth);
+		expect(overflows, `title text must not overflow its box at ${width}px`).toBe(false);
+
+		const titleBox = await title.boundingBox();
+		expect(titleBox).toBeTruthy();
+		for (const button of [paperlessButton, uploadButton]) {
+			const box = await button.boundingBox();
+			expect(box).toBeTruthy();
+			const separated =
+				titleBox!.x + titleBox!.width <= box!.x ||
+				box!.x + box!.width <= titleBox!.x ||
+				titleBox!.y + titleBox!.height <= box!.y ||
+				box!.y + box!.height <= titleBox!.y;
+			expect(separated, `header title must not overlap action buttons at ${width}px`).toBe(true);
+		}
+	}
+});
+
 test('caretaker is blocked from the paperless documents API', async ({ world, browser }) => {
 	const ctx = await browser.newContext({ baseURL: world.server.baseURL });
 	const page = await ctx.newPage();


### PR DESCRIPTION
Fixes #177.

## Mobile account access (#177)

On mobile, companion pages had no path to settings, admin, or sign out. With a single companion the Overview page (and its You tab) is unreachable because \`/\` auto-redirects to the companion dashboard, so those users had no account entry at all.

- Add an avatar button to the mobile top bar in companion context that opens the account sheet.
- Render the account sheet in both contexts; close it on any navigation.
- Overview keeps the You tab, the caretaker shell is unchanged, desktop is unchanged.

## Page header overlap on narrow screens

The page header title container used \`flex-1\`, whose 0% flex-basis made row line-breaking treat the title as zero-width: action buttons stayed on the row and the title text painted over them (Documents with Paperless enabled at ~500px). Switched to \`flex-auto\` and \`flex-wrap\` so the actions wrap below the title when they don't fit. Applies to all 16 pages using \`PageHeader\`.

## Tests

- New mobile e2e tests for the avatar button and account sheet (member + admin), and a guard that the Overview keeps the You tab as its only account entry.
- New regression test for the header at 393/500/620px that asserts on title text overflow (\`scrollWidth\` vs \`clientWidth\`) as well as bounding boxes, since the overflowing ink never intersects the layout boxes.

Also bumps the version to 1.1.2 (package, lock, README badge).