### PR TITLE
Fix openssl CVE-2026-14456 in release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,14 @@ WORKDIR /app
 # libx264 for H.264 encode. Adds ~100-150MB to the image.
 RUN apk add --no-cache ffmpeg
 
+# Pull in OS security fixes published after the pinned base digest. The node
+# image only picks these up when the alpine base image itself is rebuilt, which
+# does not happen for every Alpine package release, so a digest bump alone is
+# not enough. Covers CVE-2026-14456 (libcrypto3/libssl3 3.5.8-r0). Keep targeted
+# so the layer stays deterministic-ish; drop entries once the base image catches
+# up.
+RUN apk upgrade --no-cache libcrypto3 libssl3
+
 # Strip npm, npx, corepack, and the bundled yarn from the runtime image. The
 # app starts with `node build` and never invokes a package manager at runtime;
 # keeping them adds attack surface and CVE noise (npm's transitives, etc.).


### PR DESCRIPTION
## Problem

The Release workflow fails on every push to main since 2026-09-06 at the Trivy scan step. CI is green; only the image scan trips:

```
libcrypto3 / libssl3  CVE-2026-14456  HIGH  installed 3.5.7-r0  fixed 3.5.8-r0
```

The pinned `node:26-alpine` base ships openssl 3.5.7-r0. The newest `26-alpine` digest on Docker Hub (2026-08-27) shares the same alpine base layer and also has 3.5.7-r0, so a digest bump does not fix it. The 3.5.8-r0 package only exists in the Alpine 3.24 repo.

## Fix

Restore the targeted `apk upgrade` in the runner stage (the pattern #242 removed as a no-op), scoped to `libcrypto3 libssl3`. Trivy reports nothing else, so this clears the scan.

## Verification

CI on PRs does not build the image, so the proof is the Release run on main after merge.
