### PR TITLE
Fix Overview showing "Tomorrow" for far-future reminders

### DIFF
--- a/src/lib/reminderBuckets.test.ts
+++ b/src/lib/reminderBuckets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { reminderBuckets, type BucketableReminder } from './reminderBuckets';
+import { reminderBuckets, reminderUrgency, type BucketableReminder } from './reminderBuckets';
 
 const R = (id: string, dueAt: string): BucketableReminder => ({ id, dueAt: new Date(dueAt) });
 const now = new Date('2026-06-12T12:00:00');
@@ -36,5 +36,31 @@ describe('reminderBuckets', () => {
 		expect(overdue).toEqual([]);
 		expect(today).toEqual([]);
 		expect(upcoming).toEqual([]);
+	});
+});
+
+describe('reminderUrgency', () => {
+	it('classifies a past due date as overdue', () => {
+		expect(reminderUrgency(new Date('2026-06-10T09:00:00'), now)).toBe('overdue');
+	});
+	it('classifies a same-day earlier time as overdue', () => {
+		expect(reminderUrgency(new Date('2026-06-12T09:00:00'), now)).toBe('overdue');
+	});
+	it('classifies later today as today', () => {
+		expect(reminderUrgency(new Date('2026-06-12T18:00:00'), now)).toBe('today');
+	});
+	it('classifies the next local day as tomorrow', () => {
+		expect(reminderUrgency(new Date('2026-06-13T00:30:00'), now)).toBe('tomorrow');
+	});
+	it('classifies two days out as upcoming, not tomorrow', () => {
+		expect(reminderUrgency(new Date('2026-06-14T09:00:00'), now)).toBe('upcoming');
+	});
+	it('classifies five days out as upcoming (issue #228)', () => {
+		expect(reminderUrgency(new Date('2026-06-17T09:00:00'), now)).toBe('upcoming');
+	});
+	it('handles the tomorrow check across a month boundary', () => {
+		const eom = new Date('2026-06-30T12:00:00');
+		expect(reminderUrgency(new Date('2026-07-01T09:00:00'), eom)).toBe('tomorrow');
+		expect(reminderUrgency(new Date('2026-07-02T09:00:00'), eom)).toBe('upcoming');
 	});
 });

--- a/src/lib/reminderBuckets.ts
+++ b/src/lib/reminderBuckets.ts
@@ -17,6 +17,24 @@ function isSameLocalDay(a: Date, b: Date): boolean {
 	);
 }
 
