### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # EinVault
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.3.0-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
+[![Version](https://img.shields.io/badge/version-1.3.1-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
 
 EinVault is a private, self-hosted companion health and care tracker built for homelabs. Track health records, daily activities, and care schedules for your animal companions. All data stays on your hardware. No cloud, no telemetry, no external accounts.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "einvault",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "einvault",
-			"version": "1.3.0",
+			"version": "1.3.1",
 			"dependencies": {
 				"@asteasolutions/zod-to-openapi": "^9.1.0",
 				"@fontsource-variable/bricolage-grotesque": "^5.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "einvault",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",


### PR DESCRIPTION
Patch release: version bump in package.json, package-lock.json, and the README badge. Ships the dependency updates merged since v1.3.0 (lucide, zod-to-openapi, svelte, eslint, playwright, types) and the libssh CVE fixes in the release image.