### PR TITLE
Build(deps): override deepmerge-ts to ^8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3750,6 +3750,7 @@
 			"version": "13.0.3",
 			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
 			"integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"node-addon-api": "^8.0.0"
@@ -3768,9 +3769,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4000,10 +4001,20 @@
 			}
 		},
 		"node_modules/deepmerge-ts": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-			"integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+			"integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "ko-fi",
+					"url": "https://ko-fi.com/rebeccastevens"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+				}
+			],
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 	"type": "module",
 	"overrides": {
 		"cookie": "^0.7.0",
+		"deepmerge-ts": "^8.0.1",
 		"esbuild": "^0.28.1"
 	}
 }


### PR DESCRIPTION
npm audit reports 3 high findings, all from GHSA-ggr8-5vv4-36mx (stack exhaustion in deepmerge-ts < 8.0.0), pulled in via mailparser -> html-to-text -> deepmerge-ts. Dev-only chain (mailparser is used by the e2e SMTP sink).

html-to-text has no release on deepmerge-ts 8 yet, so this adds an npm override to force 8.0.1. Its only usage is deepmergeCustom with mergeArrays/metaDataUpdater, which is unaffected by the v8 breaking changes (Map merging, type renames, deepmergeInto).

Verified: npm audit clean, simpleParser HTML-to-text conversion output unchanged, unit tests and lint pass.

Remove the override once html-to-text bumps its own deepmerge-ts range.