+export type ReminderUrgency = 'overdue' | 'today' | 'tomorrow' | 'upcoming';
+
+/**
+ * Classify a single reminder's urgency relative to `now`:
+ * - overdue: dueAt < now
+ * - today: same local calendar day as now AND not yet past
+ * - tomorrow: the next local calendar day
+ * - upcoming: any later day
+ */
+export function reminderUrgency(dueAt: Date | string | number, now: Date): ReminderUrgency {
+	const due = new Date(dueAt);
+	if (due.getTime() < now.getTime()) return 'overdue';
+	if (isSameLocalDay(due, now)) return 'today';
+	const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+	if (isSameLocalDay(due, tomorrow)) return 'tomorrow';
+	return 'upcoming';
+}
+
 /**
  * Bucket active reminders by urgency relative to `now`:
  * - overdue: dueAt < now

--- a/src/routes/(app)/(companion)/[companionId]/+page.svelte
+++ b/src/routes/(app)/(companion)/[companionId]/+page.svelte
@@ -38,6 +38,7 @@
 	import { registerDismissForm } from '$lib/actions/registerDismissForm';
 	import { clearSubmittingFlag } from '$lib/clearSubmittingFlag';
 	import { formatRecurrence } from '$lib/reminderRecurrence';
+	import { reminderUrgency } from '$lib/reminderBuckets';
 	import { careStatus } from '$lib/careStatus';
 	import DocumentPreview from '$lib/components/DocumentPreview.svelte';
 	import ActivityDetailModal from '$lib/components/log/ActivityDetailModal.svelte';
@@ -123,24 +124,9 @@
 			.slice(0, 8)
 	);
 
-	// Reminder urgency
-	function reminderUrgency(dueAt: Date | string): 'overdue' | 'today' | 'upcoming' {
-		const dueMs = new Date(dueAt).getTime();
-		const nowMs = Date.now();
-		if (dueMs < nowMs) return 'overdue';
-		// compute end-of-today in local time by extracting date parts
-		const d = new Date(nowMs);
-		const todayEndMs = new Date(
-			d.getFullYear(),
-			d.getMonth(),
-			d.getDate(),
-			23,
-			59,
-			59,
-			999
-		).getTime();
-		if (dueMs <= todayEndMs) return 'today';
-		return 'upcoming';
+	// Reminder urgency ('tomorrow' renders the same as 'upcoming' here: a date chip)
+	function urgencyOf(dueAt: Date | string) {
+		return reminderUrgency(dueAt, new Date());
 	}
 
 	// Detail modal
@@ -672,7 +658,7 @@
 			{:else}
 				<div class="space-y-1">
 					{#each upcomingReminders.slice(0, 5) as reminder (reminder.id)}
-						{@const urgency = reminderUrgency(reminder.dueAt)}
+						{@const urgency = urgencyOf(reminder.dueAt)}
 						{@const allowLogEvent =
 							REMINDER_TO_HEALTH_TYPE[reminder.type as keyof typeof REMINDER_TO_HEALTH_TYPE] !==
 							null}

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -15,7 +15,6 @@
 	import { renderMarkdown } from '$lib/markdown';
 	import CompanionAvatar from '$lib/components/CompanionAvatar.svelte';
 	import LocalTime from '$lib/components/LocalTime.svelte';
-	import { localDateISO } from '$lib/date';
 	import { createPendingDismissals } from '$lib/pendingDismiss.svelte';
 	import { registerDismissForm } from '$lib/actions/registerDismissForm';
 	import { clearSubmittingFlag } from '$lib/clearSubmittingFlag';
@@ -27,6 +26,7 @@
 		healthTypeLabel
 	} from '$lib/i18n/labels';
 	import { careStatus } from '$lib/careStatus';
+	import { reminderUrgency, type ReminderUrgency } from '$lib/reminderBuckets';
 	import { REMINDER_TO_HEALTH_TYPE } from '$lib/health';
 	import ReminderCompleteButtons from '$lib/components/reminders/ReminderCompleteButtons.svelte';
 	import { formatRecurrence } from '$lib/reminderRecurrence';
@@ -48,16 +48,8 @@
 	};
 
 	// Urgency classification for reminders
-	type Urgency = 'overdue' | 'today' | 'upcoming';
-
-	function reminderUrgency(dueAt: Date | string | number): Urgency {
-		const now = new Date();
-		const due = new Date(dueAt);
-		const todayISO = localDateISO(now);
-		const dueISO = localDateISO(due);
-		if (due < now) return 'overdue';
-		if (dueISO === todayISO) return 'today';
-		return 'upcoming';
+	function urgencyOf(dueAt: Date | string | number): ReminderUrgency {
+		return reminderUrgency(dueAt, new Date());
 	}
 
 	type Reminder = (typeof data.upcomingReminders)[number];
@@ -65,7 +57,7 @@
 	// Needs-attention: overdue + today reminders, sorted overdue first
 	let attentionItems = $derived.by(() => {
 		return data.upcomingReminders
-			.map((r) => ({ r, urgency: reminderUrgency(r.dueAt) }))
+			.map((r) => ({ r, urgency: urgencyOf(r.dueAt) }))
 			.filter(({ urgency }) => urgency === 'overdue' || urgency === 'today')
 			.sort((a, b) => {
 				if (a.urgency === 'overdue' && b.urgency !== 'overdue') return -1;
@@ -165,9 +157,9 @@
 		return `${adjusted}y`;
 	}
 
-	function urgencyLabel(urgency: Urgency): string {
-		if (urgency === 'overdue') return t(locale, 'page.dashboard.caretaker.reminderOverdue');
-		if (urgency === 'today') return t(locale, 'overview.day.today');
+	function urgencyLabel(u: ReminderUrgency): string {
+		if (u === 'overdue') return t(locale, 'page.dashboard.caretaker.reminderOverdue');
+		if (u === 'today') return t(locale, 'overview.day.today');
 		return t(locale, 'overview.day.tomorrow');
 	}
 
@@ -537,7 +529,7 @@
 						}))
 					)}
 					{@const nextReminder = nextReminderByCompanion[companion.id]}
-					{@const nextUrgency = nextReminder ? reminderUrgency(nextReminder.dueAt) : null}
+					{@const nextUrgency = nextReminder ? urgencyOf(nextReminder.dueAt) : null}
 					{@const journalEntry = data.todayJournalByCompanion[companion.id]}
 					{@const lastActivity = lastActivityByCompanion[companion.id]}
 
@@ -648,7 +640,11 @@
 												: 'teal'}
 										class="shrink-0 text-[10px] py-0 px-1.5"
 									>
-										{urgencyLabel(nextUrgency)}
+										{#if nextUrgency === 'upcoming'}
+											<LocalTime date={nextReminder.dueAt} />
+										{:else}
+											{urgencyLabel(nextUrgency)}
+										{/if}
 									</Badge>
 								{/if}
 							{:else}

--- a/tests/e2e/overview.spec.ts
+++ b/tests/e2e/overview.spec.ts
@@ -9,6 +9,14 @@ function justPast(): string {
 	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+/** N local days ahead at noon — noon keeps the date stable across midnight-adjacent runs. */
