### PR TITLE
Fix stale recent-activity widget and missing journal days

### DIFF
--- a/src/lib/server/journal.test.ts
+++ b/src/lib/server/journal.test.ts
@@ -126,4 +126,70 @@ describe('journal', () => {
 		expect(entry?.updater?.displayName).toBe('J Editor');
 		expect(entry?.logger?.displayName).toBe('J User');
 	});
+
+	// Local noon avoids UTC-midnight boundary flakes regardless of test TZ.
+	const localNoon = (date: string) => {
+		const [y, m, d] = date.split('-').map(Number);
+		return new Date(y, m - 1, d, 12, 0, 0);
+	};
+
+	const insertEvent = (companionId: string, date: string) =>
+		db.insert(schema.dailyEvents).values({
+			id: `ev-${companionId}-${date}`,
+			companionId,
+			type: 'walk',
+			notes: null,
+			durationMinutes: null,
+			loggedAt: localNoon(date),
+			loggedBy: 'u-j'
+		} as typeof schema.dailyEvents.$inferInsert);
+
+	it('shows an activity-only day newer than the newest journal entry (#181)', async () => {
+		// Newest journal entry for c-j is 2026-05-01; log activity on a later day
+		// with no journal entry.
+		await insertEvent('c-j', '2026-06-15');
+		const page = await getEnrichedJournalEntries('c-j', { limit: 50 });
+		const day = page.entries.find((e) => e.date === '2026-06-15');
+		expect(day).toBeDefined();
+		expect(day!.id).toBeNull();
+		expect(day!.events).toHaveLength(1);
+		expect(page.entries[0].date).toBe('2026-06-15'); // newest first
+	});
+
+	it('shows activity-only days when the companion has no journal entries at all', async () => {
+		await db.insert(schema.companions).values({
+			id: 'c-j2',
+			name: 'Eventful'
+		} as typeof schema.companions.$inferInsert);
+		await insertEvent('c-j2', '2026-06-10');
+		await insertEvent('c-j2', '2026-06-12');
+
+		const page = await getEnrichedJournalEntries('c-j2');
+		expect(page.entries.map((e) => e.date)).toEqual(['2026-06-12', '2026-06-10']);
+		expect(page.entries.every((e) => e.id === null && e.events.length === 1)).toBe(true);
+	});
+
+	it('paginates over days including activity-only days', async () => {
+		await db.insert(schema.companions).values({
+			id: 'c-j3',
+			name: 'Pager'
+		} as typeof schema.companions.$inferInsert);
+		// Interleaved: journal entries on 01/03, activity-only days on 02/04.
+		await upsertJournalEntry('c-j3', '2026-06-01', 'entry 1', null, 'u-j');
+		await insertEvent('c-j3', '2026-06-02');
+		await upsertJournalEntry('c-j3', '2026-06-03', 'entry 3', null, 'u-j');
+		await insertEvent('c-j3', '2026-06-04');
+
+		const page1 = await getEnrichedJournalEntries('c-j3', { limit: 2 });
+		expect(page1.entries.map((e) => e.date)).toEqual(['2026-06-04', '2026-06-03']);
+		expect(page1.hasMore).toBe(true);
+		expect(page1.oldestDate).toBe('2026-06-03');
+
+		const page2 = await getEnrichedJournalEntries('c-j3', {
+			limit: 2,
+			before: page1.oldestDate!
+		});
+		expect(page2.entries.map((e) => e.date)).toEqual(['2026-06-02', '2026-06-01']);
+		expect(page2.hasMore).toBe(false);
+	});
 });

--- a/src/lib/server/journal.ts
+++ b/src/lib/server/journal.ts
@@ -1,5 +1,5 @@
 import { db, schema } from '$lib/server/db';
-import { eq, lt, gte, and, inArray } from 'drizzle-orm';
+import { eq, lt, gte, and, inArray, sql, desc } from 'drizzle-orm';
 import { localDateISO } from '$lib/date';
 import { generateId } from '$lib/server/utils';
 import type { Mood } from '$lib/server/validation';
