### PR TITLE
Bump version to 1.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # EinVault
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.3.5-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
+[![Version](https://img.shields.io/badge/version-1.3.6-7348f4.svg)](https://github.com/davefatkin/EinVault/releases)
 
 EinVault is a private, self-hosted companion health and care tracker built for homelabs. Track health records, daily activities, and care schedules for your animal companions. All data stays on your hardware. No cloud, no telemetry, no external accounts.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "einvault",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "einvault",
-			"version": "1.3.5",
+			"version": "1.3.6",
 			"dependencies": {
 				"@asteasolutions/zod-to-openapi": "^9.1.0",
 				"@fontsource-variable/bricolage-grotesque": "^5.2.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "einvault",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"private": true,
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",


### PR DESCRIPTION
Version bump for the 1.3.6 patch release: openssl CVE fix in the release image (#257), node base image pinned by full version tag (#258), and dependency updates.