+function daysAhead(days: number): string {
+	const d = new Date();
+	d.setDate(d.getDate() + days);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T12:00`;
+}
+
 /**
  * Fill and submit the "Add Reminder" form on the companion reminders page.
  * Mirrors the helper in reminders.spec.ts.
@@ -20,10 +28,12 @@ async function addReminder(
 		type?: string;
 		dueAt: string;
 		recurring?: { interval: number; unit: 'day' | 'week' | 'month' | 'year' };
+		companionId?: string;
 	}
 ) {
-	await page.goto(`/${COMP}/reminders`);
-	await page.getByRole('button', { name: 'Add Reminder' }).click();
+	await page.goto(`/${opts.companionId ?? COMP}/reminders`);
+	// A freshly created companion shows a second "Add Reminder" in the empty state.
+	await page.getByRole('button', { name: 'Add Reminder' }).first().click();
 	await page.locator('#title').fill(opts.title);
 	if (opts.type) {
 		await page.locator('select[name="type"]').selectOption(opts.type);
@@ -141,6 +151,51 @@ test('needs-attention detail modal: skip commits via toast and leaves the list',
 	await expect(
 		asMember.locator('section[aria-label="Needs attention"]').getByText('e2e-overview-modal-skip')
 	).toHaveCount(0, { timeout: 8_000 });
+});
+
+// Companion cards: the next-reminder pill must only say "Tomorrow" for actual
+// next-day reminders; farther-out ones show the due date instead (#228).
+test('companion card pill shows date, not "Tomorrow", for a reminder 5 days out', async ({
+	asMember
+}) => {
+	// Fresh companion so its only reminder is the one we add (seed companions
+	// have overdue reminders that would win the "next reminder" slot).
+	await asMember.goto('/companions/new');
+	await asMember.locator('#name').fill('e2e-228-later');
+	await asMember.getByRole('button', { name: 'Add Companion' }).click();
+	await expect(asMember).not.toHaveURL(/\/companions\/new/, { timeout: 10_000 });
+	const companionId = asMember.url().split('/').filter(Boolean).pop()!;
+
+	await addReminder(asMember, {
+		title: 'e2e-228-nexguard',
+		type: 'medication',
+		dueAt: daysAhead(5),
+		companionId
+	});
+
+	await asMember.goto('/');
+	const card = asMember.locator('div[role="link"]').filter({ hasText: 'e2e-228-later' });
+	await expect(card.getByText('e2e-228-nexguard')).toBeVisible({ timeout: 8_000 });
+	await expect(card.getByText('Tomorrow', { exact: true })).toHaveCount(0);
+});
+
+test('companion card pill shows "Tomorrow" for a next-day reminder', async ({ asMember }) => {
+	await asMember.goto('/companions/new');
+	await asMember.locator('#name').fill('e2e-228-nextday');
+	await asMember.getByRole('button', { name: 'Add Companion' }).click();
+	await expect(asMember).not.toHaveURL(/\/companions\/new/, { timeout: 10_000 });
+	const companionId = asMember.url().split('/').filter(Boolean).pop()!;
+
+	await addReminder(asMember, {
+		title: 'e2e-228-checkup',
+		type: 'vet',
+		dueAt: daysAhead(1),
+		companionId
+	});
+
+	await asMember.goto('/');
+	const card = asMember.locator('div[role="link"]').filter({ hasText: 'e2e-228-nextday' });
+	await expect(card.getByText('Tomorrow', { exact: true })).toBeVisible({ timeout: 8_000 });
 });
 
 test('one-off reminder in needs-attention has no skip button', async ({ asMember }) => {


### PR DESCRIPTION
Fixes #228.

The overview card's next-reminder pill labelled every future reminder "Tomorrow", so a reminder due in 5 days showed as due tomorrow.

## Changes

- Add a shared `reminderUrgency(dueAt, now)` classifier in `src/lib/reminderBuckets.ts` with a real `tomorrow` bucket (`overdue | today | tomorrow | upcoming`).
- Overview now labels the pill "Tomorrow" only for actual next-day reminders; anything farther out shows its due date instead, matching the companion page's existing date chip.
- The companion page drops its duplicate local classifier in favour of the shared one (rendering unchanged).

## Tests

- Unit tests for the classifier, including the issue's 5-days-out case and a month-boundary tomorrow check; verified green under UTC-8 and UTC+14.
- Two e2e tests in `overview.spec.ts`: date chip (not "Tomorrow") for a reminder 5 days out, and "Tomorrow" for a genuine next-day reminder. The first reproduced the bug against the pre-fix build.