@@ -14,21 +14,48 @@ export async function getEnrichedJournalEntries(
 	const pageSize = opts?.limit ?? PAGE_SIZE;
 	const before = opts?.before;
 
-	const entries = await db.query.journalEntries.findMany({
-		where: and(
-			eq(schema.journalEntries.companionId, companionId),
-			before ? lt(schema.journalEntries.date, before) : undefined
-		),
-		orderBy: (j, { desc }) => [desc(j.date)],
-		limit: pageSize + 1,
-		with: {
-			logger: { columns: { displayName: true } },
-			updater: { columns: { displayName: true } }
-		}
-	});
+	// The timeline paginates over DAYS: a day is shown when it has a journal
+	// entry, a daily event, or both. Fetch pageSize+1 candidate days from each
+	// source; the k newest days of the union are then guaranteed complete
+	// (adding dates from the other source only pushes a source's own dates down
+	// the order, never past its fetch horizon).
+	// loggedAt is stored as unixepoch seconds; 'localtime' matches the process
+	// TZ that localDateISO uses, so both sides bucket days identically.
+	const eventDay = sql<string>`date(${schema.dailyEvents.loggedAt}, 'unixepoch', 'localtime')`;
+	const [entries, eventDayRows] = await Promise.all([
+		db.query.journalEntries.findMany({
+			where: and(
+				eq(schema.journalEntries.companionId, companionId),
+				before ? lt(schema.journalEntries.date, before) : undefined
+			),
+			orderBy: (j, { desc }) => [desc(j.date)],
+			limit: pageSize + 1,
+			with: {
+				logger: { columns: { displayName: true } },
+				updater: { columns: { displayName: true } }
+			}
+		}),
+		db
+			.select({ date: eventDay })
+			.from(schema.dailyEvents)
+			.where(
+				and(
+					eq(schema.dailyEvents.companionId, companionId),
+					before ? sql`${eventDay} < ${before}` : undefined
+				)
+			)
+			.groupBy(eventDay)
+			.orderBy(desc(eventDay))
+			.limit(pageSize + 1)
+	]);
 
-	const hasMore = entries.length > pageSize;
-	const pageEntries = entries.slice(0, pageSize);
+	const dateSet = new Set([...entries.map((e) => e.date), ...eventDayRows.map((r) => r.date)]);
+	// Sort descending (ISO strings sort lexicographically)
+	const sortedDates = [...dateSet].sort((a, b) => (a < b ? 1 : -1));
+	const hasMore = sortedDates.length > pageSize;
+	const allDates = sortedDates.slice(0, pageSize);
+	const shownDates = new Set(allDates);
+	const pageEntries = entries.filter((e) => shownDates.has(e.date));
 
 	type EventWithUserRef = typeof schema.dailyEvents.$inferSelect & {
 		logger: UserRef;
@@ -39,10 +66,10 @@ export async function getEnrichedJournalEntries(
 	let mediaByEntry = new Map<string, MediaWithUserRef[]>();
 	let eventsByDate = new Map<string, EventWithUserRef[]>();
 
-	if (pageEntries.length > 0) {
+	if (allDates.length > 0) {
 		const entryIds = pageEntries.map((e) => e.id);
-		const oldest = pageEntries[pageEntries.length - 1].date;
-		const newest = pageEntries[0].date;
+		const oldest = allDates[allDates.length - 1];
+		const newest = allDates[0];
 		const [oy, om, od] = oldest.split('-').map(Number);
 		const [ny, nm, nd] = newest.split('-').map(Number);
 		const rangeStart = new Date(oy, om - 1, od); // local midnight (respects TZ)
@@ -71,18 +98,13 @@ export async function getEnrichedJournalEntries(
 		}
 		for (const event of allEvents) {
 			const date = localDateISO(new Date(event.loggedAt));
+			// A day inside the range but past a source's fetch horizon can't
+			// exist (see pagination note above), but guard anyway.
+			if (!shownDates.has(date)) continue;
 			if (!eventsByDate.has(date)) eventsByDate.set(date, []);
 			eventsByDate.get(date)!.push(event);
 		}
 	}
-
-	// Collect all dates that have either a journal entry or a daily event
-	const entryDates = new Set(pageEntries.map((e) => e.date));
-	for (const date of eventsByDate.keys()) {
-		entryDates.add(date);
-	}
-	// Sort descending (ISO strings sort lexicographically)
-	const allDates = [...entryDates].sort((a, b) => (a < b ? 1 : -1));
 
 	const entryByDate = new Map(pageEntries.map((e) => [e.date, e]));
 	const enrichedEntries = allDates.map((date) => {
@@ -107,7 +129,7 @@ export async function getEnrichedJournalEntries(
 	return {
 		entries: enrichedEntries,
 		hasMore,
-		oldestDate: pageEntries.length > 0 ? pageEntries[pageEntries.length - 1].date : null
+		oldestDate: allDates.length > 0 ? allDates[allDates.length - 1] : null
 	};
 }
 

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -114,7 +114,9 @@
 				}))
 			] as ActivityItem[]
 		)
-			.filter((e) => e.ts.getTime() <= Date.now())
+			// No client-clock "future" filter here: loggedAt comes from the server
+			// clock, and any skew between the two hides freshly logged items (#179).
+			// The server already rejects far-future timestamps at write time.
 			.sort((a, b) => b.ts.getTime() - a.ts.getTime())
 			.slice(0, 8)
 	);

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -142,10 +142,10 @@
 				ts: new Date(item.occurredAt)
 			}))
 		];
-		return items
-			.filter((item) => item.ts.getTime() <= Date.now())
-			.sort((a, b) => b.ts.getTime() - a.ts.getTime())
-			.slice(0, 8);
+		// No client-clock "future" filter here: loggedAt comes from the server
+		// clock, and any skew between the two hides freshly logged items (#179).
+		// The server already rejects far-future timestamps at write time.
+		return items.sort((a, b) => b.ts.getTime() - a.ts.getTime()).slice(0, 8);
 	});
 
 	// Age from DOB string "YYYY-MM-DD"

