### PR TITLE
Fix e2e config load and libssh CVEs in release image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npm rebuild better-sqlite3
+      # --ignore-scripts skips the prepare hook, so .svelte-kit/tsconfig.json
+      # (extended by tsconfig.json) never exists; Playwright >=1.62 errors on
+      # the unresolvable extends when loading its config.
+      - run: npx svelte-kit sync
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,12 +63,13 @@ WORKDIR /app
 RUN apk add --no-cache ffmpeg
 
 # Pull in OS security fixes published after the pinned base digest. Covers
-# CVE-2026-45447 (libcrypto3/libssl3 3.5.7-r0) and CVE-2026-8461 (ffmpeg
-# 8.1.2-r0); each no-ops once the node base image catches up. The ffmpeg sub-
-# libraries are separate packages with shared-object deps, so each must be
-# named explicitly. Keep targeted so the layer stays deterministic-ish.
+# CVE-2026-45447 (libcrypto3/libssl3 3.5.7-r0), CVE-2026-8461 (ffmpeg
+# 8.1.2-r0), and CVE-2026-15370/-59847/-59849/-59850/-59851 (libssh 0.12.1-r0,
+# an ffmpeg dependency); each no-ops once the node base image catches up. The
+# ffmpeg sub-libraries are separate packages with shared-object deps, so each
+# must be named explicitly. Keep targeted so the layer stays deterministic-ish.
 RUN apk upgrade --no-cache \
-	libcrypto3 libssl3 \
+	libcrypto3 libssl3 libssh \
 	ffmpeg ffmpeg-libavcodec ffmpeg-libavdevice ffmpeg-libavfilter \
 	ffmpeg-libavformat ffmpeg-libavutil ffmpeg-libswresample ffmpeg-libswscale
 


### PR DESCRIPTION
Two build/CI fixes:

- **CI:** run `npx svelte-kit sync` in the `test-e2e` job. `npm ci --ignore-scripts` skips the prepare hook, so `.svelte-kit/tsconfig.json` (extended by `tsconfig.json`) never exists there. Playwright 1.62 (#219) turns the previously tolerated unresolvable `extends` into a hard error at config load, failing all four shards before any test runs.
- **Docker:** add `libssh` to the targeted `apk upgrade` list in the runtime stage. Alpine 3.24 ships libssh 0.12.0-r0 with five HIGH CVEs fixed in 0.12.1-r0 (CVE-2026-15370, CVE-2026-59847, CVE-2026-59849, CVE-2026-59850, CVE-2026-59851); libssh is an ffmpeg dependency and was not covered by the existing list, so the Trivy gate fails every release build. Unblocks `release.yml` on main.