### PR TITLE
Move quick log notices below the action buttons

### DIFF
--- a/src/lib/components/log/QuickLogButtons.svelte
+++ b/src/lib/components/log/QuickLogButtons.svelte
@@ -57,23 +57,6 @@
 
 {#if buttons.length > 0}
 	<div class="space-y-2">
-		{#if form?.quickLogError}
-			<div
-				role="alert"
-				class="rounded-lg border border-coral/30 bg-coral/10 px-3 py-2 text-sm text-coral"
-			>
-				{form.quickLogError}
-			</div>
-		{/if}
-		{#if executedId && form?.quickLogExecuted === executedId}
-			<div
-				role="status"
-				class="rounded-lg border border-teal/30 bg-teal/10 px-3 py-2 text-sm text-teal"
-			>
-				{t(locale, 'page.log.activityLogged')}
-			</div>
-		{/if}
-
 		<div class="flex flex-wrap gap-2">
 			{#each buttons as button (button.id)}
 				{#if button.companionIds.length === 1}
@@ -201,5 +184,23 @@
 				</form>
 			{/if}
 		{/each}
+
+		<!-- Notices sit below the actions so a result never shifts the buttons (#245). -->
+		{#if form?.quickLogError}
+			<div
+				role="alert"
+				class="rounded-lg border border-coral/30 bg-coral/10 px-3 py-2 text-sm text-coral"
+			>
+				{form.quickLogError}
+			</div>
+		{/if}
+		{#if executedId && form?.quickLogExecuted === executedId}
+			<div
+				role="status"
+				class="rounded-lg border border-teal/30 bg-teal/10 px-3 py-2 text-sm text-teal"
+			>
+				{t(locale, 'page.log.activityLogged')}
+			</div>
+		{/if}
 	</div>
 {/if}


### PR DESCRIPTION
## Summary

The "Activity logged" and error notices in `QuickLogButtons` rendered above the button row, so every tap pushed the buttons down. They now render after the actions (and the expanded companion picker), keeping button placement stable.

Closes #245

## Testing

- `npm run lint`, `npm run check` clean
- `quick-log`, `quick-logs`, `caretaker` e2e specs pass on a fresh build (17 tests)