--- a/tests/e2e/journal.spec.ts
+++ b/tests/e2e/journal.spec.ts
@@ -146,6 +146,22 @@ test.describe('journal day editor', () => {
 		await expect(asMember.locator('[role="dialog"]')).toBeVisible({ timeout: 5_000 });
 	});
 
+	test('timeline shows a day that has activities but no journal entry (#181)', async ({
+		asMember
+	}) => {
+		// Edward's newest seeded journal entry is days old and no spec writes one
+		// for today, so today is an activity-only day on his timeline.
+		await asMember.goto('/seed-comp-edward/log?type=grooming');
+		await asMember.getByRole('button', { name: /^Log / }).click();
+		await expect(asMember.getByText(/Activity logged/)).toBeVisible();
+
+		await asMember.goto('/seed-comp-edward/journal');
+		await expect(asMember.getByText('Today', { exact: true }).first()).toBeVisible({
+			timeout: 8_000
+		});
+		await expect(asMember.getByRole('button', { name: /grooming/i }).first()).toBeVisible();
+	});
+
 	test('journal list shows entries', async ({ asMember }) => {
 		await asMember.goto(`/${COMP}/journal`);
 

--- a/tests/e2e/quick-logs.spec.ts
+++ b/tests/e2e/quick-logs.spec.ts
@@ -93,18 +93,29 @@ test.describe('custom quick logs', () => {
 	});
 
 	test('quick log with a single assigned companion logs in one click', async ({ asMember }) => {
-		// Create assigned to Ein only (uncheck Edward).
+		// Create assigned to Ein only. Uncheck every other preselected companion,
+		// not just Edward, since specs sharing this worker's DB may have added more.
 		await asMember.goto('/settings/quick-logs');
 		await asMember.getByRole('button', { name: 'Add quick log' }).click();
 		await asMember.locator('input[name="name"]').fill('Sardine snack');
 		await asMember.locator('label').filter({ hasText: /Treat/i }).first().click();
-		await asMember.locator('label').filter({ hasText: 'Edward' }).first().click();
+		const preselected = await asMember
+			.locator('input[name="companionIds"]:checked')
+			.evaluateAll((els) => els.map((el) => (el as HTMLInputElement).value));
+		for (const value of preselected) {
+			if (value === EIN) continue;
+			await asMember.locator(`input[name="companionIds"][value="${value}"]`).click({ force: true });
+		}
 		await asMember.locator('textarea[name="note"]').fill('ate one sardine');
 		await asMember.getByRole('button', { name: 'Save', exact: true }).click();
 		await expect(asMember.getByText('Sardine snack')).toBeVisible();
 
 		// One click on the companion page logs it — no target picker step.
 		await asMember.goto(`/${EIN}`);
+		// Freeze the browser clock 2 minutes behind the server: the freshly
+		// logged event's server timestamp is then "in the future" client-side.
+		// The recent-activity widget must not hide it (#179).
+		await asMember.clock.setFixedTime(Date.now() - 120_000);
 		await asMember.getByRole('button', { name: /Sardine snack/ }).click();
 		await expect(asMember.getByText(/Activity logged/)).toBeVisible();
 		await expect(asMember.getByRole('button', { name: /Log Sardine snack/ })).toHaveCount(0);


### PR DESCRIPTION
Closes #179, closes #181.

## Recent Activity widget not refreshing after a quick log (#179)

The widget's data refresh was working all along. The merged timeline on the companion dashboard (and the household feed on the Overview page) filtered items with `ts.getTime() <= Date.now()`, comparing server-written timestamps against the browser clock. When the server clock runs ahead of the browser, a freshly logged event sits in the client's future and gets hidden until the next submission pushes it far enough into the past. That produces the exact lag-by-one behavior reported: the second click reveals the first log, and a full page refresh shows everything.

The filter is removed. The server already rejects far-future timestamps at write time (`parseLoggedAt` / `parseRecordTimestamp`), so the client-side check only ever hid legitimate data.

## Journal timeline missing activity-only days (#181)

`getEnrichedJournalEntries` fetched daily events only within the date range spanned by the journal entries on the current page. Days carrying activities but no journal entry were shown only if they happened to fall between two existing entries. Today (until a mood or note is saved) fell outside the range and never appeared, and companions with no journal entries at all showed no activity days whatsoever.

The function now paginates over days: the union of journal-entry dates and distinct daily-event dates (bucketed to local days via SQLite `date(logged_at, 'unixepoch', 'localtime')`, which matches the Node-side `localDateISO` bucketing). Each source fetches `pageSize + 1` of its newest dates, so the top `pageSize` days of the union are always complete and the `hasMore` / `oldestDate` cursor semantics carry over unchanged for the existing load-more client and API endpoint.

## Tests

- Three new unit tests for `getEnrichedJournalEntries` (activity-only day newer than the newest entry, companion with zero journal entries, day-based pagination across mixed pages). All three failed before the fix.
- New e2e test: the journal timeline shows Today when it only has activities.
- The quick-log e2e test now freezes the browser clock two minutes behind the server before clicking, which reproduces the reported bug against the old code.
- Also hardened the quick-log creation e2e test against companions created by other specs sharing the same worker DB.